### PR TITLE
Remove `$ ` from in front of bash commands.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,19 +4,19 @@ Use the following instructions to make documentation changes locally.
 
 ## Prerequisites
 ```bash
-$ sudo apt install ruby bundler
-$ bundle install --path vendor/bundle
+sudo apt install ruby bundler
+bundle install --path vendor/bundle
 ```
 
 ## Serving locally
 ```bash
-$ bundle exec jekyll serve
+bundle exec jekyll serve
 ```
 
 or from the project root:
 
 ```bash
-$ make docs-serve
+make docs-serve
 ```
 
 ## Theme documentation

--- a/docs/getting-started/adding_a_new_fuzzer.md
+++ b/docs/getting-started/adding_a_new_fuzzer.md
@@ -23,9 +23,9 @@ subdirectory will be the name of the fuzzer. The fuzzer name can contain
 alphanumeric characters and underscores and must be a valid python module.
 
 ```bash
-$ export FUZZER_NAME=<your_fuzzer_name>
-$ cd fuzzers
-$ mkdir $FUZZER_NAME
+export FUZZER_NAME=<your_fuzzer_name>
+cd fuzzers
+mkdir $FUZZER_NAME
 ```
 
 You can verify the name of your fuzzer is valid by running `make run-presubmit`
@@ -222,21 +222,21 @@ successfully:
 * Build a specific benchmark:
 
 ```shell
-$ export FUZZER_NAME=afl
-$ export BENCHMARK_NAME=libpng-1.2.56
-$ make build-$FUZZER_NAME-$BENCHMARK_NAME
+export FUZZER_NAME=afl
+export BENCHMARK_NAME=libpng-1.2.56
+make build-$FUZZER_NAME-$BENCHMARK_NAME
 ```
 
 * Run the fuzzer in the docker image:
 
 ```shell
-$ make run-$FUZZER_NAME-$BENCHMARK_NAME
+make run-$FUZZER_NAME-$BENCHMARK_NAME
 ```
 
 * Building all benchmarks for a fuzzer:
 
 ```shell
-$ make build-$FUZZER_NAME-all
+make build-$FUZZER_NAME-all
 ```
 
 *Tips*:
@@ -245,23 +245,23 @@ $ make build-$FUZZER_NAME-all
   * Start a new shell and run fuzzer there:
 
   ```shell
-  $ make debug-$FUZZER_NAME-$BENCHMARK_NAME
+  make debug-$FUZZER_NAME-$BENCHMARK_NAME
   ```
 
   * Or, debug an existing fuzzer run in the `make run-*` docker container:
 
   ```shell
-  $ docker container ls
-  $ docker exec -ti <container-id> /bin/bash
+  docker container ls
+  docker exec -ti <container-id> /bin/bash
 
   # E.g. check corpus.
-  $ ls /out/corpus
+  ls /out/corpus
   ```
 
 * To do builds in parallel, pass -j <number_of_parallel_jobs> to make:
 
   ```shell
-  $ make -j6 build-$FUZZER_NAME-all
+  make -j6 build-$FUZZER_NAME-all
   ```
 
 * Run `make run-format` to format your code.

--- a/docs/getting-started/contributing_code.md
+++ b/docs/getting-started/contributing_code.md
@@ -32,7 +32,7 @@ FuzzBench.
 You can run all checks and unit tests for the core functionality using:
 
 ```bash
-$ make run-presubmit
+make run-presubmit
 ```
 
 You can also run the following to format your code or do different checks

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -21,9 +21,9 @@ This page explains how to set up your environment for using FuzzBench.
 Clone the FuzzBench repository to your machine by running the following command:
 
 ```bash
-$ git clone https://github.com/google/fuzzbench
-$ cd fuzzbench
-$ git submodule update --init
+git clone https://github.com/google/fuzzbench
+cd fuzzbench
+git submodule update --init
 ```
 
 ## Installing prerequisites
@@ -45,7 +45,7 @@ docker images periodically.
 Install make for your linux distribution. E.g. for Ubuntu:
 
 ```bash
-$ sudo apt-get install build-essential
+sudo apt-get install build-essential
 ```
 
 ### Python programming language
@@ -61,14 +61,14 @@ If you already have Python installed, you can verify its version by running
 Install the python dependencies by running the following command:
 
 ```bash
-$ make install-dependencies
+make install-dependencies
 ```
 
 This installs all the dependencies in a virtualenv `.venv`. Activate this
 virtualenv before running furthur commands.
 
 ```bash
-$ source .venv/bin/activate
+source .venv/bin/activate
 ```
 
 You can exit from this virtualenv anytime using the `deactivate` command.
@@ -79,7 +79,7 @@ You can verify that your local setup is working correctly by running the
 presubmit checks.
 
 ```bash
-$ make run-presubmit
+make run-presubmit
 ```
 
 ### Formatting
@@ -87,5 +87,5 @@ $ make run-presubmit
 You can format your changes using the following command:
 
 ```bash
-$ make run-format
+make run-format
 ```


### PR DESCRIPTION
It makes copy-paste harder.