### PR TITLE
Add reference doc on benchmarks

### DIFF
--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -10,31 +10,33 @@ This page describes each benchmark that is part of fuzzbench.
 
 The table below was generated using benchmarks.py.
 
-| Benchmark                   | Fuzz target            | Has dictionary? | Number of seed inputs | Number of progam edges | Size (MB) |
-|:---------------------------:|:----------------------:|:---------------:|:---------------------:|:----------------------:|:---------:|
-| bloaty_fuzz_target          | fuzz_target            | False           | 94                    | 89530                  | 43.74     |
-| curl_curl_fuzzer_http       | curl_fuzzer_http       | False           | 31                    | 62523                  | 20.11     |
-| freetype2-2017              | fuzz-target            | False           | 2                     | 19056                  | 6.76      |
-| harfbuzz-1.3.2              | fuzz-target            | False           | 58                    | 10021                  | 6.24      |
-| irssi_server-fuzz           | server-fuzz            | True            | 895                   | 37455                  | 15.3      |
-| jsoncpp_jsoncpp_fuzzer      | jsoncpp_fuzzer         | True            | 0                     | 5536                   | 5.96      |
-| lcms-2017-03-21             | fuzz-target            | False           | 1                     | 6959                   | 6.11      |
-| libjpeg-turbo-07-2017       | fuzz-target            | False           | 1                     | 9586                   | 6.4       |
-| libpcap_fuzz_both           | fuzz_both              | False           | 0                     | 8149                   | 6.14      |
-| libpng-1.2.56               | fuzz-target            | False           | 1                     | 2991                   | 5.8       |
-| libxml2-v2.9.2              | fuzz-target            | False           | 0                     | 50461                  | 8.23      |
-| mbedtls_fuzz_dtlsclient     | fuzz_dtlsclient        | False           | 1                     | 10942                  | 6.67      |
-| openssl_x509                | x509                   | True            | 2241                  | 45989                  | 18.14     |
-| openthread-2019-12-23       | fuzz-target            | False           | 0                     | 17932                  | 6.72      |
-| php_php-fuzz-parser         | php-fuzz-parser        | True            | 2782                  | 123767                 | 15.57     |
-| proj4-2017-08-14            | fuzz-target            | False           | 44                    | 6156                   | 6.17      |
-| re2-2014-12-09              | fuzz-target            | False           | 0                     | 6547                   | 6.02      |
-| sqlite3_ossfuzz             | ossfuzz                | False           | 1258                  | 45136                  | 7.9       |
-| systemd_fuzz-link-parser    | fuzz-link-parser       | False           | 6                     | 53453                  | 5.91      |
-| vorbis-2017-12-11           | fuzz-target            | False           | 1                     | 5022                   | 6.0       |
-| woff2-2016-05-06            | fuzz-target            | False           | 62                    | 10923                  | 6.72      |
-| wpantund-2018-02-27         | fuzz-target            | False           | 8                     | 28888                  | 7.35      |
-| zlib_zlib_uncompress_fuzzer | zlib_uncompress_fuzzer | False           | 0                     | 875                    | 5.69      |
+| Benchmark                   | Fuzz target            | Has dictionary? | Number of seed inputs | Number of progam edges\* | Binary Size (MB)\*\* |
+|:---------------------------:|:----------------------:|:---------------:|:---------------------:|:------------------------:|:--------------------:|
+| bloaty_fuzz_target          | fuzz_target            | False           | 94                    | 89530                    | 43.74                |
+| curl_curl_fuzzer_http       | curl_fuzzer_http       | False           | 31                    | 62523                    | 20.11                |
+| freetype2-2017              | fuzz-target            | False           | 2                     | 19056                    | 6.76                 |
+| harfbuzz-1.3.2              | fuzz-target            | False           | 58                    | 10021                    | 6.24                 |
+| irssi_server-fuzz           | server-fuzz            | True            | 895                   | 37455                    | 15.3                 |
+| jsoncpp_jsoncpp_fuzzer      | jsoncpp_fuzzer         | True            | 0                     | 5536                     | 5.96                 |
+| lcms-2017-03-21             | fuzz-target            | False           | 1                     | 6959                     | 6.11                 |
+| libjpeg-turbo-07-2017       | fuzz-target            | False           | 1                     | 9586                     | 6.4                  |
+| libpcap_fuzz_both           | fuzz_both              | False           | 0                     | 8149                     | 6.14                 |
+| libpng-1.2.56               | fuzz-target            | False           | 1                     | 2991                     | 5.8                  |
+| libxml2-v2.9.2              | fuzz-target            | False           | 0                     | 50461                    | 8.23                 |
+| mbedtls_fuzz_dtlsclient     | fuzz_dtlsclient        | False           | 1                     | 10942                    | 6.67                 |
+| openssl_x509                | x509                   | True            | 2241                  | 45989                    | 18.14                |
+| openthread-2019-12-23       | fuzz-target            | False           | 0                     | 17932                    | 6.72                 |
+| php_php-fuzz-parser         | php-fuzz-parser        | True            | 2782                  | 123767                   | 15.57                |
+| proj4-2017-08-14            | fuzz-target            | False           | 44                    | 6156                     | 6.17                 |
+| re2-2014-12-09              | fuzz-target            | False           | 0                     | 6547                     | 6.02                 |
+| sqlite3_ossfuzz             | ossfuzz                | False           | 1258                  | 45136                    | 7.9                  |
+| systemd_fuzz-link-parser    | fuzz-link-parser       | False           | 6                     | 53453                    | 5.91                 |
+| vorbis-2017-12-11           | fuzz-target            | False           | 1                     | 5022                     | 6.0                  |
+| woff2-2016-05-06            | fuzz-target            | False           | 62                    | 10923                    | 6.72                 |
+| wpantund-2018-02-27         | fuzz-target            | False           | 8                     | 28888                    | 7.35                 |
+| zlib_zlib_uncompress_fuzzer | zlib_uncompress_fuzzer | False           | 0                     | 875                      | 5.69                 |
 
