### PR TITLE
[new_process] Refactor and simplify new_process.execute

### DIFF
--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -123,8 +123,7 @@ def delete_instances(instance_names: List[str], zone: str, **kwargs) -> bool:
 
 def list_instances() -> List[str]:
     """Return list of current running instances."""
-    result = new_process.execute(['gcloud', 'compute', 'instances', 'list'],
-                                 write_to_stdout=False)
+    result = new_process.execute(['gcloud', 'compute', 'instances', 'list'])
     return [instance.split(' ')[0] for instance in result.output.splitlines()]
 
 

--- a/common/gsutil.py
+++ b/common/gsutil.py
@@ -22,18 +22,14 @@ logger = logs.Logger('gsutil')
 
 def gsutil_command(arguments, *args, parallel=True, **kwargs):
     """Executes a gsutil command with |arguments| and returns the result."""
-    if environment.get('LOCAL_EXPERIMENT'):
-        logger.info('LOCAL_EXPERIMENT set, not running \'gsutil %s\'.',
+    if environment.get('FUZZ_OUTSIDE_EXPERIMENT'):
+        logger.info('FUZZ_OUTSIDE_EXPERIMENT set, not running \'gsutil %s\'.',
                     ' '.join(arguments))
         return 0, ''
     command = ['gsutil']
     if parallel:
         command.append('-m')
-    write_to_stdout = kwargs.pop('write_to_stdout', False)
-    return new_process.execute(command + arguments,
-                               *args,
-                               write_to_stdout=write_to_stdout,
-                               **kwargs)
+    return new_process.execute(command + arguments, *args, **kwargs)
 
 
 def cp(*cp_arguments, **kwargs):  # pylint: disable=invalid-name
@@ -54,7 +50,9 @@ def ls(*ls_arguments, must_exist=True, **kwargs):  # pylint: disable=invalid-nam
                             parallel=False,
                             expect_zero=must_exist,
                             **kwargs)
-    return result.retcode, result.output.splitlines()
+    retcode = result.retcode  # pytype: disable=attribute-error
+    output = result.output.splitlines()  # pytype: disable=attribute-error
+    return retcode, output
 
 
 def rm(*rm_arguments, recursive=True, force=False, **kwargs):  # pylint: disable=invalid-name

--- a/common/new_process.py
+++ b/common/new_process.py
@@ -17,7 +17,6 @@ import os
 import signal
 import subprocess
 import threading
-
 from typing import List
 
 from common import logs
@@ -74,14 +73,19 @@ def execute(  # pylint: disable=too-many-locals,too-many-branches
         *args,
         expect_zero: bool = True,
         timeout: int = None,
+        write_to_stdout=False,
+        # If not set, will default to PIPE.
+        output_file=None,
         # Not True by default because we can't always set group on processes.
-        output_file=subprocess.PIPE,
         kill_children: bool = False,
         **kwargs) -> ProcessResult:
     """Execute |command| and return the returncode and the output"""
-    if output_file:
-        kwargs['stdout'] = output_file
-        kwargs['stderr'] = subprocess.STDOUT
+    if write_to_stdout:
+        assert output_file is None
+        output_file = sys.stdout.fileno()
+
+    kwargs['stdout'] = output_file
+    kwargs['stderr'] = subprocess.STDOUT
     if kill_children:
         kwargs['preexec_fn'] = os.setsid
 

--- a/common/new_process.py
+++ b/common/new_process.py
@@ -75,14 +75,13 @@ def execute(  # pylint: disable=too-many-locals,too-many-branches
         expect_zero: bool = True,
         timeout: int = None,
         # Not True by default because we can't always set group on processes.
-        output_file: str = None,
+        output_file=subprocess.PIPE,
         kill_children: bool = False,
         **kwargs) -> ProcessResult:
     """Execute |command| and return the returncode and the output"""
-    if not output_file:
-        output_file = subprocess.PIPE
-    kwargs['stdout'] = output_file
-    kwargs['stderr'] = subprocess.STDOUT
+    if output_file:
+        kwargs['stdout'] = output_file
+        kwargs['stderr'] = subprocess.STDOUT
     if kill_children:
         kwargs['preexec_fn'] = os.setsid
 

