### PR TITLE
Use recommended per-testcase timeout for Eclipser.

### DIFF
--- a/fuzzers/eclipser/fuzzer.py
+++ b/fuzzers/eclipser/fuzzer.py
@@ -69,6 +69,10 @@ def fuzz(input_corpus, output_corpus, target_binary):
         # Default is too low (8 bytes), match experiment config at:
         # https://github.com/SoftSec-KAIST/Eclipser-Artifact/blob/6aadf02eeadb0416bd4c5edeafc8627bc24ebc82/docker-scripts/experiment-scripts/package-exp/run_eclipser.sh#L25
         '1048576',
+        # Default is low (0.5 sec), recommended to use higher:
+        # https://github.com/google/fuzzbench/issues/70#issuecomment-596060572
+        '--exectimeout',
+        '2000',
     ]
     if os.listdir(input_corpus):  # Important, otherwise Eclipser crashes.
         command += ['-i', input_corpus]


### PR DESCRIPTION
As per fix recommendation in #70.