### PR TITLE
Minor indexing fix.

### DIFF
--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -40,14 +40,14 @@ class ExperimentResults:
             self.name = experiment_name
         else:
             # Take name from first row.
-            self.name = experiment_df.experiment[0]
+            self.name = experiment_df.experiment.iloc[0]
 
         # FuzzBench repo commit hash.
         self.git_hash = None
         if 'git_hash' in experiment_df.columns:
             # Not possible to represent hashes for multiple experiments.
             if len(experiment_df.experiment.unique()) == 1:
-                self.git_hash = experiment_df.git_hash[0]
+                self.git_hash = experiment_df.git_hash.iloc[0]
 
         # Earliest trial start time.
         self.started = experiment_df.time_started.min()


### PR DESCRIPTION
Get the row in the first position, instead of the one with index label 0. This
is more efficient and more robust: if we do some post filtering, we might not
have an index label 0, but we always have a first position.