### PR TITLE
Add some small optimizations to the measurer

### DIFF
--- a/common/gsutil.py
+++ b/common/gsutil.py
@@ -62,18 +62,6 @@ def rm(*rm_arguments, recursive=True, force=False, **kwargs):  # pylint: disable
     return gsutil_command(command, expect_zero=(not force), **kwargs)
 
 
-def cat(path, must_exist=True, **kwargs):
-    """Runs the cat gsutil subcommand on |path|. Throws a
-    subprocess.CalledProcessException if |must_exist| and the return code of the
-    command is nonzero."""
-    command = ['cat', path]
-    result = gsutil_command(command,
-                            parallel=False,
-                            expect_zero=must_exist,
-                            **kwargs)
-    return result.retcode, result.output.splitlines()
-
-
 def rsync(  # pylint: disable=too-many-arguments
         source,
         destination,

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -506,6 +506,7 @@ def measure_snapshot_coverage(fuzzer: str, benchmark: str, trial_num: int,
     snapshot_measurer = SnapshotMeasurer(fuzzer, benchmark, trial_num,
                                          snapshot_logger)
 
+    measuring_start_time = time.time()
     snapshot_logger.info('Measuring cycle: %d.', cycle)
     this_time = cycle * experiment_utils.get_snapshot_seconds()
     if snapshot_measurer.is_cycle_unchanged(cycle):
@@ -549,7 +550,9 @@ def measure_snapshot_coverage(fuzzer: str, benchmark: str, trial_num: int,
     # Archive crashes directory.
     snapshot_measurer.archive_crashes(cycle)
 
-    snapshot_logger.info('Measured cycle: %d.', cycle)
+    measuring_time = round(time.time() - measuring_start_time, 2)
+    snapshot_logger.info('Measured cycle: %d in %d seconds.', cycle,
+                         measuring_time)
     return snapshot
 
 

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -328,8 +328,8 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
                                                  'covered-pcs.txt')
 
         # Stores the files that have already been measured for a trial.
-        self.measured_files_filename = os.path.join(self.report_dir,
-                                                    'measured-files.txt')
+        self.measured_files_path = os.path.join(self.report_dir,
+                                                'measured-files.txt')
 
         # Used by the runner to signal that there won't be a corpus archive for
         # a cycle because the corpus hasn't changed since the last cycle.
@@ -450,16 +450,17 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
         gsutil.cp(archive, gcs_path)
         os.remove(archive)
 
-    def updated_measured_files(self):
+    def update_measured_files(self):
         """Updates the measured-files.txt file for this trial with
         files measured in this snapshot."""
-        current_files = set(os.listdir(snapshot_measurer.corpus_dir))
+        current_files = set(os.listdir(self.corpus_dir))
         already_measured = set(self.get_measured_files())
         filesystem.write('\n'.join(current_files + already_measured),
                          self.measured_files_path)
 
     def get_measured_files(self):
-        """Returns a list of files that have been measured for this snapshot's trials."""
+        """Returns a list of files that have been measured for this
+        snapshot's trials."""
         if not os.path.exists(self.measured_files_path):
             return []
         return filesystem.read(self.measured_files_path).splitlines()

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -454,16 +454,16 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
         """Updates the measured-files.txt file for this trial with
         files measured in this snapshot."""
         current_files = set(os.listdir(self.corpus_dir))
-        already_measured = set(self.get_measured_files())
-        filesystem.write('\n'.join(current_files + already_measured),
-                         self.measured_files_path)
+        already_measured = self.get_measured_files()
+        filesystem.write(self.measured_files_path,
+                         '\n'.join(current_files.union(already_measured)))
 
     def get_measured_files(self):
-        """Returns a list of files that have been measured for this
+        """Returns a the set of files that have been measured for this
         snapshot's trials."""
         if not os.path.exists(self.measured_files_path):
-            return []
-        return filesystem.read(self.measured_files_path).splitlines()
+            return set()
+        return set(filesystem.read(self.measured_files_path).splitlines())
 
 
 def measure_trial_coverage(  # pylint: disable=invalid-name

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -333,8 +333,8 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
 
         # Used by the runner to signal that there won't be a corpus archive for
         # a cycle because the corpus hasn't changed since the last cycle.
-        self.unchanged_cycles_bucket_path = exp_path.gcs(
-            posixpath.join(self.trial_dir, 'results', 'unchanged-cycles'))
+        self.unchanged_cycles_path = os.path.join(self.trial_dir, 'results',
+                                                  'unchanged-cycles')
 
     def initialize_measurement_dirs(self):
         """Initialize directories that will be needed for measuring
@@ -388,10 +388,11 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
     def is_cycle_unchanged(self, cycle: int) -> bool:
         """Returns True if |cycle| is unchanged according to the
         unchanged-cycles file. This file is written to by the trial's runner."""
+
         def copy_unchanged_cycles_file():
             result = gsutil.cp(exp_path.gcs(self.unchanged_cycles_path),
                                self.unchanged_cycles_path)
-            return result.retcode == 0:
+            return result.retcode == 0
 
         if not os.path.exists(self.unchanged_cycles_path):
             if not copy_unchanged_cycles_file():
@@ -399,8 +400,8 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
 
         def get_unchanged_cycles():
             return [
-                int(cycle)
-                for cycle in filesystem.read(self.unchanged_cycles_path).splitlines()
+                int(cycle) for cycle in filesystem.read(
+                    self.unchanged_cycles_path).splitlines()
             ]
 
         unchanged_cycles = get_unchanged_cycles()
@@ -454,7 +455,8 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
         files measured in this snapshot."""
         current_files = set(os.listdir(snapshot_measurer.corpus_dir))
         already_measured = set(self.get_measured_files())
-        filesystem.write('\n'.join(current_files + already_measured), self.measured_files_path)
+        filesystem.write('\n'.join(current_files + already_measured),
+                         self.measured_files_path)
 
     def get_measured_files(self):
         """Returns a list of files that have been measured for this snapshot's trials."""

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -341,7 +341,7 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
         coverage."""
         for directory in [self.corpus_dir, self.sancov_dir, self.crashes_dir]:
             filesystem.recreate_directory(directory)
-        pathlib.Path(self.report_dir).mkdir(exist_ok=True)
+        filesystem.create_directory(self.report_dir)
 
     def run_cov_new_units(self):
         """Run the coverage binary on new units."""

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -162,8 +162,8 @@ def test_is_cycle_unchanged_first_copy(mocked_read, mocked_cp, experiment):
     snapshot_measurer = measurer.SnapshotMeasurer(FUZZER, BENCHMARK, TRIAL_NUM,
                                                   SNAPSHOT_LOGGER)
     this_cycle = 100
-    unchanged_cycles_file_contents = ('\n'.join([str(num) for num in range(10)] +
-                                               [str(this_cycle)]))
+    unchanged_cycles_file_contents = (
+        '\n'.join([str(num) for num in range(10)] + [str(this_cycle)]))
     mocked_read.return_value = unchanged_cycles_file_contents
     mocked_cp.return_value = new_process.ProcessResult(0, '', False)
 
@@ -174,18 +174,18 @@ def test_is_cycle_unchanged_first_copy(mocked_read, mocked_cp, experiment):
 def test_is_cycle_unchanged_update(fs, experiment):
     """Test that is_cycle_unchanged can properly determine that a
     cycle has changed when it has the file but needs to update it."""
-    snapshot_measurer = measurer.SnapshotMeasurer(
-        FUZZER, BENCHMARK, TRIAL_NUM, SNAPSHOT_LOGGER)
+    snapshot_measurer = measurer.SnapshotMeasurer(FUZZER, BENCHMARK, TRIAL_NUM,
+                                                  SNAPSHOT_LOGGER)
 
     this_cycle = 100
-    initial_unchanged_cycles_file_contents = ('\n'.join([str(num) for num in range(10)] +
-                                                        [str(this_cycle)]))
-    fs.create_file(
-        snapshot_measurer.unchanged_cycles_path,
-        contents=initial_unchanged_cycles_file_contents)
+    initial_unchanged_cycles_file_contents = (
+        '\n'.join([str(num) for num in range(10)] + [str(this_cycle)]))
+    fs.create_file(snapshot_measurer.unchanged_cycles_path,
+                   contents=initial_unchanged_cycles_file_contents)
 
     next_cycle = this_cycle + 1
-    unchanged_cycles_file_contents = (initial_unchanged_cycles_file_contents + '\n' + str(next_cycle))
+    unchanged_cycles_file_contents = (initial_unchanged_cycles_file_contents +
+                                      '\n' + str(next_cycle))
     assert snapshot_measurer.is_cycle_unchanged(this_cycle)
     with mock.patch('common.gsutil.cp') as mocked_cp:
         with mock.patch('common.filesystem.read') as mocked_read:
@@ -197,14 +197,13 @@ def test_is_cycle_unchanged_update(fs, experiment):
 @mock.patch('common.gsutil.cp')
 def test_is_cycle_unchanged_skip_cp(mocked_cp, fs, experiment):
     """Check that is_cycle_unchanged doesn't call gsutil.cp unnecessarily."""
-    snapshot_measurer = measurer.SnapshotMeasurer(
-        FUZZER, BENCHMARK, TRIAL_NUM, SNAPSHOT_LOGGER)
+    snapshot_measurer = measurer.SnapshotMeasurer(FUZZER, BENCHMARK, TRIAL_NUM,
+                                                  SNAPSHOT_LOGGER)
     this_cycle = 100
-    initial_unchanged_cycles_file_contents = ('\n'.join([str(num) for num in range(10)] +
-                                                        [str(this_cycle + 1)]))
-    fs.create_file(
-        snapshot_measurer.unchanged_cycles_path,
-        contents=initial_unchanged_cycles_file_contents)
+    initial_unchanged_cycles_file_contents = (
+        '\n'.join([str(num) for num in range(10)] + [str(this_cycle + 1)]))
+    fs.create_file(snapshot_measurer.unchanged_cycles_path,
+                   contents=initial_unchanged_cycles_file_contents)
     assert not snapshot_measurer.is_cycle_unchanged(this_cycle)
     mocked_cp.assert_not_called()
 
@@ -233,9 +232,11 @@ def test_run_cov_new_units(mocked_execute, fs, environ):
                                                   SNAPSHOT_LOGGER)
     snapshot_measurer.initialize_measurement_dirs()
     shared_units = ['shared1', 'shared2']
+    fs.create_file(
+        snapshot_measurer.measured_files_path, contents='\n'.join(shared_units))
     for unit in shared_units:
-        fs.create_file(os.path.join(snapshot_measurer.prev_corpus_dir, unit))
         fs.create_file(os.path.join(snapshot_measurer.corpus_dir, unit))
+
     new_units = ['new1', 'new2']
     for unit in new_units:
         fs.create_file(os.path.join(snapshot_measurer.corpus_dir, unit))

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -232,8 +232,8 @@ def test_run_cov_new_units(mocked_execute, fs, environ):
                                                   SNAPSHOT_LOGGER)
     snapshot_measurer.initialize_measurement_dirs()
     shared_units = ['shared1', 'shared2']
-    fs.create_file(
-        snapshot_measurer.measured_files_path, contents='\n'.join(shared_units))
+    fs.create_file(snapshot_measurer.measured_files_path,
+                   contents='\n'.join(shared_units))
     for unit in shared_units:
         fs.create_file(os.path.join(snapshot_measurer.corpus_dir, unit))
 
@@ -288,8 +288,11 @@ def create_measurer(experiment):
 class TestIntegrationMeasurement:
     """Integration tests for measurement."""
 
-    def test_measure_snapshot_coverage(self, create_measurer, db, experiment):
+    @mock.patch('experiment.measurer.SnapshotMeasurer.is_cycle_unchanged')
+    def test_measure_snapshot_coverage(  # pylint: disable=too-many-locals
+            self, mocked_is_cycle_unchanged, create_measurer, db, experiment):
         """Integration test for measure_snapshot_coverage."""
+        mocked_is_cycle_unchanged.return_value = False
         # Set up the coverage binary.
         benchmark = 'freetype2-2017'
         coverage_binary_src = get_test_data_path(


### PR DESCRIPTION
1. Keep the names of measured files in a list on disk instead of keeping the actual files on disk. This should modestly reduce disk space usage.
2. Copy unchanged-cycles to disk and only copy it again when it may contain new information (e.g. don't copy it again if the current cycle is in the file already or if some other greater cycle is in the file already).

Also, log the amount of time it takes to measure each snapshot.