--- a/common/new_process.py
+++ b/common/new_process.py
@@ -81,8 +81,11 @@ def execute(  # pylint: disable=too-many-locals,too-many-branches
         **kwargs) -> ProcessResult:
     """Execute |command| and return the returncode and the output"""
     if write_to_stdout:
+        # Don't set stdout, it's default value None, causes it to be set to
+        # stdout.
         assert output_file is None
-        output_file = sys.stdout.fileno()
+    elif not output_file:
+        output_file = subprocess.PIPE
 
     kwargs['stdout'] = output_file
     kwargs['stderr'] = subprocess.STDOUT

--- a/common/test_new_process.py
+++ b/common/test_new_process.py
@@ -49,20 +49,14 @@ class TestIntegrationExecute:
         assert result.retcode != 0
 
     @mock.patch('common.logs.info')
-    def test_output_files(self, mocked_info):
-        """Test that execute handles the output_files argument as intended."""
-        mocked_output_file = mock.Mock()
+    def test_output_file(self, mocked_info, tmp_path):
+        """Test that execute handles the output_file argument as intended."""
+        output_file_path = tmp_path / 'output'
+        with open(output_file_path, 'w') as output_file:
+            new_process.execute(self.COMMAND,
+                                timeout=1,
+                                output_file=output_file,
+                                expect_zero=False)
 
-        def mock_write(data):
-            assert data == 'Hello, World!\n'
-            # Assert that the log.info call hasn't been made yet since it
-            # happens after process termination.
-            assert not mocked_info.call_count
-            return len(data)
-
-        mocked_output_file.write.side_effect = mock_write
-        new_process.execute(self.COMMAND,
-                            timeout=1,
-                            output_files=[mocked_output_file],
-                            expect_zero=False)
-        mocked_output_file.write.assert_called()
+        with open(output_file_path, 'r') as output_file:
+            assert output_file.read() == 'Hello, World!\n'

--- a/docker/build.mk
+++ b/docker/build.mk
@@ -88,7 +88,7 @@ run-$(1)-$(2): .$(1)-$(2)-runner
 	docker run \
     --cap-add SYS_NICE \
     --cap-add SYS_PTRACE \
-    -e LOCAL_EXPERIMENT=1 \
+    -e FUZZ_OUTSIDE_EXPERIMENT=1 \
     -e TRIAL_ID=1 \
     -e FUZZER=$(1) \
     -e BENCHMARK=$(2) \
@@ -99,7 +99,7 @@ debug-$(1)-$(2): .$(1)-$(2)-runner
 	docker run \
     --cap-add SYS_NICE \
     --cap-add SYS_PTRACE \
-    -e LOCAL_EXPERIMENT=1 \
+    -e FUZZ_OUTSIDE_EXPERIMENT=1 \
     -e TRIAL_ID=1 \
     -e FUZZER=$(1) \
     -e BENCHMARK=$(2) \
@@ -167,7 +167,7 @@ run-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
 	docker run \
     --cap-add SYS_NICE \
     --cap-add SYS_PTRACE \
-    -e LOCAL_EXPERIMENT=1 \
+    -e FUZZ_OUTSIDE_EXPERIMENT=1 \
     -e TRIAL_ID=1 \
     -e FUZZER=$(1) \
     -e BENCHMARK=$($(2)-project-name) \
@@ -178,7 +178,7 @@ debug-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
 	docker run \
     --cap-add SYS_NICE \
     --cap-add SYS_PTRACE \
-    -e LOCAL_EXPERIMENT=1 \
+    -e FUZZ_OUTSIDE_EXPERIMENT=1 \
     -e TRIAL_ID=1 \
     -e FUZZER=$(1) \
     -e BENCHMARK=$($(2)-project-name) \

