### PR TITLE
Move restore_directory into utils so other modules can use it.

### DIFF
--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -15,8 +15,6 @@
 
 import os
 import shutil
-import contextlib
-import tempfile
 
 from fuzzers.afl import fuzzer as afl_fuzzer
 from fuzzers import utils
@@ -72,7 +70,7 @@ def build():
 
     src = os.getenv('SRC')
     work = os.getenv('WORK')
-    with restore_directory(src), restore_directory(work):
+    with utils.restore_directory(src), utils.restore_directory(work):
         # Restore SRC to its initial state so we can build again without any
         # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
         # twice in the same directory without this.
@@ -124,37 +122,3 @@ def fuzz(input_corpus, output_corpus, target_binary):
                             output_corpus,
                             target_binary,
                             additional_flags=flags)
-
-
-@contextlib.contextmanager
-def restore_directory(directory):
-    """Helper contextmanager that when created saves a backup of |directory| and
-    when closed/exited replaces |directory| with the backup.
-
-    Example usage:
-
-    directory = 'my-directory'
-    with restore_directory(directory):
-       shutil.rmtree(directory)
-    # At this point directory is in the same state where it was before we
-    # deleted it.
-    """
-    # TODO(metzman): Figure out if this is worth it, so far it only allows QSYM
-    # to compile bloaty.
-    if not directory:
-        # Don't do anything if directory is None.
-        yield
-        return
-    # Save cwd so that if it gets deleted we can just switch into the restored
-    # version without code that runs after us running into issues.
-    initial_cwd = os.getcwd()
-    with tempfile.TemporaryDirectory() as temp_dir:
-        backup = os.path.join(temp_dir, os.path.basename(directory))
-        shutil.copytree(directory, backup)
-        yield
-        shutil.rmtree(directory)
-        shutil.move(backup, directory)
-        try:
-            os.getcwd()
-        except FileNotFoundError:
-            os.chdir(initial_cwd)

