### PR TITLE
New AFL++ fuzzer.py

### DIFF
--- a/docker/base-builder/Dockerfile
+++ b/docker/base-builder/Dockerfile
@@ -52,4 +52,4 @@ COPY --from=base-clang /usr/local/lib/libc++*.a /usr/local/lib/
 COPY --from=base-clang /usr/local/include/ /usr/local/include
 
 # Use libc++ thoughout the build.
-ENV CXXFLAGS -stdlib=libc++
+ENV CXXFLAGS -stdlib=libc++ -pthread

--- a/experiment/generate_report.py
+++ b/experiment/generate_report.py
@@ -58,11 +58,10 @@ def get_arg_parser():
         '--benchmarks',
         nargs='*',
         help='Names of the benchmarks to include in the report.')
-    parser.add_argument(
-        '-f',
-        '--fuzzers',
-        nargs='*',
-        help='Names of the fuzzers to include in the report.')
+    parser.add_argument('-f',
+                        '--fuzzers',
+                        nargs='*',
+                        help='Names of the fuzzers to include in the report.')
     parser.add_argument(
         '-l',
         '--label-by-experiment',
@@ -133,8 +132,8 @@ def main():
     args = parser.parse_args()
 
     generate_report(args.experiments, args.report_dir, args.report_name,
-                    args.label_by_experiment, args.benchmarks, args.fuzzers, args.report_type,
-                    args.quick, args.from_cached_data)
+                    args.label_by_experiment, args.benchmarks, args.fuzzers,
+                    args.report_type, args.quick, args.from_cached_data)
 
 
 if __name__ == '__main__':

--- a/fuzzers/aflplusplus/builder.Dockerfile
+++ b/fuzzers/aflplusplus/builder.Dockerfile
@@ -26,7 +26,7 @@ RUN git clone https://github.com/vanhauser-thc/AFLplusplus.git /afl && \
     cd /afl && \
     git checkout c159b872ef17d4c09238f99ac11021e12975cb3a && \
     AFL_NO_X86=1 make PYTHON_INCLUDE=/ && \
-    cd libdislocator && make && cd .. \
+    cd libdislocator && make && cd .. && \
     cd llvm_mode && CXXFLAGS= make
 
 # Use afl_driver.cpp from LLVM as our fuzzing library.

--- a/fuzzers/aflplusplus/builder.Dockerfile
+++ b/fuzzers/aflplusplus/builder.Dockerfile
@@ -19,15 +19,15 @@ FROM $parent_image
 RUN apt-get update && \
     apt-get install wget libstdc++-5-dev -y
 
-# Download and compile afl++ (v2.60c).
+# Download and compile afl++ (v2.62d).
 # Build without Python support as we don't need it.
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/vanhauser-thc/AFLplusplus.git /afl && \
     cd /afl && \
-    git checkout 842cd9dec3c4c83d660d96dcdb3f5cf0c6e6f4fb && \
+    git checkout c159b872ef17d4c09238f99ac11021e12975cb3a && \
     AFL_NO_X86=1 make PYTHON_INCLUDE=/ && \
-    cd llvm_mode && \
-    CXXFLAGS= make
+    cd libdislocator && make && cd .. \
+    cd llvm_mode && CXXFLAGS= make
 
 # Use afl_driver.cpp from LLVM as our fuzzing library.
 RUN wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \

--- a/fuzzers/aflplusplus/builder.Dockerfile
+++ b/fuzzers/aflplusplus/builder.Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/vanhauser-thc/AFLplusplus.git /afl && \
     cd /afl && \
-    git checkout c159b872ef17d4c09238f99ac11021e12975cb3a && \
+    git checkout 684f4dd1c44053517c6685a8a3137691535ecd84 && \
     AFL_NO_X86=1 make PYTHON_INCLUDE=/ && \
     cd libdislocator && make && cd .. && \
     cd llvm_mode && CXXFLAGS= make

--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -115,7 +115,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
-    flags = []
+    flags = ["-d"] # FidgetyAFL is better when runnign alone
     if os.path.exists(cmplog_target_binary):
         flags += ["-c", cmplog_target_binary]
     if 'ADDITIONAL_ARGS' in os.environ:

--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -22,19 +22,38 @@ from fuzzers import utils
 # OUT environment variable is the location of build directory (default is /out).
 
 
+def get_cmplog_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'cmplog')
+
+
 def build():
     """Build fuzzer."""
+    build_modes = []
+    if "BUILD_MODES" in os.environ:
+        build_modes = os.environ['BUILD_MODES'].split(',')
+
     cflags = [
         '-O2',
         '-fno-omit-frame-pointer',
         '-gline-tables-only',
-        '-fsanitize=address',
     ]
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 
-    os.environ['CC'] = '/afl/afl-clang-fast'
-    os.environ['CXX'] = '/afl/afl-clang-fast++'
+    if "qemu" in build_modes:
+        os.environ['CC'] = 'clang'
+        os.environ['CXX'] = 'clang++'
+    else:
+        os.environ['CC'] = '/afl/afl-clang-fast'
+        os.environ['CXX'] = '/afl/afl-clang-fast++'
+        os.environ["AFL_USE_ASAN"] = "1"
+
+        if "laf" in build_modes:
+            os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+            os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+            os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+
     os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
 
     # Some benchmarks like lcms
