### PR TITLE
Update honggfuzz (previous update performs badly under KVM).

### DIFF
--- a/fuzzers/honggfuzz/builder.Dockerfile
+++ b/fuzzers/honggfuzz/builder.Dockerfile
@@ -23,14 +23,14 @@ RUN apt-get update -y && \
     libblocksruntime-dev \
     liblzma-dev
 
-# Download honggfuz version 2.1 + 8c0808190bd10ae63b26853ca8ef29e5e17736fe
+# Download honggfuz version 2.1 + 5a40d002370fdb26aeb2156bd062bae697ce925f
 # Set CFLAGS use honggfuzz's defaults except for -mnative which can build CPU
 # dependent code that may not work on the machines we actually fuzz on.
 # Create an empty object file which will become the FUZZER_LIB lib (since
 # honggfuzz doesn't need this when hfuzz-clang(++) is used).
 RUN git clone https://github.com/google/honggfuzz.git /honggfuzz && \
     cd /honggfuzz && \
-    git checkout 8c0808190bd10ae63b26853ca8ef29e5e17736fe && \
+    git checkout 5a40d002370fdb26aeb2156bd062bae697ce925f && \
     CFLAGS="-O3 -funroll-loops" make && \
     touch empty_lib.c && \
     cc -c -o empty_lib.o empty_lib.c


### PR DESCRIPTION
Previous update https://github.com/google/fuzzbench/pull/140 performs
not-so-well under GCE/KVM, because of extensive bus locking (use of
atomics).

Sorry for so quick pace of updates, but I've just tested it under KVM.
On my desktop PC it performed well enough.