### PR TITLE
Revert "[presubmit] Remove unnecessary git diff invocation (#103)"

### DIFF
--- a/presubmit.py
+++ b/presubmit.py
@@ -260,15 +260,19 @@ def license_check(paths: List[Path]) -> bool:
 
 def get_changed_files() -> List[Path]:
     """Return a list of absolute paths of files changed in this git branch."""
-    diff_command = ['git', 'diff', '--name-only', 'origin...']
+    uncommitted_diff_command = ['git', 'diff', '--name-only', 'HEAD']
+    output = subprocess.check_output(
+        uncommitted_diff_command).decode().splitlines()
+    uncommitted_changed_files = set(
+        Path(path).absolute() for path in output if Path(path).is_file())
+
+    committed_diff_command = ['git', 'diff', '--name-only', 'origin...']
     try:
-        output = subprocess.check_output(diff_command).decode().splitlines()
-        changed_files = list(
-            set(
-                Path(path).absolute()
-                for path in output
-                if Path(path).is_file()))
-        return changed_files
+        output = subprocess.check_output(
+            committed_diff_command).decode().splitlines()
+        committed_changed_files = set(
+            Path(path).absolute() for path in output if Path(path).is_file())
+        return list(committed_changed_files.union(uncommitted_changed_files))
     except subprocess.CalledProcessError:
         # This probably won't happen to anyone. It can happen if your copy
         # of the repo wasn't cloned so give instructions on how to handle.
@@ -279,7 +283,7 @@ def get_changed_files() -> List[Path]:
         'git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master" '
         'and try again.\n'
         'Please file an issue if this doesn\'t fix things.') %
-                    ' '.join(diff_command))
+                    ' '.join(committed_diff_command))
 
 
 def do_tests() -> bool:


### PR DESCRIPTION
This reverts commit ac642951a9ad7a039d51f66f1ec96e151067860c.

If you change a file and don't commit it, presubmit currently ignores it.
We do need to take the union.