### PR TITLE
Add new experiment level ranking method, tests, and cleanup.

### DIFF
--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -96,44 +96,58 @@ class ExperimentResults:
     @functools.lru_cache()
     def summary_table(self):
         """A pivot table of medians for each fuzzer on each benchmark."""
-        return data_utils.experiment_pivot_table(self._experiment_snapshots_df,
-                                                 data_utils.rank_by_median)
+        return data_utils.experiment_pivot_table(
+            self._experiment_snapshots_df, data_utils.benchmark_rank_by_median)
 
     @property
-    def rank_by_mean(self):
-        """Ranking across benchmarks (using mean based per-benchmark
-        ranking.)"""
-        pivot_table_of_means = data_utils.experiment_pivot_table(
-            self._experiment_snapshots_df, data_utils.rank_by_mean)
-        return data_utils.experiment_rank_by_average_rank(pivot_table_of_means)
+    def rank_by_average_rank_and_average_rank(self):
+        """Rank fuzzers using average rank per benchmark and average rank
+        across benchmarks."""
+        return data_utils.experiment_level_ranking(
+            self._experiment_snapshots_df,
+            data_utils.benchmark_rank_by_average_rank,
+            data_utils.experiment_rank_by_average_rank)
 
     @property
-    @functools.lru_cache()
-    def rank_by_median(self):
-        """Ranking across benchmarks (using median based per-benchmark
-        ranking.)"""
-        pivot_table_of_medians = data_utils.experiment_pivot_table(
-            self._experiment_snapshots_df, data_utils.rank_by_median)
-        return data_utils.experiment_rank_by_average_rank(
-            pivot_table_of_medians)
+    def rank_by_mean_and_average_rank(self):
+        """Rank fuzzers using mean coverage per benchmark and average rank
+        across benchmarks."""
+        return data_utils.experiment_level_ranking(
+            self._experiment_snapshots_df, data_utils.benchmark_rank_by_mean,
+            data_utils.experiment_rank_by_average_rank)
 
     @property
-    def rank_by_average_rank(self):
-        """Ranking across benchmarks (using rank average based per-benchmark
-        ranking.)"""
-        pivot_table_of_average_ranks = data_utils.experiment_pivot_table(
-            self._experiment_snapshots_df, data_utils.rank_by_average_rank)
-        return data_utils.experiment_rank_by_average_rank(
-            pivot_table_of_average_ranks)
+    def rank_by_median_and_average_rank(self):
+        """Rank fuzzers using median coverage per benchmark and average rank
+        across benchmarks."""
+        return data_utils.experiment_level_ranking(
+            self._experiment_snapshots_df, data_utils.benchmark_rank_by_median,
+            data_utils.experiment_rank_by_average_rank)
 
     @property
-    def rank_by_stat_test_wins(self):
-        """Ranking across benchmarks (using statistical test wins based per-
-        benchmark ranking.)"""
-        pivot_table_of_stat_test_wins = data_utils.experiment_pivot_table(
-            self._experiment_snapshots_df, data_utils.rank_by_average_rank)
-        return data_utils.experiment_rank_by_average_rank(
-            pivot_table_of_stat_test_wins)
+    def rank_by_median_and_average_normalized_score(self):
+        """Rank fuzzers using median coverage per benchmark and average
+        normalized score across benchmarks."""
+        return data_utils.experiment_level_ranking(
+            self._experiment_snapshots_df, data_utils.benchmark_rank_by_median,
+            data_utils.experiment_rank_by_average_normalized_score)
+
+    @property
+    def rank_by_median_and_number_of_firsts(self):
+        """Rank fuzzers using median coverage per benchmark and number of first
+        places across benchmarks."""
+        return data_utils.experiment_level_ranking(
+            self._experiment_snapshots_df, data_utils.benchmark_rank_by_median,
+            data_utils.experiment_rank_by_num_firsts)
+
+    @property
+    def rank_by_stat_test_wins_and_average_rank(self):
+        """Rank fuzzers using statistical test wins per benchmark and average
+        rank across benchmarks."""
+        return data_utils.experiment_level_ranking(
+            self._experiment_snapshots_df,
+            data_utils.benchmark_rank_by_stat_test_wins,
+            data_utils.experiment_rank_by_average_rank)
 
     @property
     def friedman_p_value(self):
