### PR TITLE
Add --merge-with-clobber argument to generate_report.py

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -254,7 +254,8 @@ good-names=i,
            ex,
            Run,
            logger,
-           _
+           _,
+           df
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -69,8 +69,8 @@ def clobber_snapshots(df, experiments):
         covered_pairs = result[['benchmark', 'fuzzer']].drop_duplicates()
         covered_pairs = covered_pairs.apply(tuple, axis=1)
         experiment_data = df[df.experiment == experiment]
-        experiment_pairs = experiment_data[['benchmark', 'fuzzer']].apply(
-            tuple, axis=1)
+        experiment_pairs = experiment_data[['benchmark',
+                                            'fuzzer']].apply(tuple, axis=1)
         to_include = experiment_data[~experiment_pairs.isin(covered_pairs)]
         result = result.append(to_include)
     return result

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -37,7 +37,7 @@ def drop_uninteresting_columns(experiment_df):
     ]]
 
 
-def clobber_snapshots(df, experiments):
+def clobber_experiments_data(df, experiments):
     """Clobber experiment data that is part of lower priority (generally
     earlier) versions of the same trials in |df|. For example in experiment-1 we
     may test fuzzer-a on benchmark-1. In experiment-2 we may again test fuzzer-a
@@ -47,9 +47,7 @@ def clobber_snapshots(df, experiments):
     determined by order of each experiment in |experiments| with the highest
     priority experiment coming last in that list."""
     # We don't call |df| "experiment_df" because it is a misnomer and leads to
-    # confusion in this case where it contains data from multiple experiments
-    # and we actually build DataFrames containing data from individual
-    # experiments.
+    # confusion in this case where it contains data from multiple experiments.
 
     # Include everything from the last experiment.
     experiments = experiments.copy()  # Copy so we dont mutate experiments.

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -43,59 +43,37 @@ FuzzerBenchmark = collections.namedtuple('FuzzerBenchmark',
                                          ['fuzzer', 'benchmark', 'experiment'])
 
 
-def clobber_snapshots(experiment_df, experiments):
+def clobber_snapshots(df, experiments):
     """Clobber snapshots that are part of lower priority (generally earlier)
-    versions of the same trials in |experiment_df|. For example in experiment-1
+    versions of the same trials in |df|. For example in experiment-1
     we may test fuzzer-a on benchmark-1. In experiment-2 we may again test
     fuzzer-a on benchmark-1 because fuzzer-a was updated. This function will
     remove the snapshots from fuzzer-a,benchmark-1,experiment-1 from
-    |experiment_df| because we want the report to only contain the up-to-date
+    |df| because we want the report to only contain the up-to-date
     data. Experiment priority is determined by order of each experiment in
     |experiments| with the highest priority experiment coming last in that
     list."""
-    # Create a set of tuples that contain all the unique
-    # fuzzer-benchmark-experiment combinations in experiment_df. We'll use this
-    # to determine which snapshots to drop.
-    fuzzer_benchmarks_df = experiment_df[['fuzzer', 'benchmark', 'experiment']]
-    fuzzer_benchmarks = {
-        FuzzerBenchmark(*fuzzer_benchmark)
-        for fuzzer_benchmark in fuzzer_benchmarks_df.to_numpy()
-    }
-    experiment_rankings = {
-        experiment: experiments.index(experiment) for experiment in experiments
-    }
+    # We don't call |df| "experiment_df" because it is a misnomer and leads to
+    # confusion in this case where it contains data from multiple experiments
+    # and we actually build DataFrames containing data from individual
+    # experiments.
 
-    highest_rank = max(experiment_rankings.values())
+    # Include everything from the last experiment.
+    experiments = experiments.copy()  # Copy so we dont mutate experiments.
+    experiments.reverse()
+    highest_rank_experiment = experiments[0]
+    result = df[df.experiment == highest_rank_experiment]
 
