### PR TITLE
Use github actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        fuzzer:
+          - afl
+          - aflfast
+          - aflplusplus
+          - eclipser
+          - entropic
+          - fairfuzz
+          - honggfuzz
+          - libfuzzer
+          - mopt
+          - qsym
+
+    env:
+      FUZZER_NAME: ${{ matrix.fuzzer }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python environment
+      uses: actions/setup-python@v1.1.1
+      with:
+        python-version: 3.7
+    - name: Build benchmarks
+      run: |
+        make install-dependencies
+        source .venv/bin/activate
+        make presubmit
+        make build-$FUZZER_NAME-all

--- a/docs/getting-started/adding_a_new_fuzzer.md
+++ b/docs/getting-started/adding_a_new_fuzzer.md
@@ -269,5 +269,8 @@ make build-$FUZZER_NAME-all
 
 * Run `make presubmit` to lint your code and ensure all tests are passing.
 
+* Add your fuzzer to the list in `.github/workflows/ci.yml` to enable building
+  it on continous integration.
+
 * Submit the integration in a
 [GitHub pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).


### PR DESCRIPTION
This will be useful to catch issues like https://github.com/google/fuzzbench/pull/51 early.

Some things of note:
* Building all the fuzzers with all the benchmarks currently can take up to 1h30m: https://github.com/ammaraskar/fuzzbench/actions/runs/49177543
  Instead we might want to consider building a representative subset of the benchmarks (e.g ones that use `.s` files since I remember Angora having trouble with this in the past, ones that are large and complex etc)

* afl++ actually seems to be broken right now: https://github.com/ammaraskar/fuzzbench/runs/483851588?check_suite_focus=true

```
+ clang++ -stdlib=libc++ -O2 -fno-omit-frame-pointer -gline-tables-only -fsanitize=address -fsanitize-coverage=trace-pc-guard -std=c++11 benchmark/libjpeg_turbo_fuzzer.cc -I BUILD BUILD/.libs/libturbojpeg.a /libAFL.a -o /out/fuzz-target
+ cp -r benchmark/seeds /out/
[post_build] Copying afl-fuzz to $OUT directory
[post_build] Copying libradamsa.so to $OUT directory
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/src/fuzzer.py", line 29, in build
    shutil.copy('/afl/libradamsa.so', os.environ['OUT'])
  File "/usr/local/lib/python3.7/shutil.py", line 248, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/local/lib/python3.7/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/afl/libradamsa.so'
The command '/bin/sh -c python3 -u -c "import fuzzer; fuzzer.build()"' returned a non-zero code: 1
make: *** [.aflplusplus-libjpeg-turbo-07-2017-builder] Error 1
docker/build.mk:114: recipe for target '.aflplusplus-libjpeg-turbo-07-2017-builder' failed
##[error]Process completed with exit code 2.
```

so the CI fails because of that. I think this is an oversight from https://github.com/google/fuzzbench/pull/39 /cc @jonathanmetzman @andreafioraldi