### PR TITLE
[afl] Skip deterministic steps (ie: use -d).

### DIFF
--- a/fuzzers/afl/fuzzer.py
+++ b/fuzzers/afl/fuzzer.py
@@ -83,6 +83,9 @@ def run_afl_fuzz(input_corpus,
         input_corpus,
         '-o',
         output_corpus,
+        # Use deterministic mode as it does best when we don't have
+        # seeds which is often the case.
+        '-d',
         # Use no memory limit as ASAN doesn't play nicely with one.
         '-m',
         'none'

--- a/fuzzers/afl_deterministic/builder.Dockerfile
+++ b/fuzzers/afl_deterministic/builder.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image=gcr.io/fuzzbench/base-builder
+FROM $parent_image
+
+# Download and compile AFL v2.56b.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/google/AFL.git /afl && \
+    cd /afl && \
+    git checkout 8da80951dd7eeeb3e3b5a3bcd36c485045f40274 && \
+    AFL_NO_X86=1 make
+
+# Use afl_driver.cpp from LLVM as our fuzzing library.
+RUN apt-get update && \
+    apt-get install wget -y && \
+    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
+    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
+    ar r /libAFL.a *.o

--- a/fuzzers/afl_deterministic/fuzzer.py
+++ b/fuzzers/afl_deterministic/fuzzer.py
@@ -13,12 +13,9 @@
 # limitations under the License.
 """Integration code for AFL fuzzer."""
 
-import shutil
 import subprocess
-import os
 
 from fuzzers.afl import fuzzer as afl_fuzzer
-from fuzzers import utils
 
 # OUT environment variable is the location of build directory (default is /out).
 
@@ -64,6 +61,6 @@ def run_afl_fuzz(input_corpus,
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run afl-fuzz on target."""
-    prepare_fuzz_environment(input_corpus)
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
 
     run_afl_fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_deterministic/fuzzer.py
+++ b/fuzzers/afl_deterministic/fuzzer.py
@@ -1,0 +1,69 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for AFL fuzzer."""
+
+import shutil
+import subprocess
+import os
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+from fuzzers import utils
+
+# OUT environment variable is the location of build directory (default is /out).
+
+
+def build():
+    """Build fuzzer."""
+    afl_fuzzer.build()
+
+
+def run_afl_fuzz(input_corpus,
+                 output_corpus,
+                 target_binary,
+                 additional_flags=None,
+                 hide_output=False):
+    """Run afl-fuzz."""
+    # Spawn the afl fuzzing process.
+    # FIXME: Currently AFL will exit if it encounters a crashing input in seed
+    # corpus (usually timeouts). Add a way to skip/delete such inputs and
+    # re-run AFL. This currently happens with a seed in wpantund benchmark.
+    print('[run_fuzzer] Running target with afl-fuzz')
+    command = [
+        './afl-fuzz',
+        '-i',
+        input_corpus,
+        '-o',
+        output_corpus,
+        # Use no memory limit as ASAN doesn't play nicely with one.
+        '-m',
+        'none'
+    ]
+    if additional_flags:
+        command.extend(additional_flags)
+    command += [
+        '--',
+        target_binary,
+        # Pass INT_MAX to afl the maximize the number of persistent loops it
+        # performs.
+        '2147483647'
+    ]
+    output_stream = subprocess.DEVNULL if hide_output else None
+    subprocess.call(command, stdout=output_stream, stderr=output_stream)
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run afl-fuzz on target."""
+    prepare_fuzz_environment(input_corpus)
+
+    run_afl_fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_deterministic/runner.Dockerfile
+++ b/fuzzers/afl_deterministic/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-runner

--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -112,7 +112,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
-    flags = ['-d']  # FidgetyAFL is better when running alone.
+    flags = []
     if os.path.exists(cmplog_target_binary):
         flags += ['-c', cmplog_target_binary]
     if 'ADDITIONAL_ARGS' in os.environ:

--- a/fuzzers/aflplusplus_mopt/fuzzer.py
+++ b/fuzzers/aflplusplus_mopt/fuzzer.py
@@ -37,10 +37,9 @@ def fuzz(input_corpus, output_corpus, target_binary):
                                         target_binary_name)
 
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
-    # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
-    flags = ['-L0']  # afl++ MOpt activation at once
-    flags += ['-pfast']  # fast scheduling
+    flags = ['-L0']  # afl++ MOpt activation at once.
+    flags += ['-pfast']  # Fast scheduling.
     if os.path.exists(cmplog_target_binary):
         flags += ['-c', cmplog_target_binary]
     if 'ADDITIONAL_ARGS' in os.environ:


### PR DESCRIPTION
Deterministic mode doesn't work well when we have no seeds, skip
it by default.

Also, fix some nits in aflplusplus_mopt/fuzzer.py