### PR TITLE
Only use Docker's cache-from when on a CI service.

### DIFF
--- a/.github/workflows/build.py
+++ b/.github/workflows/build.py
@@ -72,7 +72,7 @@ def make_builds(benchmarks, fuzzer):
 
         # Then build.
         print('Building', build_target)
-        build_command = ['make', '-j', build_target]
+        build_command = ['make', 'RUNNING_ON_CI=yes', '-j', build_target]
         result = subprocess.run(build_command, check=False)
         if not result.returncode == 0:
             return False

--- a/docker/build.mk
+++ b/docker/build.mk
@@ -22,11 +22,18 @@ BASE_TAG ?= gcr.io/fuzzbench
 build-all: $(addsuffix -all, $(addprefix build-,$(FUZZERS)))
 pull-all: $(addsuffix -all, $(addprefix pull-,$(FUZZERS)))
 
+# If we're running on a CI service, cache-from a remote image. Otherwise just
+# use the local cache.
+cache_from = $(if ${RUNNING_ON_CI},--cache-from $(1),)
+
+# For base-* images (and those that depend on it), use a remote cache by
+# default, unless the developer sets DISABLE_REMOTE_CACHE_FOR_BASE.
+cache_from_base = $(if ${DISABLE_REMOTE_CACHE_FOR_BASE},,--cache-from $(1))
 
 base-image:
 	docker build \
     --tag $(BASE_TAG)/base-image \
-    --cache-from $(BASE_TAG)/base-image \
+    $(call cache_from_base,${BASE_TAG}/base-image) \
     docker/base-image
 
 pull-base-image:
@@ -35,8 +42,8 @@ pull-base-image:
 base-builder: base-image
 	docker build \
     --tag $(BASE_TAG)/base-builder \
-    --cache-from $(BASE_TAG)/base-builder \
-    --cache-from gcr.io/oss-fuzz-base/base-clang \
+    $(call cache_from_base,${BASE_TAG}/base-builder) \
+    $(call cache_from_base,gcr.io/oss-fuzz-base/base-clang) \
     docker/base-builder
 
 pull-base-clang:
@@ -48,7 +55,7 @@ pull-base-builder: pull-base-image pull-base-clang
 base-runner: base-image
 	docker build \
     --tag $(BASE_TAG)/base-runner \
-    --cache-from $(BASE_TAG)/base-runner \
+    $(call cache_from_base,${BASE_TAG}/base-runner) \
     docker/base-runner
 
 
@@ -58,7 +65,7 @@ pull-base-runner: pull-base-image
 dispatcher-image: base-image
 	docker build \
     --tag $(BASE_TAG)/dispatcher-image \
-    --cache-from $(BASE_TAG)/dispatcher-image \
+    $(call cache_from,${BASE_TAG}/dispatcher-image) \
     docker/dispatcher-image
 
 
@@ -68,7 +75,7 @@ define fuzzer_template
 	docker build \
     --tag $(BASE_TAG)/builders/$(1) \
     --file fuzzers/$(1)/builder.Dockerfile \
-    --cache-from $(BASE_TAG)/builders/$(1) \
+    $(call cache_from,${BASE_TAG}/builders/$(1)) \
     fuzzers/$(1)
 
 .pull-$(1)-builder: pull-base-builder
@@ -89,7 +96,7 @@ define fuzzer_benchmark_template
     --tag $(BASE_TAG)/builders/$(1)/$(2) \
     --build-arg fuzzer=$(1) \
     --build-arg benchmark=$(2) \
-    --cache-from $(BASE_TAG)/builders/$(1)/$(2) \
+    $(call cache_from,${BASE_TAG}/builders/$(1)/$(2)) \
     --file docker/benchmark-builder/Dockerfile \
     .
 
@@ -102,7 +109,7 @@ ifneq ($(1), coverage)
 	docker build \
     --tag $(BASE_TAG)/runners/$(1)/$(2)-intermediate \
     --file fuzzers/$(1)/runner.Dockerfile \
-    --cache-from $(BASE_TAG)/runners/$(1)/$(2)-intermediate \
+    $(call cache_from,${BASE_TAG}/runners/$(1)/$(2)-intermediate) \
     fuzzers/$(1)
 
 .pull-$(1)-$(2)-intermediate-runner: pull-base-runner
@@ -113,7 +120,7 @@ ifneq ($(1), coverage)
     --tag $(BASE_TAG)/runners/$(1)/$(2) \
     --build-arg fuzzer=$(1) \
     --build-arg benchmark=$(2) \