-    # Get the set of those tuples that we should drop because they are
-    # lower priority/rank than others in experiment_df.
-    fuzzer_benchmarks_to_drop = set()
-    for fuzzer_benchmark in fuzzer_benchmarks:
-        experiment = fuzzer_benchmark.experiment
-        rank = experiment_rankings[experiment]
-        if rank == highest_rank:
-            # We're never going to drop trials in the highest ranked experiment.
-            continue
-
-        higher_rank_experiments = experiments[rank + 1:]
-        for higher_rank_experiment in higher_rank_experiments:
-            # See if there exist trials for fuzzer,benchmark in a higher rank
-            # experiment.
-            higher_rank_fuzzer_benchmark = FuzzerBenchmark(
-                fuzzer_benchmark.fuzzer, fuzzer_benchmark.benchmark,
-                higher_rank_experiment)
-            if higher_rank_fuzzer_benchmark in fuzzer_benchmarks:
-                fuzzer_benchmarks_to_drop.add(fuzzer_benchmark)
-                break
-
-    def should_drop_row(row):
-        """Should we drop |row| based on the fuzzer,benchmark,experiment that
-        we are supposed to drop."""
-        fuzzer_benchmark = FuzzerBenchmark(row['fuzzer'], row['benchmark'],
-                                           row['experiment'])
-        return fuzzer_benchmark not in fuzzer_benchmarks_to_drop
-
-    return experiment_df[experiment_df.apply(should_drop_row, axis=1)]
+    for experiment in experiments[1:]:
+        # Include data for not yet covered benchmark/fuzzer pairs.
+        covered_pairs = result[['benchmark', 'fuzzer']].drop_duplicates()
+        covered_pairs = covered_pairs.apply(tuple, axis=1)
+        experiment_data = df[df.experiment == experiment]
+        experiment_pairs = experiment_data[['benchmark', 'fuzzer']].apply(
+            tuple, axis=1)
+        to_include = experiment_data[~experiment_pairs.isin(covered_pairs)]
+        result = result.append(to_include)
+    return result
 
 
 def filter_fuzzers(experiment_df, included_fuzzers):

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Utility functions for data (frame) transformations."""
-import collections
-
 from analysis import stat_tests
 
 
@@ -39,20 +37,15 @@ def drop_uninteresting_columns(experiment_df):
     ]]
 
 
-FuzzerBenchmark = collections.namedtuple('FuzzerBenchmark',
-                                         ['fuzzer', 'benchmark', 'experiment'])
-
-
 def clobber_snapshots(df, experiments):
-    """Clobber snapshots that are part of lower priority (generally earlier)
-    versions of the same trials in |df|. For example in experiment-1
-    we may test fuzzer-a on benchmark-1. In experiment-2 we may again test
-    fuzzer-a on benchmark-1 because fuzzer-a was updated. This function will
-    remove the snapshots from fuzzer-a,benchmark-1,experiment-1 from
-    |df| because we want the report to only contain the up-to-date
-    data. Experiment priority is determined by order of each experiment in
-    |experiments| with the highest priority experiment coming last in that
-    list."""
+    """Clobber experiment data that is part of lower priority (generally
+    earlier) versions of the same trials in |df|. For example in experiment-1 we
+    may test fuzzer-a on benchmark-1. In experiment-2 we may again test fuzzer-a
+    on benchmark-1 because fuzzer-a was updated. This function will remove the
+    snapshots from fuzzer-a,benchmark-1,experiment-1 from |df| because we want
+    the report to only contain the up-to-date data. Experiment priority is
+    determined by order of each experiment in |experiments| with the highest
+    priority experiment coming last in that list."""
     # We don't call |df| "experiment_df" because it is a misnomer and leads to
     # confusion in this case where it contains data from multiple experiments
     # and we actually build DataFrames containing data from individual

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -69,13 +69,29 @@ def get_arg_parser():
                         '--fuzzers',
                         nargs='*',
                         help='Names of the fuzzers to include in the report.')
-    parser.add_argument(
+
+    # It doesn't make sense to clobber and label by experiment, since nothing
+    # can get clobbered like this.
+    mutually_exclusive_group = parser.add_mutually_exclusive_group()
+    mutually_exclusive_group.add_argument(
         '-l',
         '--label-by-experiment',
         action='store_true',
         default=False,
         help='If set, then the report will track progress made in experiments')
-
+    mutually_exclusive_group.add_argument(
+        '-m',
+        '--merge-with-clobber',
+        action='store_true',
+        default=False,
+        help=('When generating a report from multiple experiments, and trials '
+              'exist for fuzzer-benchmark pairs in multiple experiments, only '
+              'include trials for that pair from the last experiment. For '
+              'example, if experiment "A" has all fuzzers but experiment "B" '
+              'has used an updated version of afl++, this option allows you to '
+              'get a report of all trials in "A" except for afl++ and all the '
+              'trials from "B". "Later experiments" are those whose names come '
+              'later when passed to this script.'))
     parser.add_argument(
         '-c',
         '--from-cached-data',
@@ -98,7 +114,8 @@ def generate_report(experiment_names,
                     quick=False,
                     from_cached_data=False,
                     in_progress=False,
-                    end_time=None):
+                    end_time=None,
+                    merge_with_clobber=False):
     """Generate report helper."""
     report_name = report_name or experiment_names[0]
 
@@ -125,6 +142,10 @@ def generate_report(experiment_names,
 
     if end_time is not None:
         experiment_df = data_utils.filter_max_time(experiment_df, end_time)
+
+    if merge_with_clobber:
+        experiment_df = data_utils.clobber_snapshots(experiment_df,
+                                                     experiment_names)
 
     fuzzer_names = experiment_df.fuzzer.unique()
     plotter = plotting.Plotter(fuzzer_names, quick)
@@ -155,7 +176,8 @@ def main():
                     report_type=args.report_type,
                     quick=args.quick,
                     from_cached_data=args.from_cached_data,
-                    end_time=args.end_time)
+                    end_time=args.end_time,
+                    merge_with_clobber=args.merge_with_clobber)
 
 
 if __name__ == '__main__':

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -144,8 +144,8 @@ def generate_report(experiment_names,
         experiment_df = data_utils.filter_max_time(experiment_df, end_time)
 
     if merge_with_clobber:
-        experiment_df = data_utils.clobber_snapshots(experiment_df,
-                                                     experiment_names)
+        experiment_df = data_utils.clobber_experiments_data(experiment_df,
+                                                            experiment_names)
 
     fuzzer_names = experiment_df.fuzzer.unique()
     plotter = plotting.Plotter(fuzzer_names, quick)

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -144,8 +144,8 @@ def generate_report(experiment_names,
         experiment_df = data_utils.filter_max_time(experiment_df, end_time)
 
     if merge_with_clobber:
-        experiment_df = data_utils.clobber_experiments_data(experiment_df,
-                                                            experiment_names)
+        experiment_df = data_utils.clobber_experiments_data(
+            experiment_df, experiment_names)
 
     fuzzer_names = experiment_df.fuzzer.unique()
     plotter = plotting.Plotter(fuzzer_names, quick)

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -74,15 +74,12 @@ def test_clobber_snapshots():
     """Tests that clobber snapshots clobbers stale snapshots from earlier
     experiments."""
     experiments = []
-    df = None
+    df = pd.DataFrame()
     for experiment_num in range(3):
         experiment = 'experiment-%d' % experiment_num
         experiments.append(experiment)
         experiment_df = create_experiment_data(experiment)
-        if df is None:
-            df = experiment_df
-        else:
-            df = pd.concat([df, experiment_df])
+        df = pd.concat([df, experiment_df])
     not_updated_benchmark = 'libpng'
     not_updated_fuzzer = 'afl'
     drop_condition = ((df.experiment != experiments[2]) |

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -70,8 +70,8 @@ def test_drop_uniteresting_columns():
     assert 'time_started' not in cleaned_df.columns
 
 
-def test_clobber_snapshots():
-    """Tests that clobber snapshots clobbers stale snapshots from earlier
+def test_experiments_data():
+    """Tests that clobber experiments data clobbers stale snapshots from earlier
     experiments."""
     experiments = []
     df = pd.DataFrame()
