### PR TITLE
Fix wrong virtualenv regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ SHELL := /bin/bash
 VENV_ACTIVATE := .venv/bin/activate
 
 ${VENV_ACTIVATE}:
-	python3 -m pip install --user virtualenv
 	rm -rf .venv
 	python3 -m venv .venv
 	source ${VENV_ACTIVATE} && python3 -m pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VENV_ACTIVATE := .venv/bin/activate
 ${VENV_ACTIVATE}:
 	python3 -m pip install --user virtualenv
 	rm -rf .venv
-	python3 -m virtualenv -p `which python3` .venv
+	python3 -m venv .venv
 	source ${VENV_ACTIVATE} && python3 -m pip install -r requirements.txt
 
 install-dependencies: ${VENV_ACTIVATE}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VENV_ACTIVATE := .venv/bin/activate
 ${VENV_ACTIVATE}:
 	python3 -m pip install --user virtualenv
 	rm -rf .venv
-	python3 -m virtualenv .venv
+	python3 -m virtualenv -p `which python3` .venv
 	source ${VENV_ACTIVATE} && python3 -m pip install -r requirements.txt
 
 install-dependencies: ${VENV_ACTIVATE}


### PR DESCRIPTION
This causes Python 2 virtualenv to be created and python3 pip deps to be installed in user's system python packages directory. Just use venv as per https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment which picks python3 automatically.