-    --cache-from $(BASE_TAG)/runners/$(1)/$(2) \
+    $(call cache_from,${BASE_TAG}/runners/$(1)/$(2)) \
     --file docker/benchmark-runner/Dockerfile \
     .
 
@@ -183,7 +190,7 @@ define fuzzer_oss_fuzz_benchmark_template
     --tag $(BASE_TAG)/oss-fuzz/builders/$(1)/$($(2)-project-name)-intermediate \
     --file=fuzzers/$(1)/builder.Dockerfile \
     --build-arg parent_image=gcr.io/fuzzbench/oss-fuzz/$($(2)-project-name)@sha256:$($(2)-oss-fuzz-builder-hash) \
-    --cache-from $(BASE_TAG)/oss-fuzz/builders/$(1)/$($(2)-project-name)-intermediate \
+    $(call cache_from,${BASE_TAG}/oss-fuzz/builders/$(1)/$($(2)-project-name)-intermediate) \
     fuzzers/$(1)
 
 .pull-$(1)-$(2)-oss-fuzz-builder-intermediate:
@@ -195,7 +202,7 @@ define fuzzer_oss_fuzz_benchmark_template
     --file=docker/oss-fuzz-builder/Dockerfile \
     --build-arg parent_image=$(BASE_TAG)/oss-fuzz/builders/$(1)/$($(2)-project-name)-intermediate \
     --build-arg fuzzer=$(1) \
-    --cache-from $(BASE_TAG)/oss-fuzz/builders/$(1)/$($(2)-project-name) \
+    $(call cache_from,${BASE_TAG}/oss-fuzz/builders/$(1)/$($(2)-project-name)) \
     .
 
 .pull-$(1)-$(2)-oss-fuzz-builder: .pull-$(1)-$(2)-oss-fuzz-builder-intermediate
@@ -207,7 +214,7 @@ ifneq ($(1), coverage)
 	docker build \
     --tag $(BASE_TAG)/oss-fuzz/runners/$(1)/$($(2)-project-name)-intermediate \
     --file fuzzers/$(1)/runner.Dockerfile \
-    --cache-from $(BASE_TAG)/oss-fuzz/runners/$(1)/$($(2)-project-name)-intermediate \
+    $(call cache_from,${BASE_TAG}/oss-fuzz/runners/$(1)/$($(2)-project-name)-intermediate) \
     fuzzers/$(1)
 
 .pull-$(1)-$(2)-oss-fuzz-intermediate-runner: pull-base-runner
@@ -218,7 +225,7 @@ ifneq ($(1), coverage)
     --tag $(BASE_TAG)/oss-fuzz/runners/$(1)/$($(2)-project-name) \
     --build-arg fuzzer=$(1) \
     --build-arg oss_fuzz_project=$($(2)-project-name) \
-    --cache-from $(BASE_TAG)/oss-fuzz/runners/$(1)/$($(2)-project-name) \
+    $(call cache_from,${BASE_TAG}/oss-fuzz/runners/$(1)/$($(2)-project-name)) \
     --file docker/oss-fuzz-runner/Dockerfile \
     .
 


### PR DESCRIPTION
This speeds up local caching when developing new fuzzers.

@lszekeres 

This change dynamically sets the `--cache-from` option only if the `GITHUB_RUN_ID` is present in the environment variables - which is for by [default](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables) for GitHub Workflows (the CI we use).

To understand when this is useful, consider a failing `./configure` script, which we can simulate with a bad command.

## Simulating the Problem

Add a failing command to AFL's `builder.Dockerfile`:

`RUN ln asdf` - insert after AFL has been built (after line 24) so that AFL's `builder.Dockerfile` looks like:

```dockerfile
ARG parent_image=gcr.io/fuzzbench/base-builder
FROM $parent_image

# Download and compile AFL v2.56b.
# Set AFL_NO_X86 to skip flaky tests.
RUN git clone https://github.com/google/AFL.git /afl && \
    cd /afl && \
    git checkout 8da80951dd7eeeb3e3b5a3bcd36c485045f40274 && \
    AFL_NO_X86=1 make

RUN ln asdf

# Use afl_driver.cpp from LLVM as our fuzzing library.
RUN apt-get update && \
    apt-get install wget -y && \
    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
    clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
    ar r /libAFL.a *.o
```

Then run `make build-afl-libpng-1.2.56` twice in the `master` branch and noticed how AFL is cloned down and built each time.

## Testing the Fix

In this branch, intermediate layers are cached before the final tagging takes place and running `make build-afl-libpng-1.2.56` twice will only run commands before the failing command once. This is particularly useful when adding fuzzers with complex dependencies (KLEE for example).