@@ -173,7 +187,7 @@ class ExperimentResults:
         Represents average ranks of fuzzers across all benchmarks,
         considering medians on final coverage.
         """
-        average_ranks = self.rank_by_median
+        average_ranks = self.rank_by_median_and_average_rank
         num_of_benchmarks = self.summary_table.shape[0]
 
         plot_filename = 'experiment_critical_difference_plot.svg'

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -11,13 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions andsss
 # limitations under the License.
+
+# pylint: disable=missing-function-docstring
 """Tests for data_utils.py"""
 import pandas as pd
+import pandas.testing as pd_test
 
 from analysis import data_utils
 
 
-def label_fuzzers_by_experiment():
+def test_label_fuzzers_by_experiment():
     """Tests that label_fuzzers_by_experiment includes the experiment name in
     the fuzzer name"""
     input_df = pd.DataFrame({
@@ -30,3 +33,129 @@ def label_fuzzers_by_experiment():
         {'fuzzer': ['fuzzer-1-experiment-a', 'fuzzer-2-experiment-b']})
 
     assert (labeled_df['fuzzer'] == expected_fuzzers_df['fuzzer']).all()
+
+
+def create_trial_data(trial_id, benchmark, fuzzer, reached_coverage):
+    """Utility function to create test trial data."""
+    return pd.DataFrame([{
+        'experiment': 'test_experiment',
+        'benchmark': benchmark,
+        'fuzzer': fuzzer,
+        'trial_id': trial_id,
+        'time_started': 0,
+        'time_ended': 24,
+        'time': t,
+        'edges_covered': reached_coverage,
+    } for t in range(10)])
+
+
+def create_experiment_data():
+    """Utility function to create test experiment data."""
+    return pd.concat([
+        create_trial_data(0, 'libpng', 'afl', 100),
+        create_trial_data(1, 'libpng', 'afl', 200),
+        create_trial_data(2, 'libpng', 'libfuzzer', 200),
+        create_trial_data(3, 'libpng', 'libfuzzer', 300),
+        create_trial_data(4, 'libxml', 'afl', 1000),
+        create_trial_data(5, 'libxml', 'afl', 1200),
+        create_trial_data(6, 'libxml', 'libfuzzer', 600),
+        create_trial_data(7, 'libxml', 'libfuzzer', 800),
+    ])
+
+
+def test_benchmark_rank_by_mean():
+    experiment_df = create_experiment_data()
+    benchmark_df = experiment_df[experiment_df.benchmark == 'libxml']
+    snapshot_df = data_utils.get_benchmark_snapshot(benchmark_df)
+    ranking = data_utils.benchmark_rank_by_mean(snapshot_df)
+
+    expected_ranking = pd.Series(index=['afl', 'libfuzzer'], data=[1100, 700])
+    assert ranking.equals(expected_ranking)
+
+
+def test_benchmark_rank_by_median():
+    experiment_df = create_experiment_data()
+    benchmark_df = experiment_df[experiment_df.benchmark == 'libxml']
+    snapshot_df = data_utils.get_benchmark_snapshot(benchmark_df)
+    ranking = data_utils.benchmark_rank_by_median(snapshot_df)
+
+    expected_ranking = pd.Series(index=['afl', 'libfuzzer'], data=[1100, 700])
+    assert ranking.equals(expected_ranking)
+
+
+def test_benchmark_rank_by_average_rank():
+    experiment_df = create_experiment_data()
+    benchmark_df = experiment_df[experiment_df.benchmark == 'libxml']
+    snapshot_df = data_utils.get_benchmark_snapshot(benchmark_df)
+    ranking = data_utils.benchmark_rank_by_average_rank(snapshot_df)
+
+    expected_ranking = pd.Series(index=['afl', 'libfuzzer'], data=[3.5, 1.5])
+    assert ranking.equals(expected_ranking)
+
+
+def test_benchmark_rank_by_stat_test_wins():
+    experiment_df = create_experiment_data()
+    benchmark_df = experiment_df[experiment_df.benchmark == 'libxml']
+    snapshot_df = data_utils.get_benchmark_snapshot(benchmark_df)
+    ranking = data_utils.benchmark_rank_by_stat_test_wins(snapshot_df)
+
+    expected_ranking = pd.Series(index=['libfuzzer', 'afl'], data=[0, 0])
+    assert ranking.equals(expected_ranking)
+
+
+def test_experiment_pivot_table():
+    experiment_df = create_experiment_data()
+    snapshots_df = data_utils.get_experiment_snapshots(experiment_df)
+    pivot_table = data_utils.experiment_pivot_table(
+        snapshots_df, data_utils.benchmark_rank_by_median)
+
+    # yapf: disable
+    expected_data = pd.DataFrame([
+        {'benchmark': 'libpng', 'fuzzer': 'afl', 'median':  150},
+        {'benchmark': 'libpng', 'fuzzer': 'libfuzzer', 'median':  250},
+        {'benchmark': 'libxml', 'fuzzer': 'afl', 'median': 1100},
+        {'benchmark': 'libxml', 'fuzzer': 'libfuzzer', 'median':  700},
+    ])
+    # yapf: enable
+    expected_pivot_table = pd.pivot_table(expected_data,
+                                          index=['benchmark'],
+                                          columns=['fuzzer'],
+                                          values='median')
+    assert pivot_table.equals(expected_pivot_table)
+
+
+def test_experiment_rank_by_average_rank():
+    experiment_df = create_experiment_data()
+    snapshots_df = data_utils.get_experiment_snapshots(experiment_df)
+    ranking = data_utils.experiment_level_ranking(
+        snapshots_df, data_utils.benchmark_rank_by_median,
+        data_utils.experiment_rank_by_average_rank)
+
+    expected_ranking = pd.Series(index=['afl', 'libfuzzer'], data=[1.5, 1.5])
+    assert ranking.equals(expected_ranking)
+
+
+def test_experiment_rank_by_num_firsts():
+    experiment_df = create_experiment_data()
+    snapshots_df = data_utils.get_experiment_snapshots(experiment_df)
+    ranking = data_utils.experiment_level_ranking(
+        snapshots_df, data_utils.benchmark_rank_by_median,
+        data_utils.experiment_rank_by_num_firsts)
+
+    expected_ranking = pd.Series(index=['libfuzzer', 'afl'], data=[1.0, 1.0])
+    assert ranking.equals(expected_ranking)
+
+
+def test_experiment_rank_by_average_normalized_score():
+    experiment_df = create_experiment_data()
+    snapshots_df = data_utils.get_experiment_snapshots(experiment_df)
+    ranking = data_utils.experiment_level_ranking(
+        snapshots_df, data_utils.benchmark_rank_by_median,
+        data_utils.experiment_rank_by_average_normalized_score)
+
+    expected_ranking = pd.Series(index=['libfuzzer', 'afl'],
+                                 data=[81.81, 80.00])
+    pd_test.assert_series_equal(ranking,
+                                expected_ranking,
+                                check_names=False,
+                                check_less_precise=True)


### PR DESCRIPTION
- The new ranking method is based on average normalized score suggested in
  https://github.com/google/fuzzbench/issues/219#issuecomment-613586802
- Add unit tests for existing and new ranking methods.
- Add `benchmark_` prefix to benchmark level ranking functions to be consistent
  with the experiment level ranking function.
- Refactor and simplify related ExperimentResults code.