@@ -86,18 +86,20 @@ def test_clobber_snapshots():
                       (df.benchmark != not_updated_benchmark) |
                       (df.fuzzer != not_updated_fuzzer))
     df = df[drop_condition]
-    df = data_utils.clobber_snapshots(df, experiments)
+    df = data_utils.clobber_experiments_data(df, experiments)
     columns = ['experiment', 'benchmark', 'fuzzer']
-    expected_result = pd.DataFrame(
-        [
-            ['experiment-2', 'libpng', 'libfuzzer'],
-            ['experiment-2', 'libxml', 'afl'],
-            ['experiment-2', 'libxml', 'libfuzzer'],
-            ['experiment-1', 'libpng', 'afl'],
-        ], columns=columns)
+    expected_result = pd.DataFrame([
+        ['experiment-2', 'libpng', 'libfuzzer'],
+        ['experiment-2', 'libxml', 'afl'],
+        ['experiment-2', 'libxml', 'libfuzzer'],
+        ['experiment-1', 'libpng', 'afl'],
+    ],
+                                   columns=columns)
     print(type(expected_result), type(df[columns].drop_duplicates()))
     expected_result.sort_index(inplace=True)
-    assert (df[columns].drop_duplicates().values == expected_result.values).all()
+    assert (
+        df[columns].drop_duplicates().values == expected_result.values).all()
+
 
 def test_filter_fuzzers():
     experiment_df = create_experiment_data()

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -39,14 +39,14 @@ def create_trial_data(trial_id, benchmark, fuzzer, reached_coverage,
 def create_experiment_data(experiment='test_experiment'):
     """Utility function to create test experiment data."""
     return pd.concat([
-        create_trial_data(0, 'libpng', 'afl', 100, experiment=experiment),
-        create_trial_data(1, 'libpng', 'afl', 200, experiment=experiment),
-        create_trial_data(2, 'libpng', 'libfuzzer', 200, experiment=experiment),
-        create_trial_data(3, 'libpng', 'libfuzzer', 300, experiment=experiment),
-        create_trial_data(4, 'libxml', 'afl', 1000, experiment=experiment),
-        create_trial_data(5, 'libxml', 'afl', 1200, experiment=experiment),
-        create_trial_data(6, 'libxml', 'libfuzzer', 600, experiment=experiment),
-        create_trial_data(7, 'libxml', 'libfuzzer', 800, experiment=experiment),
+        create_trial_data(0, 'libpng', 'afl', 100, experiment),
+        create_trial_data(1, 'libpng', 'afl', 200, experiment),
+        create_trial_data(2, 'libpng', 'libfuzzer', 200, experiment),
+        create_trial_data(3, 'libpng', 'libfuzzer', 300, experiment),
+        create_trial_data(4, 'libxml', 'afl', 1000, experiment),
+        create_trial_data(5, 'libxml', 'afl', 1200, experiment),
+        create_trial_data(6, 'libxml', 'libfuzzer', 600, experiment),
+        create_trial_data(7, 'libxml', 'libfuzzer', 800, experiment),
     ])
 
 
@@ -70,32 +70,28 @@ def test_drop_uniteresting_columns():
     assert 'time_started' not in cleaned_df.columns
 
 
-def test_experiments_data():
+def test_clobber_experiments_data():
     """Tests that clobber experiments data clobbers stale snapshots from earlier
     experiments."""
-    experiments = []
-    df = pd.DataFrame()
-    for experiment_num in range(3):
-        experiment = 'experiment-%d' % experiment_num
-        experiments.append(experiment)
-        experiment_df = create_experiment_data(experiment)
-        df = pd.concat([df, experiment_df])
-    not_updated_benchmark = 'libpng'
-    not_updated_fuzzer = 'afl'
-    drop_condition = ((df.experiment != experiments[2]) |
-                      (df.benchmark != not_updated_benchmark) |
-                      (df.fuzzer != not_updated_fuzzer))
-    df = df[drop_condition]
+    df = pd.concat(create_experiment_data('experiment-%d' % experiment_num)
+                    for experiment_num in range(3))
+    df.reset_index(inplace=True)
+
+    to_drop = df[(df.experiment == 'experiment-2') &
+                 (df.benchmark == 'libpng') &
+                 (df.fuzzer == 'afl')].index
+    df.drop(to_drop, inplace=True)
+
+    experiments = list(df['experiment'].drop_duplicates().values)
     df = data_utils.clobber_experiments_data(df, experiments)
+
     columns = ['experiment', 'benchmark', 'fuzzer']
     expected_result = pd.DataFrame([
         ['experiment-2', 'libpng', 'libfuzzer'],
         ['experiment-2', 'libxml', 'afl'],
         ['experiment-2', 'libxml', 'libfuzzer'],
         ['experiment-1', 'libpng', 'afl'],
-    ],
-                                   columns=columns)
-    print(type(expected_result), type(df[columns].drop_duplicates()))
+    ], columns=columns)
     expected_result.sort_index(inplace=True)
     assert (
         df[columns].drop_duplicates().values == expected_result.values).all()

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -87,24 +87,17 @@ def test_clobber_snapshots():
                       (df.fuzzer != not_updated_fuzzer))
     df = df[drop_condition]
     df = data_utils.clobber_snapshots(df, experiments)
