### PR TITLE
Add fuzzer variants to the repository and run them by default.

### DIFF
--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -200,8 +200,8 @@ def start_experiment(experiment_name: str, config_filename: str,
         with open(fuzzer_config, 'rb') as handle:
             hasher = hashlib.sha256(handle.read())
             basename = hasher.hexdigest() + '.yaml'
-            shutil.copy(
-                fuzzer_config, os.path.join(fuzzer_config_dir, basename))
+            shutil.copy(fuzzer_config, os.path.join(fuzzer_config_dir,
+                                                    basename))
     for fuzzer in fuzzers:
         if fuzzers.count(fuzzer) > 1:
             raise Exception('Fuzzer "%s" provided more than once.' % fuzzer)

--- a/fuzzers/afl/variants/default.yaml
+++ b/fuzzers/afl/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: afl

--- a/fuzzers/afl/variants/default.yaml
+++ b/fuzzers/afl/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: afl

--- a/fuzzers/aflfast/variants/default.yaml
+++ b/fuzzers/aflfast/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: aflfast

--- a/fuzzers/aflfast/variants/default.yaml
+++ b/fuzzers/aflfast/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: aflfast

--- a/fuzzers/aflplusplus/variants/default.yaml
+++ b/fuzzers/aflplusplus/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: aflplusplus

--- a/fuzzers/aflplusplus/variants/default.yaml
+++ b/fuzzers/aflplusplus/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: aflplusplus

--- a/fuzzers/aflplusplus_fortify/variants/default.yaml
+++ b/fuzzers/aflplusplus_fortify/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: aflplusplus_fortify

--- a/fuzzers/aflplusplus_fortify/variants/default.yaml
+++ b/fuzzers/aflplusplus_fortify/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: aflplusplus_fortify

--- a/fuzzers/aflplusplus_mopt/variants/default.yaml
+++ b/fuzzers/aflplusplus_mopt/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: aflplusplus_mopt

--- a/fuzzers/aflplusplus_mopt/variants/default.yaml
+++ b/fuzzers/aflplusplus_mopt/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: aflplusplus_mopt

--- a/fuzzers/aflplusplus_noalloc/variants/default.yaml
+++ b/fuzzers/aflplusplus_noalloc/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: aflplusplus_noalloc

--- a/fuzzers/aflplusplus_noalloc/variants/default.yaml
+++ b/fuzzers/aflplusplus_noalloc/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: aflplusplus_noalloc

--- a/fuzzers/aflsmart/variants/default.yaml
+++ b/fuzzers/aflsmart/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: aflsmart

--- a/fuzzers/aflsmart/variants/default.yaml
+++ b/fuzzers/aflsmart/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: aflsmart

--- a/fuzzers/eclipser/variants/default.yaml
+++ b/fuzzers/eclipser/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: eclipser

--- a/fuzzers/eclipser/variants/default.yaml
+++ b/fuzzers/eclipser/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: eclipser

--- a/fuzzers/entropic/variants/default.yaml
+++ b/fuzzers/entropic/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: entropic

--- a/fuzzers/entropic/variants/default.yaml
+++ b/fuzzers/entropic/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: entropic

--- a/fuzzers/fairfuzz/variants/default.yaml
+++ b/fuzzers/fairfuzz/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: fairfuzz

--- a/fuzzers/fairfuzz/variants/default.yaml
+++ b/fuzzers/fairfuzz/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: fairfuzz

--- a/fuzzers/fastcgs/variants/default.yaml
+++ b/fuzzers/fastcgs/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: fastcgs

--- a/fuzzers/fastcgs/variants/default.yaml
+++ b/fuzzers/fastcgs/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: fastcgs

--- a/fuzzers/honggfuzz/variants/default.yaml
+++ b/fuzzers/honggfuzz/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: honggfuzz

--- a/fuzzers/honggfuzz/variants/default.yaml
+++ b/fuzzers/honggfuzz/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: honggfuzz

--- a/fuzzers/lafintel/variants/default.yaml
+++ b/fuzzers/lafintel/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: lafintel

--- a/fuzzers/lafintel/variants/default.yaml
+++ b/fuzzers/lafintel/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: lafintel

--- a/fuzzers/libfuzzer/variants/default.yaml
+++ b/fuzzers/libfuzzer/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: libfuzzer

--- a/fuzzers/libfuzzer/variants/default.yaml
+++ b/fuzzers/libfuzzer/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: libfuzzer

--- a/fuzzers/mopt/variants/default.yaml
+++ b/fuzzers/mopt/variants/default.yaml
@@ -1,1 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 fuzzer: mopt

--- a/fuzzers/mopt/variants/default.yaml
+++ b/fuzzers/mopt/variants/default.yaml
@@ -1,0 +1,1 @@
+fuzzer: mopt


### PR DESCRIPTION
This is not quite ready to land since we'll likely want to finalize the design. Uploading it as-is for now though.

Some open questions (which I'll prepare a short doc to address):
1) Will the default configuration always just be "fuzzer: <fuzzer_name>"? If so, we can remove the default.yaml files entirely and auto-generate them. This is less work for fuzzer authors but less flexible.
2) Abhishek suggested possibly combining the variants into a single yaml file. I think this would be useful if we want to do things that involve multiple configurations at the same time (e.g. have some way to say take the cross product of these features), but think it might be overkill in simpler cases.