### PR TITLE
Add support for fuzzer variants specified by variants.yaml files.

### DIFF
--- a/common/fuzzer_utils.py
+++ b/common/fuzzer_utils.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 from common import logs
 from common import utils
+from common import yaml_utils
 
 DEFAULT_FUZZ_TARGET_NAME = 'fuzz-target'
 FUZZ_TARGET_SEARCH_STRING = b'LLVMFuzzerTestOneInput'
@@ -77,11 +78,32 @@ def validate(fuzzer):
         return False
 
 
-def get_all_fuzzers():
+def get_fuzzer_configs(fuzzers=None):
     """Returns the list of all fuzzers."""
     fuzzers_dir = os.path.join(utils.ROOT_DIR, 'fuzzers')
-    return [
-        fuzzer for fuzzer in os.listdir(fuzzers_dir)
-        if (os.path.isfile(os.path.join(fuzzers_dir, fuzzer, 'fuzzer.py')) and
-            fuzzer != 'coverage')
-    ]
+    fuzzer_configs = []
+    for fuzzer in os.listdir(fuzzers_dir):
+        if not os.path.isfile(os.path.join(fuzzers_dir, fuzzer, 'fuzzer.py')):
+            continue
+        if fuzzer == 'coverage':
+            continue
+
+        if not fuzzers or fuzzer in fuzzers:
+            # Auto-generate the default configuration for each base fuzzer.
+            fuzzer_configs.append({'fuzzer': fuzzer})
+
+        variant_config_path = os.path.join(fuzzers_dir, fuzzer, 'variants.yaml')
+        if not os.path.isfile(variant_config_path):
+            continue
+
+        variant_config = yaml_utils.read(variant_config_path)
+        for variant in variant_config['variants']:
+            if not fuzzers or variant['name'] in fuzzers:
+                # Modify the config from the variants.yaml format to the
+                # format expected by a fuzzer config.
+                variant['variant_name'] = variant['name']
+                del variant['name']
+                variant['fuzzer'] = fuzzer
+                fuzzer_configs.append(variant)
+
+    return fuzzer_configs

--- a/common/fuzzer_utils.py
+++ b/common/fuzzer_utils.py
@@ -97,10 +97,15 @@ def get_fuzzer_configs(fuzzers=None):
             continue
 
         variant_config = yaml_utils.read(variant_config_path)
+        assert 'variants' in variant_config, (
+            'Missing "variants" section of {}'.format(variant_config_path))
         for variant in variant_config['variants']:
             if not fuzzers or variant['name'] in fuzzers:
                 # Modify the config from the variants.yaml format to the
                 # format expected by a fuzzer config.
+                assert 'name' in variant, (
+                    'Missing name attribute for fuzzer variant in {}'.format(
+                        variant_config_path))
                 variant['variant_name'] = variant['name']
                 del variant['name']
                 variant['fuzzer'] = fuzzer

--- a/common/yaml_utils.py
+++ b/common/yaml_utils.py
@@ -23,3 +23,9 @@ def read(yaml_filename):
 
     with open(yaml_filename) as file_handle:
         return yaml.load(file_handle, yaml.SafeLoader)
+
+
+def write(yaml_filename, data):
+    """Writes data to a new yaml file at |yaml_filename|."""
+    with open(yaml_filename, 'w') as file_handle:
+        return yaml.dump(data, file_handle)

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -19,7 +19,6 @@ import argparse
 import multiprocessing
 import os
 import re
-import shutil
 import subprocess
 import sys
 from typing import Dict, List

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -126,17 +126,18 @@ def validate_fuzzer(fuzzer: str):
         raise Exception('Fuzzer "%s" does not exist.' % fuzzer)
 
 
-def validate_fuzzer_config(fuzzer_config_name: str):
-    """Validate |fuzzer_config_name|."""
+def validate_fuzzer_config(fuzzer_config):
+    """Validate |fuzzer_config|."""
     allowed_fields = ['variant_name', 'env', 'fuzzer']
-    fuzzer_config = yaml_utils.read(fuzzer_config_name)
     if 'fuzzer' not in fuzzer_config:
         raise Exception('Fuzzer configuration must include the "fuzzer" field.')
 
     for key in fuzzer_config:
         if key not in allowed_fields:
