### PR TITLE
Remove boilerplate from scheduler test.

### DIFF
--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -13,8 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+## Configure the host.
+
+# Make everything ptrace-able.
 echo 0 > /proc/sys/kernel/yama/ptrace_scope
+
+# Do not notify external programs about core dumps.
 echo core >/proc/sys/kernel/core_pattern
+
+## Start docker.
+
 {% if not local_experiment %}
 while ! docker pull {{docker_image_url}}
 do

--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -22,7 +22,6 @@ echo 0 > /proc/sys/kernel/yama/ptrace_scope
 echo core >/proc/sys/kernel/core_pattern
 
 ## Start docker.
-
 {% if not local_experiment %}
 while ! docker pull {{docker_image_url}}
 do

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -73,23 +73,8 @@ def test_create_trial_instance(benchmark, expected_image, expected_target,
                                experiment_config):
     """Test that create_trial_instance invokes create_instance
     and creates a startup script for the instance, as we expect it to."""
-    expected_format_string = '''#!/bin/bash
-# Copyright 2020 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+    expected_startup_script = '''## Start docker.
 
-echo 0 > /proc/sys/kernel/yama/ptrace_scope
-echo core >/proc/sys/kernel/core_pattern
 
 while ! docker pull {docker_image_url}
 do
@@ -113,7 +98,7 @@ docker run \\
 --cap-add SYS_NICE --cap-add SYS_PTRACE \\
 {docker_image_url} 2>&1 | tee /tmp/runner-log.txt'''
     _test_create_trial_instance(benchmark, expected_image, expected_target,
-                                expected_format_string, experiment_config)
+                                expected_startup_script, experiment_config)
 
 
 @pytest.mark.parametrize(
@@ -130,23 +115,8 @@ def test_create_trial_instance_local_experiment(benchmark, expected_image,
     local_experiment."""
     os.environ['LOCAL_EXPERIMENT'] = str(True)
     os.environ['HOST_GCLOUD_CONFIG'] = '~/.config/gcloud'
-    expected_format_string = '''#!/bin/bash
-# Copyright 2020 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+    expected_startup_script = '''## Start docker.
 
-echo 0 > /proc/sys/kernel/yama/ptrace_scope
-echo core >/proc/sys/kernel/core_pattern
 
 
 docker run -v ~/.config/gcloud:/root/.config/gcloud \\
@@ -166,13 +136,13 @@ docker run -v ~/.config/gcloud:/root/.config/gcloud \\
 --cap-add SYS_NICE --cap-add SYS_PTRACE \\
 {docker_image_url} 2>&1 | tee /tmp/runner-log.txt'''
     _test_create_trial_instance(benchmark, expected_image, expected_target,
-                                expected_format_string, experiment_config)
+                                expected_startup_script, experiment_config)
 
 
 @mock.patch('common.gcloud.create_instance')
 @mock.patch('common.fuzzer_config_utils.get_by_variant_name')
 def _test_create_trial_instance(benchmark, expected_image, expected_target,
-                                expected_format_string, experiment_config,
+                                expected_startup_script, experiment_config,
                                 mocked_get_by_variant_name,
                                 mocked_create_instance):
     """Test that create_trial_instance invokes create_instance
@@ -201,7 +171,9 @@ def _test_create_trial_instance(benchmark, expected_image, expected_target,
         startup_script=expected_startup_script_path)
 
     with open(expected_startup_script_path) as file_handle:
-        assert file_handle.read() == expected_format_string.format(
+        content = file_handle.read()
+        script_for_docker = content[content.find('## Start docker.'):]
+        assert script_for_docker == expected_startup_script.format(
             benchmark=benchmark,
             oss_fuzz_target=expected_target,
             docker_image_url=expected_image)

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -75,7 +75,6 @@ def test_create_trial_instance(benchmark, expected_image, expected_target,
     and creates a startup script for the instance, as we expect it to."""
     expected_startup_script = '''## Start docker.
 
-
 while ! docker pull {docker_image_url}
 do
   echo 'Error pulling image, retrying...'
@@ -116,7 +115,6 @@ def test_create_trial_instance_local_experiment(benchmark, expected_image,
     os.environ['LOCAL_EXPERIMENT'] = str(True)
     os.environ['HOST_GCLOUD_CONFIG'] = '~/.config/gcloud'
     expected_startup_script = '''## Start docker.
-
 
 
 docker run -v ~/.config/gcloud:/root/.config/gcloud \\
@@ -172,7 +170,9 @@ def _test_create_trial_instance(benchmark, expected_image, expected_target,
 
     with open(expected_startup_script_path) as file_handle:
         content = file_handle.read()
-        script_for_docker = content[content.find('## Start docker.'):]
+        check_from = '## Start docker.'
+        assert check_from in content
+        script_for_docker = content[content.find(check_from):]
         assert script_for_docker == expected_startup_script.format(
             benchmark=benchmark,
             oss_fuzz_target=expected_target,


### PR DESCRIPTION
Compare only the docker startup part of the script, as the rest doesn't contain
any template variables. Checking the fixed part of the template is not
interesting for the test and just adds unnecessary boilerplate.