-    # All of the first experment should be clobbered
-    assert df[df.experiment == experiments[0]].empty
-    # From the second experiment, only not_updated_benchmark-not_updated_fuzzer
-    # shouldn't be clobbered.
-    second_experiment_updated = ((df.experiment == experiments[1]) &
-                                 ((df.benchmark != not_updated_benchmark) |
-                                  (df.fuzzer != not_updated_fuzzer)))
-    assert df[second_experiment_updated].empty
-    second_experiment_not_updated = ((df.experiment == experiments[1]) &
-                                     (df.benchmark == not_updated_benchmark) &
-                                     (df.fuzzer == not_updated_fuzzer))
-    assert not df[second_experiment_not_updated].empty
-    # Except for not_updated_benchmark-not_updated_fuzzer, everything should be
-    # from the third trial.
-    updated_df = (df[(df.benchmark != not_updated_benchmark) |
-                     (df.fuzzer != not_updated_fuzzer)])
-    assert (updated_df.experiment == experiments[2]).all()
-
+    columns = ['experiment', 'benchmark', 'fuzzer']
+    expected_result = pd.DataFrame(
+        [
+            ['experiment-2', 'libpng', 'libfuzzer'],
+            ['experiment-2', 'libxml', 'afl'],
+            ['experiment-2', 'libxml', 'libfuzzer'],
+            ['experiment-1', 'libpng', 'afl'],
+        ], columns=columns)
+    print(type(expected_result), type(df[columns].drop_duplicates()))
+    expected_result.sort_index(inplace=True)
+    assert (df[columns].drop_duplicates().values == expected_result.values).all()
 
 def test_filter_fuzzers():
     experiment_df = create_experiment_data()

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -73,13 +73,13 @@ def test_drop_uniteresting_columns():
 def test_clobber_experiments_data():
     """Tests that clobber experiments data clobbers stale snapshots from earlier
     experiments."""