-            raise Exception('Invalid entry "%s" in fuzzer configuration "%s"' %
-                            (key, fuzzer_config_name))
+            raise Exception('Invalid entry "%s" in fuzzer configuration.' % key)
+
+    if 'env' in fuzzer_config and not isinstance(fuzzer_config['env'], list):
+        raise Exception('Fuzzer environment must be a list.')
 
     variant_name = fuzzer_config.get('variant_name')
     if variant_name:
@@ -180,34 +181,31 @@ def get_git_hash():
     return output.strip().decode('utf-8')
 
 
-def set_up_fuzzer_config_files(fuzzers, fuzzer_configs):
-    """Set up config files for each fuzzer in |fuzzers| and each
-    config file provided in |fuzzer_configs|."""
-    if not fuzzers and not fuzzer_configs:
+def get_full_fuzzer_name(fuzzer_config):
+    """Get the full fuzzer name in the form <base fuzzer>_<variant name>."""
+    if 'variant_name' not in fuzzer_config:
+        return fuzzer_config['fuzzer']
+    return fuzzer_config['fuzzer'] + '_' + fuzzer_config['variant_name']
+
+
+def set_up_fuzzer_config_files(fuzzer_configs):
+    """Write configurations specified by |fuzzer_configs| to yaml files that
+    will be used to store configurations."""
+    if not fuzzer_configs:
         raise Exception('Need to provide either a list of fuzzers or '
                         'a list of fuzzer configs.')
     fuzzer_config_dir = os.path.join(CONFIG_DIR, 'fuzzer-configs')
     filesystem.recreate_directory(fuzzer_config_dir)
     for fuzzer_config in fuzzer_configs:
-        if fuzzer_configs.count(fuzzer_config) > 1:
-            raise Exception('Fuzzer config "%s" provided more than once.' %
-                            fuzzer_config)
         # Validate the fuzzer yaml attributes e.g. fuzzer, env, etc.
         validate_fuzzer_config(fuzzer_config)
-        shutil.copy(fuzzer_config, fuzzer_config_dir)
-    for fuzzer in fuzzers:
-        if fuzzers.count(fuzzer) > 1:
-            raise Exception('Fuzzer "%s" provided more than once.' % fuzzer)
-        validate_fuzzer(fuzzer)
-        fuzzer_config_file_path = os.path.join(fuzzer_config_dir, fuzzer)
-        # Create a simple yaml with just the fuzzer attribute.
-        with open(fuzzer_config_file_path, 'w') as file_handle:
-            file_handle.write('fuzzer: ' + fuzzer)
+        config_file_name = os.path.join(fuzzer_config_dir,
+                                        get_full_fuzzer_name(fuzzer_config))
+        yaml_utils.write(config_file_name, fuzzer_config)
 
 
 def start_experiment(experiment_name: str, config_filename: str,
-                     benchmarks: List[str], fuzzers: List[str],
-                     fuzzer_configs: List[str]):
+                     benchmarks: List[str], fuzzer_configs: List[dict]):
     """Start a fuzzer benchmarking experiment."""
     check_no_local_changes()
 
@@ -220,7 +218,7 @@ def start_experiment(experiment_name: str, config_filename: str,
     config['git_hash'] = get_git_hash()
 
     set_up_experiment_config_file(config)
-    set_up_fuzzer_config_files(fuzzers, fuzzer_configs)
+    set_up_fuzzer_config_files(fuzzer_configs)
 
     # Make sure we can connect to database.
     local_experiment = config.get('local_experiment', False)
@@ -477,13 +475,16 @@ def main():
                         default=[])
     args = parser.parse_args()
 
-    if not args.fuzzers and not args.fuzzer_configs:
-        fuzzers = fuzzer_utils.get_all_fuzzers()
+    if not args.fuzzer_configs:
+        fuzzer_configs = fuzzer_utils.get_fuzzer_configs(fuzzers=args.fuzzers)
     else:
-        fuzzers = args.fuzzers
+        fuzzer_configs = [
+            yaml_utils.read(fuzzer_config)
+            for fuzzer_config in args.fuzzer_configs
+        ]
 
     start_experiment(args.experiment_name, args.experiment_config,
-                     args.benchmarks, fuzzers, args.fuzzer_configs)
+                     args.benchmarks, fuzzer_configs)
     if not os.getenv('MANUAL_EXPERIMENT'):
         stop_experiment.stop_experiment(args.experiment_name,
                                         args.experiment_config)