--- a/experiment/builder.py
+++ b/experiment/builder.py
@@ -164,8 +164,7 @@ def store_build_logs(build_config, build_result):
         build_log_filename = build_config + '.txt'
         gsutil.cp(tmp.name,
                   exp_path.gcs(get_build_logs_dir() / build_log_filename),
-                  parallel=False,
-                  write_to_stdout=False)
+                  parallel=False)
 
 
 def gcb_build(config_file: str,
@@ -204,7 +203,6 @@ def gcb_build(config_file: str,
     # Don't write to stdout to make concurrent building faster. Otherwise
     # writing becomes the bottleneck.
     result = new_process.execute(command,
-                                 write_to_stdout=False,
                                  kill_children=True,
                                  timeout=timeout_seconds)
     store_build_logs(config_name, result)
@@ -235,8 +233,7 @@ def build_measurer(benchmark: str) -> bool:
                                                  archive_name)
         gsutil.cp(cloud_bucket_archive_path,
                   str(benchmark_coverage_binary_dir),
-                  parallel=False,
-                  write_to_stdout=False)
+                  parallel=False)
 
         archive_path = benchmark_coverage_binary_dir / archive_name
         tar = tarfile.open(archive_path, 'r:gz')

--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -86,13 +86,6 @@ class Experiment:
                                          experiment_utils.get_experiment_name())
 
 
-def initialize_global_state(project: str):
-    """Set up any global state needed by the dispatcher, including
-    authenticating to docker and gcloud and setting the project for gcloud."""
-    # TODO(metzman): Move global state set up into startup script.
-    gcloud.set_default_project(project)
-
-
 def dispatcher_main():
     """Do the experiment and report results."""
     logs.info('Starting experiment.')
@@ -100,9 +93,6 @@ def dispatcher_main():
     # Set this here because we get failures if we do it in measurer for some
     # reason.
     multiprocessing.set_start_method('spawn')
-
-    initialize_global_state(experiment_utils.get_cloud_project())
-
     builder.gcb_build_base_images()
 
     experiment_config_file_path = os.path.join(fuzzer_config_utils.get_dir(),

--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -27,7 +27,6 @@ from typing import List
 
 from common import experiment_utils
 from common import fuzzer_config_utils
-from common import gcloud
 from common import logs
 from common import yaml_utils
 from database import models

--- a/experiment/run_coverage.py
+++ b/experiment/run_coverage.py
@@ -57,7 +57,6 @@ def do_coverage_run(  # pylint: disable=too-many-locals
         env = os.environ.copy()
         env['UBSAN_OPTIONS'] = 'coverage_dir=%s' % sancov_dir
         result = new_process.execute(command,
-                                     write_to_stdout=False,
                                      env=env,
                                      cwd=coverage_binary_dir,
                                      expect_zero=False,

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -189,20 +189,22 @@ def run_fuzzer(max_total_time, log_filename):
                  output_corpus=shlex.quote(output_corpus),
                  target_binary=shlex.quote(target_binary))
         ]
+
+        fuzzer_environment = _get_fuzzer_environment()
         # Write output to stdout if user is fuzzing from command line.
         # Otherwise, write output to the log file.
         if environment.get('FUZZ_OUTSIDE_EXPERIMENT'):
             new_process.execute(command,
                                 timeout=max_total_time,
                                 kill_children=True,
-                                env=_get_fuzzer_environment())
+                                env=fuzzer_environment)
         else:
             with open(log_filename, 'wb') as log_file:
                 new_process.execute(command,
                                     timeout=max_total_time,
                                     output_file=log_file,
                                     kill_children=True,
-                                    env=_get_fuzzer_environment())
+                                    env=fuzzer_environment)
 
     except subprocess.CalledProcessError:
         logs.error('Fuzz process returned nonzero.')

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -196,6 +196,7 @@ def run_fuzzer(max_total_time, log_filename):
         if environment.get('FUZZ_OUTSIDE_EXPERIMENT'):
             new_process.execute(command,
                                 timeout=max_total_time,
+                                output_file=sys.stdout.fileno(),
                                 kill_children=True,
                                 env=fuzzer_environment)
         else:

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -196,7 +196,7 @@ def run_fuzzer(max_total_time, log_filename):
         if environment.get('FUZZ_OUTSIDE_EXPERIMENT'):
             new_process.execute(command,
                                 timeout=max_total_time,
-                                output_file=sys.stdout.fileno(),
+                                write_to_stdout=True,
                                 kill_children=True,
                                 env=fuzzer_environment)
         else:

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -100,9 +100,7 @@ def end_expired_trials(experiment_config: dict):
         i for i in expired_instances if i in running_instances
     ]
     if instances_to_delete and not gcloud.delete_instances(
-            instances_to_delete,
-            experiment_config['cloud_compute_zone'],
-            write_to_stdout=False):
+            instances_to_delete, experiment_config['cloud_compute_zone']):
         # If we failed to delete some instances, then don't update the status
         # of expired trials in database as we don't know which instances were
         # successfully deleted. Wait for next iteration of end_expired_trials.