--- a/fuzzers/qsym/fuzzer.py
+++ b/fuzzers/qsym/fuzzer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Integration code for QSYM fuzzer."""
 
-import contextlib
 import shutil
 import subprocess
 import os
@@ -43,7 +42,7 @@ def build():
 
     src = os.getenv('SRC')
     work = os.getenv('WORK')
-    with restore_directory(src), restore_directory(work):
+    with utils.restore_directory(src), utils.restore_directory(work):
         # Restore SRC to its initial state so we can build again without any
         # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
         # twice in the same directory without this.
@@ -112,37 +111,3 @@ def fuzz(input_corpus, output_corpus, target_binary):
         './qsym/bin/run_qsym_afl.py', '-a', 'afl-slave', '-o', output_corpus,
         '-n', 'qsym', '--', uninstrumented_target_binary
     ])
-
-
-@contextlib.contextmanager
-def restore_directory(directory):
-    """Helper contextmanager that when created saves a backup of |directory| and
-    when closed/exited replaces |directory| with the backup.
-
-    Example usage:
-
-    directory = 'my-directory'
-    with restore_directory(directory):
-       shutil.rmtree(directory)
-    # At this point directory is in the same state where it was before we
-    # deleted it.
-    """
-    # TODO(metzman): Figure out if this is worth it, so far it only allows QSYM
-    # to compile bloaty.
-    if not directory:
-        # Don't do anything if directory is None.
-        yield
-        return
-    # Save cwd so that if it gets deleted we can just switch into the restored
-    # version without code that runs after us running into issues.
-    initial_cwd = os.getcwd()
-    with tempfile.TemporaryDirectory() as temp_dir:
-        backup = os.path.join(temp_dir, os.path.basename(directory))
-        shutil.copytree(directory, backup)
-        yield
-        shutil.rmtree(directory)
-        shutil.move(backup, directory)
-        try:
-            os.getcwd()
-        except FileNotFoundError:
-            os.chdir(initial_cwd)

--- a/fuzzers/qsym/fuzzer.py
+++ b/fuzzers/qsym/fuzzer.py
@@ -16,7 +16,6 @@
 import shutil
 import subprocess
 import os
-import tempfile
 import threading
 import time
 

--- a/fuzzers/utils.py
+++ b/fuzzers/utils.py
@@ -17,42 +17,9 @@ import contextlib
 import os
 import shutil
 import subprocess
+import tempfile
 
 OSS_FUZZ_LIB_FUZZING_ENGINE_PATH = '/usr/lib/libFuzzingEngine.a'
-
-
-@contextlib.contextmanager
-def restore_directory(directory):
-    """Helper contextmanager that when created saves a backup of |directory| and
-    when closed/exited replaces |directory| with the backup.
-
-    Example usage:
-
-    directory = 'my-directory'
-    with restore_directory(directory):
-       shutil.rmtree(directory)
-    # At this point directory is in the same state where it was before we
-    # deleted it.
-    """
-    # TODO(metzman): Figure out if this is worth it, so far it only allows QSYM
-    # to compile bloaty.
-    if not directory:
-        # Don't do anything if directory is None.
-        yield
-        return
-    # Save cwd so that if it gets deleted we can just switch into the restored
-    # version without code that runs after us running into issues.
-    initial_cwd = os.getcwd()
-    with tempfile.TemporaryDirectory() as temp_dir:
-        backup = os.path.join(temp_dir, os.path.basename(directory))
-        shutil.copytree(directory, backup)
-        yield
-        shutil.rmtree(directory)
-        shutil.move(backup, directory)
-        try:
-            os.getcwd()
-        except FileNotFoundError:
-            os.chdir(initial_cwd)
 
 
 def build_benchmark(env=None):
@@ -107,3 +74,37 @@ def set_no_sanitizer_compilation_flags(env=None):
         env = os.environ
     env['CFLAGS'] = ' '.join(NO_SANITIZER_COMPAT_CFLAGS)
     env['CXXFLAGS'] = ' '.join(NO_SANITIZER_COMPAT_CXXFLAGS)
+
+
+@contextlib.contextmanager
+def restore_directory(directory):
+    """Helper contextmanager that when created saves a backup of |directory| and
+    when closed/exited replaces |directory| with the backup.
+
+    Example usage:
+
+    directory = 'my-directory'
+    with restore_directory(directory):
+       shutil.rmtree(directory)
+    # At this point directory is in the same state where it was before we
+    # deleted it.
+    """
+    # TODO(metzman): Figure out if this is worth it, so far it only allows QSYM
+    # to compile bloaty.
+    if not directory:
+        # Don't do anything if directory is None.
+        yield
+        return
+    # Save cwd so that if it gets deleted we can just switch into the restored
+    # version without code that runs after us running into issues.
+    initial_cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        backup = os.path.join(temp_dir, os.path.basename(directory))
+        shutil.copytree(directory, backup)
+        yield
+        shutil.rmtree(directory)
+        shutil.move(backup, directory)
+        try:
+            os.getcwd()
+        except FileNotFoundError:
+            os.chdir(initial_cwd)

--- a/fuzzers/utils.py
+++ b/fuzzers/utils.py
@@ -13,11 +13,46 @@
 # limitations under the License.
 """Utility functions for running fuzzers."""
 
+import contextlib
 import os
 import shutil
 import subprocess
 
 OSS_FUZZ_LIB_FUZZING_ENGINE_PATH = '/usr/lib/libFuzzingEngine.a'
+
+
+@contextlib.contextmanager
+def restore_directory(directory):
+    """Helper contextmanager that when created saves a backup of |directory| and
+    when closed/exited replaces |directory| with the backup.
+
+    Example usage:
+
+    directory = 'my-directory'
+    with restore_directory(directory):
+       shutil.rmtree(directory)
+    # At this point directory is in the same state where it was before we
+    # deleted it.
+    """
+    # TODO(metzman): Figure out if this is worth it, so far it only allows QSYM
+    # to compile bloaty.
+    if not directory:
+        # Don't do anything if directory is None.
+        yield
+        return
+    # Save cwd so that if it gets deleted we can just switch into the restored
+    # version without code that runs after us running into issues.
+    initial_cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        backup = os.path.join(temp_dir, os.path.basename(directory))
+        shutil.copytree(directory, backup)
+        yield
+        shutil.rmtree(directory)
+        shutil.move(backup, directory)
+        try:
+            os.getcwd()
+        except FileNotFoundError:
+            os.chdir(initial_cwd)
 
 
 def build_benchmark(env=None):


### PR DESCRIPTION
Move restore_directory from qsym/fuzzer.py to fuzzers/utils.py so other fuzzers can use it.
AFLplusplus in #90 is copying it for now.