### PR TITLE
Install llvm tools when installing clang in base-builder.

### DIFF
--- a/docker/base-builder/Dockerfile
+++ b/docker/base-builder/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update -y && apt-get install -y \
 
 # Copy clang binaries and libs.
 COPY --from=base-clang /usr/local/bin/clang* /usr/local/bin/
+COPY --from=base-clang /usr/local/bin/llvm-* /usr/local/bin/
 COPY --from=base-clang /usr/local/lib/clang /usr/local/lib/clang
 COPY --from=base-clang /usr/local/lib/libc++*.a /usr/local/lib/
 COPY --from=base-clang /usr/local/include/ /usr/local/include


### PR DESCRIPTION
This is one fix (of two) needed to build AFL's llvm_mode (not working in #46).