### PR TITLE
[honggfuzz]: version update

### DIFF
--- a/fuzzers/honggfuzz/builder.Dockerfile
+++ b/fuzzers/honggfuzz/builder.Dockerfile
@@ -23,14 +23,14 @@ RUN apt-get update -y && \
     libblocksruntime-dev \
     liblzma-dev
 
-# Download honggfuz version 2.1 + 4ff004700c3da264a2e8a867af1d97ed1d93ebd0
+# Download honggfuz version 2.1 + 7c34b297d365d1f9fbfc230db7504c8aca384608
 # Set CFLAGS use honggfuzz's defaults except for -mnative which can build CPU
 # dependent code that may not work on the machines we actually fuzz on.
 # Create an empty object file which will become the FUZZER_LIB lib (since
 # honggfuzz doesn't need this when hfuzz-clang(++) is used).
 RUN git clone https://github.com/google/honggfuzz.git /honggfuzz && \
     cd /honggfuzz && \
-    git checkout 4ff004700c3da264a2e8a867af1d97ed1d93ebd0 && \
+    git checkout 7c34b297d365d1f9fbfc230db7504c8aca384608 && \
     CFLAGS="-O3 -funroll-loops" make && \
     touch empty_lib.c && \
     cc -c -o empty_lib.o empty_lib.c


### PR DESCRIPTION
In
https://github.com/google/honggfuzz/commit/0f3001e5b5407ae094781406361182ae151afdde
I identified a problem which cause honggfuzz benchmarks to achieve lower
numbers of PC-guards in some tests (e.g. in jsoncpp_fuzzer). This was
b/c of arbitrary use of -fno-inline. The master branch now removed the problem,
and I'd like to test that on fuzzbench.

Fuzzbench is awesome! :)

PS: Any plans on running a new round of tests?