### PR TITLE
afl++ run option changes

### DIFF
--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -112,7 +112,9 @@ def fuzz(input_corpus, output_corpus, target_binary):
     # os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
     # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
-    flags = []
+    flags = ['-d'] # disable deterministic mutations.
+    flags += ['-pmmopt']  # modified MOpt scheduling.
+    flags += ['-s123']  # fixed random seed.
     if os.path.exists(cmplog_target_binary):
         flags += ['-c', cmplog_target_binary]
     if 'ADDITIONAL_ARGS' in os.environ:

--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -112,8 +112,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
     # os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
     # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
-    flags = ['-d'] # disable deterministic mutations.
-    flags += ['-pmmopt']  # modified MOpt scheduling.
+    flags = ['-pmmopt']  # modified MOpt scheduling.
     flags += ['-s123']  # fixed random seed.
     if os.path.exists(cmplog_target_binary):
         flags += ['-c', cmplog_target_binary]

--- a/fuzzers/aflplusplus_mopt/fuzzer.py
+++ b/fuzzers/aflplusplus_mopt/fuzzer.py
@@ -39,7 +39,8 @@ def fuzz(input_corpus, output_corpus, target_binary):
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
 
     flags = ['-L0']  # afl++ MOpt activation at once.
-    flags += ['-pfast']  # Fast scheduling.
+    flags += ['-prare']  # rare branch scheduling.
+    flags += ['-s666']  # fixed random seed.
     if os.path.exists(cmplog_target_binary):
         flags += ['-c', cmplog_target_binary]
     if 'ADDITIONAL_ARGS' in os.environ:


### PR DESCRIPTION
normal aflplusplus did not receive the -d option as compared to all other afl based fuzzer.
additionally the change modifies two things:
  - different schedules / seed selection algorithms to test them against the targets
  - fixed random seeds to compare the results in the future better against each other