### PR TITLE
Update honggfuzz to the newest version, and disable --sanitizers

### DIFF
--- a/fuzzers/honggfuzz/builder.Dockerfile
+++ b/fuzzers/honggfuzz/builder.Dockerfile
@@ -18,14 +18,14 @@ FROM $parent_image
 # honggfuzz requires libfd and libunwid.
 RUN apt-get update -y && apt-get install -y libbfd-dev libunwind-dev libblocksruntime-dev
 
-# Download honggfuz version 2.1 + 815ccf8e9580b8c83ee673211da9fa217d354b5f
+# Download honggfuz version 2.1 + f316276ee58c2339ce8505d58eaf63baa967ed1c
 # Set CFLAGS use honggfuzz's defaults except for -mnative which can build CPU
 # dependent code that may not work on the machines we actually fuzz on.
 # Create an empty object file which will become the FUZZER_LIB lib (since
 # honggfuzz doesn't need this when hfuzz-clang(++) is used).
 RUN git clone https://github.com/google/honggfuzz.git /honggfuzz && \
     cd /honggfuzz && \
-    git checkout 815ccf8e9580b8c83ee673211da9fa217d354b5f && \
+    git checkout f316276ee58c2339ce8505d58eaf63baa967ed1c && \
     CFLAGS="-O3 -funroll-loops" make && \
     touch empty_lib.c && \
     cc -c -o empty_lib.o empty_lib.c

--- a/fuzzers/honggfuzz/fuzzer.py
+++ b/fuzzers/honggfuzz/fuzzer.py
@@ -54,6 +54,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
 
     print('[run_fuzzer] Running target with honggfuzz')
     subprocess.call([
-        './honggfuzz', '--sanitizers', '--persistent', '--input', input_corpus,
-        '--output', output_corpus, '--', target_binary
+        './honggfuzz', '--persistent', '--rlimit_rss', '2048',
+        '--sanitizers_del_report=true', '--input', input_corpus, '--output',
+        output_corpus, '--', target_binary
     ])


### PR DESCRIPTION
The newest version has some additional "improvements" which can make it
a better fuzzer :).

Not specifying --sanitizers doesn't affect fuzzbench. It's only useful
for off-fuzz/clusterfuzz where it's used to make *san libraries generate
proper reports (so, Clusterfuzz can pick them up and create end-user
reports - e.g with stacktraces). It's not necessary for fuzzbench.

Specifying --sanitizers_del_report=true will actually delete those
report files. With some benchmarks (e.g. with proj4) it's possible to
create testcases which crash the benchmark, and then tons of ASAN log
files will be left around, eating up disk space, and for no good reasons.

Thirdly, it sets the memory limit to 2GB per fuzzed benchmark, in order
to bring it in line with the current libfuzzer config, and to avoid OOMs.