### PR TITLE
[aflplusplus] Use afl-clang-fast(++) as compiler

### DIFF
--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -17,13 +17,35 @@ import os
 import shutil
 
 from fuzzers.afl import fuzzer as afl_fuzzer
+from fuzzers import utils
 
 # OUT environment variable is the location of build directory (default is /out).
 
 
 def build():
     """Build fuzzer."""
-    afl_fuzzer.build()
+    cflags = [
+        '-O2',
+        '-fno-omit-frame-pointer',
+        '-gline-tables-only',
+        '-fsanitize=address',
+    ]
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cflags)
+
+    os.environ['CC'] = '/afl/afl-clang-fast'
+    os.environ['CXX'] = '/afl/afl-clang-fast++'
+    os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+
+    # Some benchmarks like lcms
+    # (see: https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
+    # fail to compile if the compiler outputs things to stderr in unexepcted
+    # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
+    # from writing AFL specific messages to stderr.
+    os.environ['AFL_QUIET'] = '1'
+
+    utils.build_benchmark()
+    shutil.copy('/afl/afl-fuzz', os.environ['OUT'])
 
 
 def fuzz(input_corpus, output_corpus, target_binary):

--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -39,7 +39,7 @@ def build():
 
     # Some benchmarks like lcms
     # (see: https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
-    # fail to compile if the compiler outputs things to stderr in unexepcted
+    # fail to compile if the compiler outputs things to stderr in unexpected
     # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
     # from writing AFL specific messages to stderr.
     os.environ['AFL_QUIET'] = '1'


### PR DESCRIPTION
Use afl-clang-fast(++) as compiler instead of using clang with
trace-pc-guard for faster and better instrumentation.