### PR TITLE
Update experiment summary text

### DIFF
--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -58,8 +58,9 @@
             ranking fuzzers on each benchmark according to their median reached
             coverages. Critical difference is based on Friedman/Nemenyi post-hoc
             test. See more in the <a href="https://google.github.io/fuzzbench/reference/report/">
-            documentation</a>. Note that if a fuzzer does not support all benchmarks,
-            its ranking as shown in this diagram could be lower than it should be.
+            documentation</a>.<br>
+            Note: If a fuzzer does not support all benchmarks,
+            its ranking as shown in this diagram can be lower than it should be.
             So please check the list of supported benchmarks for the fuzzer(s) of your interest.
             The list could be specified in the fuzzer's README.md like
             <a href="https://github.com/google/fuzzbench/blob/master/fuzzers/aflsmart/README.md">this</a>.

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -57,9 +57,12 @@
             Aggregate critical difference diagram showing average ranks when
             ranking fuzzers on each benchmark according to their median reached
             coverages. Critical difference is based on Friedman/Nemenyi post-hoc
-            test. See more in the
-            <a href="https://google.github.io/fuzzbench/reference/report/">
-            documentation</a>.
+            test. See more in the <a href="https://google.github.io/fuzzbench/reference/report/">
+            documentation</a>. Note that if a fuzzer does not support all benchmarks,
+            its ranking as shown in this diagram could be lower than it should be.
+            So please check the list of supported benchmarks for the fuzzer(s) of your interest.
+            The list could be specified in the fuzzer's README.md like
+            <a href="https://github.com/google/fuzzbench/blob/master/fuzzers/aflsmart/README.md">this</a>.
 
             <div class="row">
                 <div class="col s7 offset-s3">

--- a/fuzzers/aflsmart/README.md
+++ b/fuzzers/aflsmart/README.md
@@ -1,0 +1,12 @@
+# Supported benchmarks
+
+[AFLSmart](https://github.com/aflsmart/aflsmart) is a structure-aware greybox-fuzzer and it is designed to work best for programs taking chunk-based file formats (e.g., JPEG, PNG and many others) as inputs. To fully enable its structure-aware mode, AFLSmart requires input models (e.g., grammar). So if you evaluate AFLSmart on FuzzBench, please focus on the results for the following benchmarks. We keep trying to include more input models so that more benchmarks will be supported.
+
+1. libpng-1.2.56
+
+2. libjpeg-turbo-07-2017
+
+3. libpcap_fuzz_both
+
+Since the experiment summary diagram of the default FuzzBench report is automatically generated based on the results of all benchmarks, many of them have not been supported by AFLSmart, the ranking of AFLSmart in that diagram may not be correct.
+


### PR DESCRIPTION
Hi,

As discussed, the rankings shown on the experiment summary diagram may not be correct if a fuzzer does not support all benchmarks.

This pull request is for updating the experiment summary text in the generated FuzzBench report to clarify this. I also add a list of benchmarks which are supported by AFLSmart as an example. The list is short but we are working on more input models to support more benchmarks.

Thanks, 

Thuan