### PR TITLE
FETCH_HEAD fix

### DIFF
--- a/presubmit.py
+++ b/presubmit.py
@@ -260,7 +260,7 @@ def license_check(paths: List[Path]) -> bool:
 
 def get_changed_files() -> List[Path]:
     """Return a list of absolute paths of files changed in this git branch."""
-    diff_command = ['git', 'diff', '--name-only', 'FETCH.']
+    diff_command = ['git', 'diff', '--name-only', 'origin...']
     return [
         Path(path).absolute()
         for path in subprocess.check_output(diff_command).decode().splitlines()


### PR DESCRIPTION
Fixes issue with git diff without prior pull in presubmit.py. [This](https://stackoverflow.com/questions/7251477/what-are-the-differences-between-double-dot-and-triple-dot-in-git-dif) is a good reference as to what `git diff --name-only origin...` does.