--- a/experiment/test_run_experiment.py
+++ b/experiment/test_run_experiment.py
@@ -134,31 +134,33 @@ class TestReadAndValdiateExperimentConfig(unittest.TestCase):
                     read_and_validate_experiment_config('config_file'))
 
 
-@mock.patch('common.yaml_utils.read')
-def test_validate_fuzzer_config(mock_read):
+def test_validate_fuzzer_config():
     """Tests that validate_fuzzer_config says that a valid fuzzer config name is
     valid and that an invalid one is not."""
-    mock_read.return_value = {
-        'fuzzer': 'afl',
-        'variant_name': 'name',
-        'env': []
-    }
-    run_experiment.validate_fuzzer_config('test_fuzzer.yaml')
+    config = {'fuzzer': 'afl', 'variant_name': 'name', 'env': []}
+    run_experiment.validate_fuzzer_config(config)
 
     with pytest.raises(Exception) as exception:
-        mock_read.return_value['fuzzer'] = 'afl:'
-        run_experiment.validate_fuzzer_config('test_fuzzer.yaml')
+        config['fuzzer'] = 'afl:'
+        run_experiment.validate_fuzzer_config(config)
     assert 'may only contain' in str(exception.value)
 
     with pytest.raises(Exception) as exception:
-        mock_read.return_value['fuzzer'] = 'not_exist'
-        run_experiment.validate_fuzzer_config('test_fuzzer.yaml')
+        config['fuzzer'] = 'not_exist'
+        run_experiment.validate_fuzzer_config(config)
     assert 'does not exist' in str(exception.value)
+    config['fuzzer'] = 'afl'
 
     with pytest.raises(Exception) as exception:
-        mock_read.return_value['invalid_key'] = 'invalid'
-        run_experiment.validate_fuzzer_config('test_fuzzer.yaml')
+        config['invalid_key'] = 'invalid'
+        run_experiment.validate_fuzzer_config(config)
     assert 'Invalid entry' in str(exception.value)
+    del config['invalid_key']
+
+    with pytest.raises(Exception) as exception:
+        config['env'] = {'a': 'b'}
+        run_experiment.validate_fuzzer_config(config)
+    assert 'must be a list' in str(exception.value)
 
 
 def test_validate_fuzzer():

--- a/experiment/test_run_experiment.py
+++ b/experiment/test_run_experiment.py
@@ -19,6 +19,7 @@ import unittest
 
 import pytest
 
+from common import fuzzer_utils
 from experiment import run_experiment
 
 BENCHMARKS_DIR = os.path.abspath(
@@ -161,6 +162,13 @@ def test_validate_fuzzer_config():
         config['env'] = {'a': 'b'}
         run_experiment.validate_fuzzer_config(config)
     assert 'must be a list' in str(exception.value)
+
+
+def test_variant_configs_valid():
+    """Ensure that all variant configs (variants.yaml files) are valid."""
+    fuzzer_configs = fuzzer_utils.get_fuzzer_configs()
+    for config in fuzzer_configs:
+        run_experiment.validate_fuzzer_config(config)
 
 
 def test_validate_fuzzer():

--- a/service/run_experiment.py
+++ b/service/run_experiment.py
@@ -50,13 +50,10 @@ def run_diff_experiment():
 def run_full_experiment():
     """Run a full experiment."""
     experiment_name = get_experiment_name()
-    fuzzers = fuzzer_utils.get_all_fuzzers()
+    fuzzer_configs = fuzzer_utils.get_fuzzer_configs()
     benchmarks = benchmark_utils.get_all_benchmarks()
-    run_experiment.start_experiment(experiment_name,
-                                    EXPERIMENT_CONFIG_FILE,
-                                    benchmarks,
-                                    fuzzers,
-                                    fuzzer_configs=[])
+    run_experiment.start_experiment(experiment_name, EXPERIMENT_CONFIG_FILE,
+                                    benchmarks, fuzzer_configs)
 
 
 def main():


### PR DESCRIPTION
PTAL. This is a little bit different from what's currently proposed in the one-pager, but Jonathan and I discussed this yesterday and settled on this approach. I'll update the doc to reflect the current implementation soon.

I still plan to add a test to verify that all checked-in variants.yaml files are properly formatted. In the meantime, do either of you have ideas for places where we'd want to use this now? I'd like to check in at least one variants.yaml file with this change if I can so that there's an example handy. I'm testing it locally using value profile, but I don't think that's actually a configuration we want to maintain as a variant.