### PR TITLE
[reports] Add initial implementation of progress reports

### DIFF
--- a/experiment/generate_report.py
+++ b/experiment/generate_report.py
@@ -53,6 +53,13 @@ def get_arg_parser():
         default=False,
         help='If set, plots are created faster, but contain less details.')
     parser.add_argument(
+        '-p',
+        '--track_progress',
+        action='store_true',
+        default=False,
+        help='If set, then the report will track progress made in experiments')
+
+    parser.add_argument(
         '-c',
         '--from_cached_data',
         action='store_true',
@@ -63,10 +70,21 @@ def get_arg_parser():
     return parser
 
 
+def transform_for_progress_report(experiment_df):
+    """Transforms |experiment_df| so that it will produce a report that shows
+    the progress made by fuzzers between the different experiments and returns
+    the transformed data."""
+    experiment_df['fuzzer'] = (experiment_df['fuzzer'] +
+                               '-' + experiment_df['experiment'])
+    return experiment_df
+
+
+
 # pylint: disable=too-many-arguments
 def generate_report(experiment_names,
                     report_directory,
                     report_name=None,
+                    track_progress=False,
                     report_type='default',
                     quick=False,
                     from_cached_data=False):
@@ -82,6 +100,9 @@ def generate_report(experiment_names,
         experiment_df = queries.get_experiment_data(experiment_names)
         # Save the raw data along with the report.
         experiment_df.to_csv(data_path)
+
+    if track_progress:
+        experiment_df = transform_for_progress_report(experiment_df)
 
     fuzzer_names = experiment_df.fuzzer.unique()
     plotter = plotting.Plotter(fuzzer_names, quick)
@@ -102,7 +123,7 @@ def main():
     parser = get_arg_parser()
     args = parser.parse_args()
 
-    generate_report(args.experiment, args.report_dir, args.report_name,
+    generate_report(args.experiment, args.report_dir, args.report_name, args.track_progress,
                     args.report_type, args.quick, args.from_cached_data)
 
 

--- a/experiment/generate_report.py
+++ b/experiment/generate_report.py
@@ -33,17 +33,17 @@ def get_arg_parser():
     parser.add_argument('experiment', nargs='+', help='Experiment name')
     parser.add_argument(
         '-n',
-        '--report_name',
+        '--report-name',
         help='Name of the report. Default: name of the first experiment.')
     parser.add_argument(
         '-t',
-        '--report_type',
+        '--report-type',
         choices=['default'],
         default='default',
         help='Type of the report (which template to use). Default: default.')
     parser.add_argument(
         '-d',
-        '--report_dir',
+        '--report-dir',
         default='./report',
         help='Directory for writing a report. Default: ./report')
     parser.add_argument(
@@ -53,15 +53,15 @@ def get_arg_parser():
         default=False,
         help='If set, plots are created faster, but contain less details.')
     parser.add_argument(
-        '-p',
-        '--track_progress',
+        '-l',
+        '--label-by-experiment',
         action='store_true',
         default=False,
         help='If set, then the report will track progress made in experiments')
 
     parser.add_argument(
         '-c',
-        '--from_cached_data',
+        '--from-cached-data',
         action='store_true',
         default=False,
         help=('If set, and the experiment data is already cached, '
@@ -70,12 +70,12 @@ def get_arg_parser():
     return parser
 
 
-def transform_for_progress_report(experiment_df):
-    """Transforms |experiment_df| so that it will produce a report that shows
-    the progress made by fuzzers between the different experiments and returns
-    the transformed data."""
-    experiment_df['fuzzer'] = (experiment_df['fuzzer'] +
-                               '-' + experiment_df['experiment'])
+def label_fuzzers_by_experiment(experiment_df):
+    """Returns a dataframe where every fuzzer is labeled by the experiment it
+    was run in."""
+    experiment_df['fuzzer'] = (
+        experiment_df['fuzzer'] + '-' + experiment_df['experiment'])
+
     return experiment_df
 
 
@@ -84,7 +84,7 @@ def transform_for_progress_report(experiment_df):
 def generate_report(experiment_names,
                     report_directory,
                     report_name=None,
-                    track_progress=False,
+                    label_by_experiment=False,
                     report_type='default',
                     quick=False,
                     from_cached_data=False):
@@ -101,8 +101,8 @@ def generate_report(experiment_names,
         # Save the raw data along with the report.
         experiment_df.to_csv(data_path)
 
-    if track_progress:
-        experiment_df = transform_for_progress_report(experiment_df)
+    if label_by_experiment:
+        experiment_df = label_fuzzers_by_experiment(experiment_df)
 
     fuzzer_names = experiment_df.fuzzer.unique()
     plotter = plotting.Plotter(fuzzer_names, quick)
@@ -123,8 +123,9 @@ def main():
     parser = get_arg_parser()
     args = parser.parse_args()
 
-    generate_report(args.experiment, args.report_dir, args.report_name, args.track_progress,
-                    args.report_type, args.quick, args.from_cached_data)
+    generate_report(args.experiment, args.report_dir, args.report_name,
+                    args.label_by_experiment, args.report_type, args.quick,
+                    args.from_cached_data)
 
 
 if __name__ == '__main__':

--- a/experiment/generate_report.py
+++ b/experiment/generate_report.py
@@ -73,11 +73,10 @@ def get_arg_parser():
 def label_fuzzers_by_experiment(experiment_df):
     """Returns a dataframe where every fuzzer is labeled by the experiment it
     was run in."""
-    experiment_df['fuzzer'] = (
-        experiment_df['fuzzer'] + '-' + experiment_df['experiment'])
+    experiment_df['fuzzer'] = (experiment_df['fuzzer'] + '-' +
+                               experiment_df['experiment'])
 
     return experiment_df
-
 
 
 # pylint: disable=too-many-arguments

--- a/experiment/test_generate_report.py
+++ b/experiment/test_generate_report.py
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions andsss
+# limitations under the License.
+"""Tests for generate_report.py"""
+import pandas as pd
+
+from experiment import generate_report
+
+def test_transform_for_progress_report_fuzzer_label():
+    """Tests that transform_for_progress_report includes the
+    experiment name in the fuzzer name"""
+    input_df = pd.DataFrame({'experiment': ['experiment-a', 'experiment-b'],
+                  'fuzzer': ['fuzzer-1', 'fuzzer-2']})
+    transformed_df = generate_report.transform_for_progress_report(input_df)
+
+    expected_fuzzers_df = pd.DataFrame({
+                   'fuzzer':
+                   ['fuzzer-1-experiment-a', 'fuzzer-2-experiment-b']})
+
+    from remote_pdb import RemotePdb; RemotePdb('127.0.0.1', 4444).set_trace()
+    assert (transformed_df['fuzzer'] == expected_fuzzers_df['fuzzer']).all()

--- a/experiment/test_generate_report.py
+++ b/experiment/test_generate_report.py
@@ -16,15 +16,15 @@ import pandas as pd
 
 from experiment import generate_report
 
-def test_transform_for_progress_report_fuzzer_label():
-    """Tests that transform_for_progress_report includes the
-    experiment name in the fuzzer name"""
+def label_fuzzers_by_experiment:
+    """Tests that label_fuzzers_by_experiment includes the experiment name in
+    the fuzzer name"""
     input_df = pd.DataFrame({'experiment': ['experiment-a', 'experiment-b'],
                   'fuzzer': ['fuzzer-1', 'fuzzer-2']})
-    transformed_df = generate_report.transform_for_progress_report(input_df)
+    labeled_df = generate_report.label_fuzzers_by_experiment(input_df)
 
     expected_fuzzers_df = pd.DataFrame({
                    'fuzzer':
                    ['fuzzer-1-experiment-a', 'fuzzer-2-experiment-b']})
 
-    assert (transformed_df['fuzzer'] == expected_fuzzers_df['fuzzer']).all()
+    assert (labeled_df['fuzzer'] == expected_fuzzers_df['fuzzer']).all()

--- a/experiment/test_generate_report.py
+++ b/experiment/test_generate_report.py
@@ -16,15 +16,17 @@ import pandas as pd
 
 from experiment import generate_report
 
-def label_fuzzers_by_experiment:
+
+def label_fuzzers_by_experiment():
     """Tests that label_fuzzers_by_experiment includes the experiment name in
     the fuzzer name"""
-    input_df = pd.DataFrame({'experiment': ['experiment-a', 'experiment-b'],
-                  'fuzzer': ['fuzzer-1', 'fuzzer-2']})
+    input_df = pd.DataFrame({
+        'experiment': ['experiment-a', 'experiment-b'],
+        'fuzzer': ['fuzzer-1', 'fuzzer-2']
+    })
     labeled_df = generate_report.label_fuzzers_by_experiment(input_df)
 
-    expected_fuzzers_df = pd.DataFrame({
-                   'fuzzer':
-                   ['fuzzer-1-experiment-a', 'fuzzer-2-experiment-b']})
+    expected_fuzzers_df = pd.DataFrame(
+        {'fuzzer': ['fuzzer-1-experiment-a', 'fuzzer-2-experiment-b']})
 
     assert (labeled_df['fuzzer'] == expected_fuzzers_df['fuzzer']).all()

--- a/experiment/test_generate_report.py
+++ b/experiment/test_generate_report.py
@@ -27,5 +27,4 @@ def test_transform_for_progress_report_fuzzer_label():
                    'fuzzer':
                    ['fuzzer-1-experiment-a', 'fuzzer-2-experiment-b']})
 
-    from remote_pdb import RemotePdb; RemotePdb('127.0.0.1', 4444).set_trace()
     assert (transformed_df['fuzzer'] == expected_fuzzers_df['fuzzer']).all()


### PR DESCRIPTION
An interesting feature would be comparing the progress of
a fuzzer over time.
This patch allows fuzzers from two experiments to
be compared instead of combined by appending the name of
the experiment to the name.

This does not affect the behavior of fuzzbench running in
production.