-    df = pd.concat(create_experiment_data('experiment-%d' % experiment_num)
-                    for experiment_num in range(3))
+    df = pd.concat(
+        create_experiment_data('experiment-%d' % experiment_num)
+        for experiment_num in range(3))
     df.reset_index(inplace=True)
 
     to_drop = df[(df.experiment == 'experiment-2') &
-                 (df.benchmark == 'libpng') &
-                 (df.fuzzer == 'afl')].index
+                 (df.benchmark == 'libpng') & (df.fuzzer == 'afl')].index
     df.drop(to_drop, inplace=True)
 
     experiments = list(df['experiment'].drop_duplicates().values)
@@ -91,7 +91,8 @@ def test_clobber_experiments_data():
         ['experiment-2', 'libxml', 'afl'],
         ['experiment-2', 'libxml', 'libfuzzer'],
         ['experiment-1', 'libpng', 'afl'],
-    ], columns=columns)
+    ],
+                                   columns=columns)
     expected_result.sort_index(inplace=True)
     assert (
         df[columns].drop_duplicates().values == expected_result.values).all()


### PR DESCRIPTION
This argument allows you to combine reports that have updated versions
of the same trials. For example, AFL++ from one experiment and then
an updated AFL++ on a later experiment on the same benchmarks.
It combines the reports by clobbering the stale data.

This means that if we do an experiment and then update a fuzzer,
comparing the fuzzer to others from the old experiment can be done
without running all of them in the new experiment, only the changed
fuzzers needs to run.

This can save resources and speed up measuring by doing less unnecessary
trials. Determining what to run in an experiment still must be done manually.