### PR TITLE
AFL++: Radamsa and MOpt are mutually exclusive.

### DIFF
--- a/fuzzers/aflplusplus/builder.Dockerfile
+++ b/fuzzers/aflplusplus/builder.Dockerfile
@@ -21,8 +21,7 @@ FROM $parent_image
 RUN git clone https://github.com/vanhauser-thc/AFLplusplus.git /afl && \
     cd /afl && \
     git checkout 842cd9dec3c4c83d660d96dcdb3f5cf0c6e6f4fb && \
-    AFL_NO_X86=1 make PYTHON_INCLUDE=/ && \
-    make radamsa
+    AFL_NO_X86=1 make PYTHON_INCLUDE=/
 
 # Use afl_driver.cpp from LLVM as our fuzzing library.
 RUN apt-get update && \

--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -46,6 +46,4 @@ def fuzz(input_corpus, output_corpus, target_binary):
             # is also recommended in a short-time scale evaluation.
             '-L',
             '0',
-            # Enable Radamsa mutator.
-            '-R',
         ])


### PR DESCRIPTION
If you try to run afl++ with -L and -R, in the most recent release,
the fuzzer will abort with this message:
"MOpt and Radamsa are mutually exclusive. We accept pull requests that integrates MOpt with the optional mutators (custom/radamsa/redqueen/...)".
Yes this was our fault, not enough time to work on it, MOpt integration with the other mutators is one of our GSoC proposals.