### PR TITLE
Revert "Update honggfuzz to 77ea4dc4b499799e20ba33ef5df0152ecd113925."

### DIFF
--- a/fuzzers/honggfuzz/builder.Dockerfile
+++ b/fuzzers/honggfuzz/builder.Dockerfile
@@ -18,10 +18,10 @@ FROM $parent_image
 # honggfuzz requires libfd and libunwid.
 RUN apt-get update -y && apt-get install -y libbfd-dev libunwind-dev libblocksruntime-dev
 
-# Download honggfuz version 2.1 + 77ea4dc4b499799e20ba33ef5df0152ecd113925
+# Download honggfuz version 2.0.
 # Set CFLAGS use honggfuzz's defaults except for -mnative which can build CPU
 # dependent code that may not work on the machines we actually fuzz on.
 RUN git clone https://github.com/google/honggfuzz.git /honggfuzz && \
     cd /honggfuzz && \
-    git checkout 77ea4dc4b499799e20ba33ef5df0152ecd113925 && \
+    git checkout d1de86d03b2b4e332915ee1eda06e62c43daa9b6 && \
     CFLAGS="-O3 -funroll-loops" make


### PR DESCRIPTION
Reverts google/fuzzbench#49

Breaks on multiple benchmarks, e.g. woff2, re2

```
clang++: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
+ /honggfuzz/hfuzz_cc/hfuzz-clang++ -stdlib=libc++ -O2 -fno-omit-frame-pointer -gline-tables-only -fsanitize=address backward_references.o bit_reader.o block_splitter.o brotli_bit_stream.o compress_fragment.o compress_fragment_two_pass.o decode.o dictionary.o encode.o encode_parallel.o entropy_encode.o font.o glyph.o histogram.o huffman.o literal_cost.o metablock.o normalize.o state.o static_dict.o streams.o table_tags.o transform.o utf8_util.o variable_length.o woff2_common.o woff2_dec.o woff2_enc.o woff2_out.o /honggfuzz/libhfuzz/persistent.o benchmark/target.cc -I SRC/src -o /out/fuzz-target
/honggfuzz/libhfuzz/persistent.o: In function `HF_ITER':
persistent.c:(.text+0x70): multiple definition of `HF_ITER'
/tmp/libhfuzz.0.71aa8a127231f991.a(persistent.o):persistent.c:(.text+0x70): first defined here
/honggfuzz/libhfuzz/persistent.o: In function `HonggfuzzMain':
persistent.c:(.text+0x80): multiple definition of `HonggfuzzMain'
/tmp/libhfuzz.0.71aa8a127231f991.a(persistent.o):persistent.c:(.text+0x80): first defined here
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/src/fuzzer.py", line 40, in build
    utils.build_benchmark()
  File "/src/fuzzers/utils.py", line 42, in build_benchmark
    subprocess.check_call(['/bin/bash', '-ex', build_script], env=env)
  File "/usr/local/lib/python3.7/subprocess.py", line 363, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/bin/bash', '-ex', 'benchmark/build.sh']' returned non-zero exit status 1.
The command '/bin/sh -c python3 -u -c "import fuzzer; fuzzer.build()"' returned a non-zero code: 1
```