### PR TITLE
Change Eclipser max file size from 10->1 Mb

### DIFF
--- a/fuzzers/eclipser/fuzzer.py
+++ b/fuzzers/eclipser/fuzzer.py
@@ -66,7 +66,9 @@ def fuzz(input_corpus, output_corpus, target_binary):
         '-f',
         'foo',
         '--maxfilelen',
-        str(10 * 1024 * 1024),  # Increase since default is too low (8 bytes).
+        # Default is too low (8 bytes), match experiment config at:
+        # https://github.com/SoftSec-KAIST/Eclipser-Artifact/blob/6aadf02eeadb0416bd4c5edeafc8627bc24ebc82/docker-scripts/experiment-scripts/package-exp/run_eclipser.sh#L25
+        '1048576',
     ]
     if os.listdir(input_corpus):  # Important, otherwise Eclipser crashes.
         command += ['-i', input_corpus]


### PR DESCRIPTION
This matches the experiment config at
https://github.com/SoftSec-KAIST/Eclipser-Artifact/blob/6aadf02eeadb0416bd4c5edeafc8627bc24ebc82/docker-scripts/experiment-scripts/lava-exp/run_eclipser.sh#L25

Fixes #70.