-Size is determined by the size of the libFuzzer build of the target.
-Number of program edges is the number of "guards" in the libFuzzer build of the target.
+\*Number of program edges is the number of
+["guards"](https://clang.llvm.org/docs/SanitizerCoverage.html#id2) in the
+libFuzzer build of the target.
+\*\*Size is determined by the size of the libFuzzer build of the target.

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: Benchmarks
+nav_order: 4
+permalink: /reference/benchmarks/
+parent: Reference
+---
+
+This page describes each benchmark that is part of fuzzbench.
+
+The table below was generated using benchmarks.py.
+
+| Benchmark                   | Fuzz target            | Has dictionary? | Number of seed inputs | Number of progam edges | Size (MB) |
+|:---------------------------:|:----------------------:|:---------------:|:---------------------:|:----------------------:|:---------:|
+| bloaty_fuzz_target          | fuzz_target            | False           | 94                    | 89530                  | 43.74     |
+| curl_curl_fuzzer_http       | curl_fuzzer_http       | False           | 31                    | 62523                  | 20.11     |
+| freetype2-2017              | fuzz-target            | False           | 2                     | 19056                  | 6.76      |
+| harfbuzz-1.3.2              | fuzz-target            | False           | 58                    | 10021                  | 6.24      |
+| irssi_server-fuzz           | server-fuzz            | True            | 895                   | 37455                  | 15.3      |
+| jsoncpp_jsoncpp_fuzzer      | jsoncpp_fuzzer         | True            | 0                     | 5536                   | 5.96      |
+| lcms-2017-03-21             | fuzz-target            | False           | 1                     | 6959                   | 6.11      |
+| libjpeg-turbo-07-2017       | fuzz-target            | False           | 1                     | 9586                   | 6.4       |
+| libpcap_fuzz_both           | fuzz_both              | False           | 0                     | 8149                   | 6.14      |
+| libpng-1.2.56               | fuzz-target            | False           | 1                     | 2991                   | 5.8       |
+| libxml2-v2.9.2              | fuzz-target            | False           | 0                     | 50461                  | 8.23      |
+| mbedtls_fuzz_dtlsclient     | fuzz_dtlsclient        | False           | 1                     | 10942                  | 6.67      |
+| openssl_x509                | x509                   | True            | 2241                  | 45989                  | 18.14     |
+| openthread-2019-12-23       | fuzz-target            | False           | 0                     | 17932                  | 6.72      |
+| php_php-fuzz-parser         | php-fuzz-parser        | True            | 2782                  | 123767                 | 15.57     |
+| proj4-2017-08-14            | fuzz-target            | False           | 44                    | 6156                   | 6.17      |
+| re2-2014-12-09              | fuzz-target            | False           | 0                     | 6547                   | 6.02      |
+| sqlite3_ossfuzz             | ossfuzz                | False           | 1258                  | 45136                  | 7.9       |
+| systemd_fuzz-link-parser    | fuzz-link-parser       | False           | 6                     | 53453                  | 5.91      |
+| vorbis-2017-12-11           | fuzz-target            | False           | 1                     | 5022                   | 6.0       |
+| woff2-2016-05-06            | fuzz-target            | False           | 62                    | 10923                  | 6.72      |
+| wpantund-2018-02-27         | fuzz-target            | False           | 8                     | 28888                  | 7.35      |
+| zlib_zlib_uncompress_fuzzer | zlib_uncompress_fuzzer | False           | 0                     | 875                    | 5.69      |
+
+Size is determined by the size of the libFuzzer build of the target.
+Number of program edges is the number of "guards" in the libFuzzer build of the target.

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -29,7 +29,7 @@ The table below was generated using benchmarks.py.
 | php_php-fuzz-parser         | php-fuzz-parser        | True            | 2782                  | 123767                   | 15.57                |
 | proj4-2017-08-14            | fuzz-target            | False           | 44                    | 6156                     | 6.17                 |
 | re2-2014-12-09              | fuzz-target            | False           | 0                     | 6547                     | 6.02                 |
-| sqlite3_ossfuzz             | ossfuzz                | False           | 1258                  | 45136                    | 7.9                  |
+| sqlite3_ossfuzz             | ossfuzz                | True            | 1258                  | 45136                    | 7.9                  |
 | systemd_fuzz-link-parser    | fuzz-link-parser       | False           | 6                     | 53453                    | 5.91                 |
 | vorbis-2017-12-11           | fuzz-target            | False           | 1                     | 5022                     | 6.0                  |
 | woff2-2016-05-06            | fuzz-target            | False           | 62                    | 10923                    | 6.72                 |

--- a/docs/reference/benchmarks.py
+++ b/docs/reference/benchmarks.py
@@ -94,7 +94,7 @@ def count_oss_fuzz_seeds(fuzz_target_path):
 
 def count_standard_seeds(seeds_dir):
     """Count the number of seeds for a standard benchmark."""
-    len([p for p in Path(seeds_dir).glob('**/*') if p.is_file()])
+    return len([p for p in Path(seeds_dir).glob('**/*') if p.is_file()])
 
 
 def get_seed_count(benchmark_path, fuzz_target_path):

--- a/docs/reference/benchmarks.py
+++ b/docs/reference/benchmarks.py
@@ -1,0 +1,145 @@
+import collections
+import multiprocessing
+import os
+import re
+import subprocess
+import stat
+import sys
+import tarfile
+import zipfile
+
+from common import benchmark_utils
+from common import fuzzer_utils
+from common import utils
+from common import oss_fuzz
+
+
+BUILD_ARCHIVE_EXTENSION = '.tar.gz'
+ALLOWED_FUZZ_TARGET_EXTENSIONS = ['', '.exe']
+FUZZ_TARGET_SEARCH_STRING = 'LLVMFuzzerTestOneInput'
+GUARDS_REGEX = re.compile('INFO:.*\((?P<num_guards>\d+) guards\).*')
+ONE_MB = 1024**2
+
+
+def get_benchmark_infos(builds_dir):
+    build_paths = [
+        os.path.join(builds_dir, path)
+        for path in os.listdir(builds_dir)
+        if path.endswith(BUILD_ARCHIVE_EXTENSION)
+    ]
+    pool = multiprocessing.Pool()
+    return pool.map(get_benchmark_info, build_paths)
+
+
+benchmark_info_fields = ['benchmark', 'target', 'dict', 'seeds', 'guards', 'MB']
+BenchmarkInfo = collections.namedtuple(
+    'BenchmarkInfo', benchmark_info_fields)
+
+
+COVERAGE_BUILD_PREFIX = 'coverage-build-'
+
+
+def get_real_benchmark_name(benchmark):
+    """The method we use to infer benchmark names from coverage builds
+    doesn't quite work because the project name is used in OSS-Fuzz
+    builds instead. This function figures out the actual benchmark based on
+    the project name."""
+    benchmarks_dir = os.path.join(utils.ROOT_DIR, 'benchmarks')
+    real_benchmarks = [
+        real_benchmark
+        for real_benchmark in os.listdir(benchmarks_dir)
+        if os.path.isdir(os.path.join(benchmarks_dir, real_benchmark))
+    ]
+    if benchmark in real_benchmarks:
+        return benchmark
+    for real_benchmark in real_benchmarks:
+        if not benchmark_utils.is_oss_fuzz(real_benchmark):
+            continue
+        config = oss_fuzz.get_config(real_benchmark)
+        if config['project'] == benchmark:
+            return real_benchmark
+    return None
+
+def count_oss_fuzz_seeds(fuzz_target_path):
+    zip_file_name = fuzz_target_path + '_seed_corpus.zip'
+    if not os.path.exists(zip_file_name):
+        return 0
+    seeds = 0
+    with zipfile.ZipFile(zip_file_name) as zip_file:
+        for info in zip_file.infolist():
+            if info.filename.endswith('/'):
+                continue
+            seeds += 1
+    return seeds
+
+
+def get_benchmark_info(build_path):
+    parent_dir = os.path.dirname(build_path)
+    basename = os.path.basename(build_path)
+
+    benchmark = basename[len(COVERAGE_BUILD_PREFIX):-len(BUILD_ARCHIVE_EXTENSION)]
+    benchmark = get_real_benchmark_name(benchmark)
+    benchmark_path = os.path.join(parent_dir, benchmark)
+
+    try:
+        os.mkdir(benchmark_path)
+    except FileExistsError:
+        pass # !!!
+
+    with tarfile.open(build_path) as tar_file:
+        tar_file.extractall(benchmark_path)
+
+    if benchmark_utils.is_oss_fuzz(benchmark):
+        fuzz_target = oss_fuzz.get_config(benchmark)['fuzz_target']
+    else:
+        fuzz_target = fuzzer_utils.DEFAULT_FUZZ_TARGET_NAME
+
+    fuzz_target_path = fuzzer_utils.get_fuzz_target_binary(
+        benchmark_path, fuzz_target)
+    assert fuzz_target_path, benchmark
+
+    has_dictionary = os.path.exists(fuzz_target_path + '.dict')
+
+    seeds = 0
+    standard_seeds_path = os.path.join(benchmark_path, 'seeds')
+    if os.path.exists(standard_seeds_path):
+        for _, _, files in os.walk(standard_seeds_path):
+            seeds += len(files)
+    else:
+        seeds = count_oss_fuzz_seeds(fuzz_target_path)
+
+    result = subprocess.run([fuzz_target_path, '-runs=0'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    output = result.stdout.decode()
+    search = GUARDS_REGEX.search(output)
+    assert search, benchmark
+    num_guards = int(search.groupdict()['num_guards'])
+
+    size = os.path.getsize(fuzz_target_path)
+    size = round(size / ONE_MB, 2)
+    return BenchmarkInfo(
+        benchmark, fuzz_target, has_dictionary, seeds, num_guards, size)
+
+
+def infos_to_markdown_table(benchmark_infos):
+    md = ''
+    for benchmark_info in sorted(benchmark_infos, key=lambda info: info.benchmark):
+        md += '|{}|{}|{}|{}|{}|{}|\n'.format(*benchmark_info)
+    return md
+
+
+
+def main():
+    if len(sys.argv) != 2:
+           print('Usage {} <coverage_builds_directory>'.format(sys.argv[0]))
+           return 1
+    coverage_builds_dir = sys.argv[1]
+    infos = get_benchmark_infos(coverage_builds_dir)
+    print(infos_to_markdown_table(infos))
+    print(benchmark_info_fields)
+    return 0
+
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/docs/reference/benchmarks.py
+++ b/docs/reference/benchmarks.py
@@ -1,9 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Code for generating the table in benchmarks.md."""
+
 import collections
 import multiprocessing
 import os
 import re
 import subprocess
-import stat
 import sys
 import tarfile
 import zipfile
@@ -13,15 +27,22 @@ from common import fuzzer_utils
 from common import utils
 from common import oss_fuzz
 
-
 BUILD_ARCHIVE_EXTENSION = '.tar.gz'
-ALLOWED_FUZZ_TARGET_EXTENSIONS = ['', '.exe']
-FUZZ_TARGET_SEARCH_STRING = 'LLVMFuzzerTestOneInput'
-GUARDS_REGEX = re.compile('INFO:.*\((?P<num_guards>\d+) guards\).*')
+LEN_BUILD_ARCHIVE_EXTENSION = len(BUILD_ARCHIVE_EXTENSION)
+COVERAGE_BUILD_PREFIX = 'coverage-build-'
+LEN_COVERAGE_BUILD_PREFIX = len(BUILD_ARCHIVE_EXTENSION)
+
+GUARDS_REGEX = re.compile(r'INFO:.*\((?P<num_guards>\d+) guards\).*')
+
 ONE_MB = 1024**2
+
+BENCHMARK_INFO_FIELDS = ['benchmark', 'target', 'dict', 'seeds', 'guards', 'MB']
+BenchmarkInfo = collections.namedtuple('BenchmarkInfo', BENCHMARK_INFO_FIELDS)
 
 
 def get_benchmark_infos(builds_dir):
+    """Get BenchmarkInfo for each benchmark that has a build in
+    builds_dir."""
     build_paths = [
         os.path.join(builds_dir, path)
         for path in os.listdir(builds_dir)
@@ -31,14 +52,6 @@ def get_benchmark_infos(builds_dir):
     return pool.map(get_benchmark_info, build_paths)
 
 
-benchmark_info_fields = ['benchmark', 'target', 'dict', 'seeds', 'guards', 'MB']
-BenchmarkInfo = collections.namedtuple(
-    'BenchmarkInfo', benchmark_info_fields)
-
-
-COVERAGE_BUILD_PREFIX = 'coverage-build-'
-
-
 def get_real_benchmark_name(benchmark):
     """The method we use to infer benchmark names from coverage builds
     doesn't quite work because the project name is used in OSS-Fuzz
@@ -46,8 +59,7 @@ def get_real_benchmark_name(benchmark):
     the project name."""
     benchmarks_dir = os.path.join(utils.ROOT_DIR, 'benchmarks')
     real_benchmarks = [
-        real_benchmark
-        for real_benchmark in os.listdir(benchmarks_dir)
+        real_benchmark for real_benchmark in os.listdir(benchmarks_dir)
         if os.path.isdir(os.path.join(benchmarks_dir, real_benchmark))
     ]
     if benchmark in real_benchmarks:
@@ -60,7 +72,10 @@ def get_real_benchmark_name(benchmark):
             return real_benchmark
     return None
 
+
 def count_oss_fuzz_seeds(fuzz_target_path):
+    """Count the number of seeds in the OSS-Fuzz seed archive for
+    |fuzze_target_path|."""
     zip_file_name = fuzz_target_path + '_seed_corpus.zip'
     if not os.path.exists(zip_file_name):
         return 0
@@ -73,18 +88,36 @@ def count_oss_fuzz_seeds(fuzz_target_path):
     return seeds
 
 
-def get_benchmark_info(build_path):
-    parent_dir = os.path.dirname(build_path)
-    basename = os.path.basename(build_path)
+def count_standard_seeds(seeds_path):
+    """Count the number of seeds for a standard benchmark."""
+    seeds = 0
+    for _, _, files in os.walk(seeds_path):
+        seeds += len(files)
+    return seeds
 
-    benchmark = basename[len(COVERAGE_BUILD_PREFIX):-len(BUILD_ARCHIVE_EXTENSION)]
+
+def get_seed_count(benchmark_path, fuzz_target_path):
+    """Count the number of seeds for a benchmark."""
+    standard_seeds_path = os.path.join(benchmark_path, 'seeds')
+    if os.path.exists(standard_seeds_path):
+        count_standard_seeds(standard_seeds_path)
+    else:
+        seeds = count_oss_fuzz_seeds(fuzz_target_path)
+    return seeds
+
+
+def get_benchmark_info(build_path):
+    """Get BenchmarkInfo for the benchmark in |build_path|."""
+    basename = os.path.basename(build_path)
+    benchmark = basename[LEN_COVERAGE_BUILD_PREFIX:-LEN_BUILD_ARCHIVE_EXTENSION]
     benchmark = get_real_benchmark_name(benchmark)
+    parent_dir = os.path.dirname(build_path)
     benchmark_path = os.path.join(parent_dir, benchmark)
 
     try:
         os.mkdir(benchmark_path)
     except FileExistsError:
-        pass # !!!
+        pass  # So that function is idempotent.
 
     with tarfile.open(build_path) as tar_file:
         tar_file.extractall(benchmark_path)
@@ -100,15 +133,12 @@ def get_benchmark_info(build_path):
 
     has_dictionary = os.path.exists(fuzz_target_path + '.dict')
 
-    seeds = 0
-    standard_seeds_path = os.path.join(benchmark_path, 'seeds')
-    if os.path.exists(standard_seeds_path):
-        for _, _, files in os.walk(standard_seeds_path):
-            seeds += len(files)
-    else:
-        seeds = count_oss_fuzz_seeds(fuzz_target_path)
+    seeds = get_seed_count(benchmark_path, fuzz_target_path)
 
-    result = subprocess.run([fuzz_target_path, '-runs=0'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    result = subprocess.run([fuzz_target_path, '-runs=0'],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                            check=True)
 
     output = result.stdout.decode()
     search = GUARDS_REGEX.search(output)
@@ -117,28 +147,31 @@ def get_benchmark_info(build_path):
 
     size = os.path.getsize(fuzz_target_path)
     size = round(size / ONE_MB, 2)
-    return BenchmarkInfo(
-        benchmark, fuzz_target, has_dictionary, seeds, num_guards, size)
+    return BenchmarkInfo(benchmark, fuzz_target, has_dictionary, seeds,
+                         num_guards, size)
 
 
 def infos_to_markdown_table(benchmark_infos):
-    md = ''
-    for benchmark_info in sorted(benchmark_infos, key=lambda info: info.benchmark):
-        md += '|{}|{}|{}|{}|{}|{}|\n'.format(*benchmark_info)
-    return md
-
+    """Conver a list of BenchmarkInfos into a markdown table and
+    return the result."""
+    markdown = ''
+    for benchmark_info in sorted(benchmark_infos,
+                                 key=lambda info: info.benchmark):
+        markdown += '|{}|{}|{}|{}|{}|{}|\n'.format(*benchmark_info)
+    return markdown
 
 
 def main():
+    """Print a markdown table with important data on each
+    benchmark."""
     if len(sys.argv) != 2:
-           print('Usage {} <coverage_builds_directory>'.format(sys.argv[0]))
-           return 1
+        print('Usage {} <coverage_builds_directory>'.format(sys.argv[0]))
+        return 1
     coverage_builds_dir = sys.argv[1]
     infos = get_benchmark_infos(coverage_builds_dir)
     print(infos_to_markdown_table(infos))
-    print(benchmark_info_fields)
+    print(BENCHMARK_INFO_FIELDS)
     return 0
-
 
 
 if __name__ == '__main__':

--- a/docs/reference/benchmarks.py
+++ b/docs/reference/benchmarks.py
@@ -30,7 +30,7 @@ from common import oss_fuzz
 BUILD_ARCHIVE_EXTENSION = '.tar.gz'
 LEN_BUILD_ARCHIVE_EXTENSION = len(BUILD_ARCHIVE_EXTENSION)
 COVERAGE_BUILD_PREFIX = 'coverage-build-'
-LEN_COVERAGE_BUILD_PREFIX = len(BUILD_ARCHIVE_EXTENSION)
+LEN_COVERAGE_BUILD_PREFIX = len(COVERAGE_BUILD_PREFIX)
 
 GUARDS_REGEX = re.compile(r'INFO:.*\((?P<num_guards>\d+) guards\).*')
 
@@ -100,7 +100,7 @@ def get_seed_count(benchmark_path, fuzz_target_path):
     """Count the number of seeds for a benchmark."""
     standard_seeds_path = os.path.join(benchmark_path, 'seeds')
     if os.path.exists(standard_seeds_path):
-        count_standard_seeds(standard_seeds_path)
+        seeds = count_standard_seeds(standard_seeds_path)
     else:
         seeds = count_oss_fuzz_seeds(fuzz_target_path)
     return seeds

--- a/docs/reference/useful_links.md
+++ b/docs/reference/useful_links.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Useful links
-nav_order: 4
+nav_order: 5
 permalink: /reference/useful-links/
 parent: Reference
 ---


### PR DESCRIPTION
Add reference doc that has a table for each benchmark giving:
1. The name of the fuzz target.
2. Whether it has a dictionary.
3. The number of seed inputs
4. The number of program edges (when compiled with LLVM's instrumentation).
5. The size of the target (when linked against libFuzzer.