@@ -280,8 +278,7 @@ docker run --privileged --cpuset-cpus=0 --rm \
     return gcloud.create_instance(instance_name,
                                   gcloud.InstanceType.RUNNER,
                                   experiment_config,
-                                  startup_script=startup_script_path,
-                                  write_to_stdout=False)
+                                  startup_script=startup_script_path)
 
 
 def main():

--- a/experiment/test_runner.py
+++ b/experiment/test_runner.py
@@ -28,9 +28,11 @@ from test_libs import utils as test_utils
 # pylint: disable=invalid-name,unused-argument,redefined-outer-name
 
 
-def test_run_fuzzer_log_file(fs):
+@mock.patch('subprocess.Popen.communicate')
+def test_run_fuzzer_log_file(mocked_communicate, fs):
     """Test that run_fuzzer invokes the fuzzer defined run_fuzzer function as
     expected."""
+    mocked_communicate.return_value = ('', 0)
     max_total_time = 1
     log_filename = '/log.txt'
     os.environ['MAX_TOTAL_TIME'] = str(max_total_time)
@@ -153,14 +155,12 @@ def test_do_sync_changed(mocked_execute, mocked_is_corpus_dir_same, fs,
             ('gs://bucket/experiment-name/experiment-folders/'
              'benchmark-1-fuzzer-name-a/trial-1/corpus/'
              'corpus-archive-1337.tar.gz')
-        ],
-                  write_to_stdout=False),
+        ]),
         mock.call([
             'gsutil', 'rsync', '-d', '-r', 'results-copy',
             ('gs://bucket/experiment-name/experiment-folders/'
              'benchmark-1-fuzzer-name-a/trial-1/results')
-        ],
-                  write_to_stdout=False)
+        ])
     ]
     unchanged_cycles_path = os.path.join(trial_runner.results_dir,
                                          'unchanged-cycles')

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -69,11 +69,10 @@ def pending_trials(db, experiment_config):
      ('bloaty_fuzz_target', 'gcr.io/fuzzbench/oss-fuzz/runners/fuzzer-a/bloaty',
       'fuzz_target')])
 @mock.patch('common.gcloud.create_instance')
-@mock.patch('common.fuzzer_config_utils.get_by_variant_name')  # pylint: disable=too-many-arguments
-def test_create_trial_instance(mocked_get_by_variant_name,
-                               mocked_create_instance, benchmark,
-                               expected_image, expected_target,
-                               experiment_config):
+@mock.patch('common.fuzzer_config_utils.get_by_variant_name')
+def test_create_trial_instance(  # pylint: disable=too-many-arguments
+        mocked_get_by_variant_name, mocked_create_instance, benchmark,
+        expected_image, expected_target, experiment_config):
     """Test that create_trial_instance invokes create_instance
     and creates a startup script for the instance, as we expect it to."""
     instance_name = 'instance1'
@@ -97,8 +96,7 @@ def test_create_trial_instance(mocked_get_by_variant_name,
         instance_name,
         gcloud.InstanceType.RUNNER,
         experiment_config,
-        startup_script=expected_startup_script_path,
-        write_to_stdout=False)
+        startup_script=expected_startup_script_path)
     expected_format_string = '''#!/bin/bash
 echo 0 > /proc/sys/kernel/yama/ptrace_scope
 echo core >/proc/sys/kernel/core_pattern


### PR DESCRIPTION
new_process previously used threads so that it could write fuzzer
output to stdout and a log file in real time. This allowed users
fuzzing locally to see the output of the fuzzer will still experiencing
the same behavior as in production (where a file was written to).

However, the code that did this was buggy and complex as well as
CPU intensive. This patch removes that code. Instead when fuzzing
locally, fuzzer output will only be written to stdout instead of
a log file.

Also rename LOCAL_EXPERIMENT to the more descriptive
FUZZ_OUTSIDE_EXPERIMENT since it is used for running fuzzers
outside of the context of an experiment.