### PR TITLE
Update honggfuzz to v2.1+

### DIFF
--- a/fuzzers/honggfuzz/builder.Dockerfile
+++ b/fuzzers/honggfuzz/builder.Dockerfile
@@ -18,10 +18,14 @@ FROM $parent_image
 # honggfuzz requires libfd and libunwid.
 RUN apt-get update -y && apt-get install -y libbfd-dev libunwind-dev libblocksruntime-dev
 
-# Download honggfuz version 2.0.
+# Download honggfuz version 2.1 + af1b7b21dca0bd7ee586c3f17524ee41c855c5a5
 # Set CFLAGS use honggfuzz's defaults except for -mnative which can build CPU
 # dependent code that may not work on the machines we actually fuzz on.
+# Create an empty object file which will become the FUZZER_LIB lib (since
+# honggfuzz doesn't need this when hfuzz-clang(++) is used).
 RUN git clone https://github.com/google/honggfuzz.git /honggfuzz && \
     cd /honggfuzz && \
-    git checkout d1de86d03b2b4e332915ee1eda06e62c43daa9b6 && \
-    CFLAGS="-O3 -funroll-loops" make
+    git checkout af1b7b21dca0bd7ee586c3f17524ee41c855c5a5 && \
+    CFLAGS="-O3 -funroll-loops" make && \
+    touch empty_lib.c && \
+    cc -c -o empty_lib.o empty_lib.c

--- a/fuzzers/honggfuzz/fuzzer.py
+++ b/fuzzers/honggfuzz/fuzzer.py
@@ -33,9 +33,11 @@ def build():
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 
+    # honggfuzz doesn't need additional libraries when code is compiled
+    # with hfuzz-clang(++)
     os.environ['CC'] = '/honggfuzz/hfuzz_cc/hfuzz-clang'
     os.environ['CXX'] = '/honggfuzz/hfuzz_cc/hfuzz-clang++'
-    os.environ['FUZZER_LIB'] = '/honggfuzz/libhfuzz/persistent.o'
+    os.environ['FUZZER_LIB'] = '/honggfuzz/empty_lib.o'
 
     utils.build_benchmark()
 


### PR DESCRIPTION
Update honggfuzz to v2.1+ af1b7b21dca0bd7ee586c3f17524ee41c855c5a5

This allows some targets (e.g. systemd-fuzz-link-parser), to be
instrumented correctly. See
https://github.com/google/fuzzbench/issues/47 for more on that.

It also sets LIB_FUZZER to an empty object file, to avoid problems
described in https://github.com/google/fuzzbench/pull/51 where pointing
it to an object file (libhfuzz/persistent.o) caused for some symbols
inside persistent.o and inside libhfuzz.a to be defined twice in the
final binary (and sometimes in libraries like libsystemd.so)

Tested with:
make run-honggfuzz-systemd_fuzz-link-parser
make run-honggfuzz-openthread-2019-12-23
make run-honggfuzz-mbedtls_fuzz_dtlsclient
make run-honggfuzz-openssl_x509
make run-honggfuzz-proj4-2017-08-14