### PR TITLE
Remove dislocator from AFL++

### DIFF
--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -108,7 +108,9 @@ def fuzz(input_corpus, output_corpus, target_binary):
                                         target_binary_name)
 
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
-    os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+    # decomment this to enable libdislocator
+    # os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
     flags = []
     if os.path.exists(cmplog_target_binary):


### PR DESCRIPTION
One of the possible reasons of the decrement in performance of AFL++ in the lastest report is due to the missing AFL_ALIGNED_ALLOC env var. Without this variable, dislocator's malloc does not ensure that the returned address is aligned to max_aligned_t (as required by posix) but it is able, in this way, to catch more bugs.
Many applications check for this alignment and this may cause an early exit in the application (and so a low coverage).
I completely remove dislocator to better understand what is happening in the next run of the experiments.