@@ -44,25 +63,56 @@ def build():
     # from writing AFL specific messages to stderr.
     os.environ['AFL_QUIET'] = '1'
 
-    utils.build_benchmark()
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+    with restore_directory(src), restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        utils.build_benchmark()
+
+    if "cmplog" in BUILD_MODES and "qemu" not in BUILD_MODES:
+
+        # CmpLog requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env["AFL_LLVM_CMPLOG"] = "1"
+
+        # For CmpLog build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new CmpLog build directory.
+        build_directory = os.environ['OUT']
+        cmplog_build_directory = get_cmplog_build_directory(build_directory)
+        os.mkdir(cmplog_build_directory)
+        new_env['OUT'] = cmplog_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(cmplog_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for CmpLog fuzzing target')
+        utils.build_benchmark(env=new_env)
+
     shutil.copy('/afl/afl-fuzz', os.environ['OUT'])
 
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
+    # Calculate CmpLog binary path from the instrumented target binary.
+    target_binary_directory = os.path.dirname(target_binary)
+    cmplog_target_binary_directory = (
+        get_cmplog_build_directory(target_binary_directory))
+    target_binary_name = os.path.basename(target_binary)
+    cmplog_target_binary = os.path.join(cmplog_target_binary_directory,
+                                        target_binary_name)
+
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
 
-    afl_fuzzer.run_afl_fuzz(
-        input_corpus,
-        output_corpus,
-        target_binary,
-        additional_flags=[
-            # Enable AFLFast's power schedules with default exponential
-            # schedule.
-            '-p',
-            'fast',
-            # Enable Mopt mutator with pacemaker fuzzing mode at first. This
-            # is also recommended in a short-time scale evaluation.
-            '-L',
-            '0',
-        ])
+    flags = []
+    if os.path.exists(cmplog_target_binary):
+        flags += ["-c", cmplog_target_binary]
+    if 'ADDITIONAL_ARGS' in os.environ:
+        flags += os.environ['ADDITIONAL_ARGS'].split(' ')
+
+    afl_fuzzer.run_afl_fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            additional_flags=flags)

--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -31,7 +31,9 @@ def get_cmplog_build_directory(target_directory):
 
 def build():
     """Build fuzzer."""
-    build_modes = []
+    # BUILD_MODES is not already supported by fuzzbench, meanwhile we provide
+    # a default configuration
+    build_modes = ["instrim", "laf"]
     if "BUILD_MODES" in os.environ:
         build_modes = os.environ['BUILD_MODES'].split(',')
 

--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -49,12 +49,16 @@ def build():
     else:
         os.environ['CC'] = '/afl/afl-clang-fast'
         os.environ['CXX'] = '/afl/afl-clang-fast++'
-        os.environ["AFL_USE_ASAN"] = "1"
 
         if "laf" in build_modes:
             os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
             os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
             os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        
+        if "instrim" in build_modes:
+            # I avoid to put also AFL_LLVM_INSTRIM_LOOPHEAD
+            os.environ["AFL_LLVM_INSTRIM"] = "1";
+            os.environ["AFL_LLVM_INSTRIM_SKIPSINGLEBLOCK"] = "1";
 
     os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
 
@@ -107,6 +111,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
                                         target_binary_name)
 
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
+    os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
     flags = []
     if os.path.exists(cmplog_target_binary):

--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -56,11 +56,11 @@ def build():
             os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
             os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
             os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
-        
+
         if "instrim" in build_modes:
             # I avoid to put also AFL_LLVM_INSTRIM_LOOPHEAD
-            os.environ["AFL_LLVM_INSTRIM"] = "1";
-            os.environ["AFL_LLVM_INSTRIM_SKIPSINGLEBLOCK"] = "1";
+            os.environ["AFL_LLVM_INSTRIM"] = "1"
+            os.environ["AFL_LLVM_INSTRIM_SKIPSINGLEBLOCK"] = "1"
 
     os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
 
@@ -115,7 +115,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
-    flags = ["-d"] # FidgetyAFL is better when runnign alone
+    flags = ["-d"]  # FidgetyAFL is better when runnign alone
     if os.path.exists(cmplog_target_binary):
         flags += ["-c", cmplog_target_binary]
     if 'ADDITIONAL_ARGS' in os.environ:
@@ -125,6 +125,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
                             output_corpus,
                             target_binary,
                             additional_flags=flags)
+
 
 @contextlib.contextmanager
 def restore_directory(directory):

--- a/fuzzers/utils.py
+++ b/fuzzers/utils.py
@@ -61,7 +61,8 @@ NO_SANITIZER_COMPAT_CFLAGS = [
     '-pthread', '-Wl,--no-as-needed', '-Wl,-ldl', '-Wl,-lm',
     '-Wno-unused-command-line-argument'
 ]
-NO_SANITIZER_COMPAT_CXXFLAGS = ['-stdlib=libc++'] + NO_SANITIZER_COMPAT_CFLAGS
+NO_SANITIZER_COMPAT_CXXFLAGS = ['-stdlib=libc++', '-pthread'] + \
+    NO_SANITIZER_COMPAT_CFLAGS
 
 
 def set_no_sanitizer_compilation_flags(env=None):


### PR DESCRIPTION
This AFL++ fuzzer.py works fine. There is the support to build configurations, but the conf is harcoded ATM.
I added also a small fix that includes -pthread by default because I experienced some errors while linking C++ (libc++ uses pthread).