### PR TITLE
adds dictionaries for fuzzbench benchmarks

### DIFF
--- a/benchmarks/lcms-2017-03-21/build.sh
+++ b/benchmarks/lcms-2017-03-21/build.sh
@@ -26,3 +26,4 @@ build_lib
 
 $CXX $CXXFLAGS ${SCRIPT_DIR}/cms_transform_fuzzer.cc -I BUILD/include/ BUILD/src/.libs/liblcms2.a $FUZZER_LIB -o $FUZZ_TARGET
 cp -r $SCRIPT_DIR/seeds $OUT/
+wget -qO $FUZZ_TARGET.dict https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/icc.dict

--- a/benchmarks/libpng-1.2.56/build.sh
+++ b/benchmarks/libpng-1.2.56/build.sh
@@ -28,3 +28,4 @@ build_lib
 
 $CXX $CXXFLAGS -std=c++11 $SCRIPT_DIR/target.cc BUILD/.libs/libpng12.a $FUZZER_LIB -I BUILD/ -I BUILD -lz -o $FUZZ_TARGET
 cp -r $SCRIPT_DIR/seeds $OUT/
+wget -qO $FUZZ_TARGET.dict https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/png.dict

--- a/benchmarks/proj4-2017-08-14/build.sh
+++ b/benchmarks/proj4-2017-08-14/build.sh
@@ -30,3 +30,4 @@ if [[ ! -d $OUT/seeds ]]; then
 fi
 
 $CXX $CXXFLAGS -std=c++11 -I BUILD/src BUILD/test/fuzzers/standard_fuzzer.cpp BUILD/src/.libs/libproj.a $FUZZER_LIB -o $FUZZ_TARGET -lpthread
+wget -qO $FUZZ_TARGET.dict https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/proj4.dict

--- a/benchmarks/re2-2014-12-09/build.sh
+++ b/benchmarks/re2-2014-12-09/build.sh
@@ -27,3 +27,4 @@ get_git_revision https://github.com/google/re2.git 499ef7eff7455ce9c9fae86111d4a
 build_lib
 
 $CXX $CXXFLAGS ${SCRIPT_DIR}/target.cc  -I BUILD/ BUILD/obj/libre2.a -lpthread $FUZZER_LIB -o $FUZZ_TARGET
+wget -qO $FUZZ_TARGET.dict https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/regexp.dict


### PR DESCRIPTION
- adds icc.dict for lcms, which is used in OSS-FUZZ
- adds png.dict for libpng, originally available with AFL
- adds proj4.dict for proj4, created from the seed files
- adds regexp.dict for re2, this is the dictionary for JS regex, so
  it may not be tuned/efficient for perl regex.  (not tested)