### PR TITLE
Add input models to fuzz Freetype2 and Vorbis

### DIFF
--- a/fuzzers/aflsmart/README.md
+++ b/fuzzers/aflsmart/README.md
@@ -8,5 +8,9 @@
 
 3. libpcap_fuzz_both
 
+4. freetype2-2017
+
+5. vorbis-2017-12-11
+
 Since the experiment summary diagram of the default FuzzBench report is automatically generated based on the results of all benchmarks, many of them have not been supported by AFLSmart, the ranking of AFLSmart in that diagram may not be correct.
 

--- a/fuzzers/aflsmart/builder.Dockerfile
+++ b/fuzzers/aflsmart/builder.Dockerfile
@@ -38,7 +38,7 @@ RUN add-apt-repository --keyserver hkps://keyserver.ubuntu.com:443 ppa:ubuntu-to
 # Download and compile AFLSmart
 RUN git clone https://github.com/aflsmart/aflsmart /afl && \
     cd /afl && \
-    git checkout df095901ea379f033d4d82345023de004f28b9a7 && \
+    git checkout 5fb84f3b6a0ec24059958c498fc691de01bc5fcc && \
     AFL_NO_X86=1 make
 
 # Setup Peach.

--- a/fuzzers/aflsmart/fuzzer.py
+++ b/fuzzers/aflsmart/fuzzer.py
@@ -49,6 +49,10 @@ def fuzz(input_corpus, output_corpus, target_binary):
         input_model = 'pcap.xml'
     if benchmark_name == 'libjpeg-turbo-07-2017':
         input_model = 'jpeg.xml'
+    if benchmark_name == 'freetype2-2017':
+        input_model = 'xtf.xml'
+    if benchmark_name == 'vorbis-2017-12-11':
+        input_model = 'ogg.xml'
 
     if input_model != '':
         afl_fuzzer.run_afl_fuzz(


### PR DESCRIPTION
Hi,

In this pull request, I add support for True/OpenType fonts and OGG files which are used by AFLSmart to fuzz Freetype2 and Vorbis, respectively.

Regards,

Thuan