### PR TITLE
Run presubmit seperately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,19 @@ jobs:
       run: |
         make install-dependencies
         source .venv/bin/activate
-        make presubmit
         make build-$FUZZER_NAME-all
+
+  presubmit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python environment
+      uses: actions/setup-python@v1.1.1
+      with:
+        python-version: 3.7
+    - name: Build benchmarks
+      run: |
+        make install-dependencies
+        source .venv/bin/activate
+        make presubmit
+    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,20 @@ name: CI
 on: [pull_request]
 
 jobs:
+  presubmit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python environment
+      uses: actions/setup-python@v1.1.1
+      with:
+        python-version: 3.7
+    - name: Build benchmarks
+      run: |
+        make install-dependencies
+        source .venv/bin/activate
+        make presubmit
+
   build:
     runs-on: ubuntu-latest
 
@@ -35,18 +49,3 @@ jobs:
         make install-dependencies
         source .venv/bin/activate
         make build-$FUZZER_NAME-all
-
-  presubmit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup Python environment
-      uses: actions/setup-python@v1.1.1
-      with:
-        python-version: 3.7
-    - name: Build benchmarks
-      run: |
-        make install-dependencies
-        source .venv/bin/activate
-        make presubmit
-    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,8 @@ jobs:
       uses: actions/setup-python@v1.1.1
       with:
         python-version: 3.7
-    - name: Build benchmarks
+    - name: Run presubmit checks
       run: |
-        make install-dependencies
-        source .venv/bin/activate
         make presubmit
 
   build:
@@ -46,6 +44,4 @@ jobs:
         python-version: 3.7
     - name: Build benchmarks
       run: |
-        make install-dependencies
-        source .venv/bin/activate
         make build-$FUZZER_NAME-all


### PR DESCRIPTION
This will make test failures fail in one place instead of 10, will make them easier to read and will reduce the amount of time it takes to build.