### PR TITLE
Fix docker image naming for OSS-Fuzz images

### DIFF
--- a/common/benchmark_utils.py
+++ b/common/benchmark_utils.py
@@ -57,9 +57,6 @@ def get_builder_image_url(benchmark, fuzzer, cloud_project):
     """Get the URL of the docker builder image for fuzzing the benchmark with
     fuzzer."""
     base_tag = experiment_utils.get_base_docker_tag(cloud_project)
-    if is_oss_fuzz(benchmark):
-        return '{base_tag}/oss-fuzz/builders/{fuzzer}/{project}'.format(
-            base_tag=base_tag, fuzzer=fuzzer, project=get_project(benchmark))
     return '{base_tag}/builders/{fuzzer}/{benchmark}'.format(
         base_tag=base_tag, fuzzer=fuzzer, benchmark=benchmark)
 

--- a/common/benchmark_utils.py
+++ b/common/benchmark_utils.py
@@ -48,9 +48,6 @@ def get_runner_image_url(benchmark, fuzzer, cloud_project):
     """Get the URL of the docker runner image for fuzzing the benchmark with
     fuzzer."""
     base_tag = experiment_utils.get_base_docker_tag(cloud_project)
-    if is_oss_fuzz(benchmark):
-        return '{base_tag}/oss-fuzz/runners/{fuzzer}/{project}'.format(
-            base_tag=base_tag, fuzzer=fuzzer, project=get_project(benchmark))
     return '{base_tag}/runners/{fuzzer}/{benchmark}'.format(base_tag=base_tag,
                                                             fuzzer=fuzzer,
                                                             benchmark=benchmark)

--- a/common/test_benchmark_utils.py
+++ b/common/test_benchmark_utils.py
@@ -57,7 +57,7 @@ def test_get_fuzz_target(benchmark, expected_fuzz_target, oss_fuzz_benchmark):
 @pytest.mark.parametrize(
     'benchmark,expected_url',
     [(conftest.OSS_FUZZ_BENCHMARK_NAME,
-      'gcr.io/fuzzbench/runners/fuzzer/' + conftest.OSS_FUZZ_BENCHMARK_NAME),
+      'gcr.io/fuzzbench/runners/fuzzer/oss-fuzz-benchmark'),
      (OTHER_BENCHMARK, 'gcr.io/fuzzbench/runners/fuzzer/benchmark')])
 def test_get_runner_image_url(benchmark, expected_url, oss_fuzz_benchmark):
     """Test that we can get the runner image url of a benchmark."""

--- a/common/test_benchmark_utils.py
+++ b/common/test_benchmark_utils.py
@@ -57,7 +57,7 @@ def test_get_fuzz_target(benchmark, expected_fuzz_target, oss_fuzz_benchmark):
 @pytest.mark.parametrize(
     'benchmark,expected_url',
     [(conftest.OSS_FUZZ_BENCHMARK_NAME,
-      'gcr.io/fuzzbench/oss-fuzz/runners/fuzzer/oss-fuzz-project'),
+      'gcr.io/fuzzbench/runners/fuzzer/' + conftest.OSS_FUZZ_BENCHMARK_NAME),
      (OTHER_BENCHMARK, 'gcr.io/fuzzbench/runners/fuzzer/benchmark')])
 def test_get_runner_image_url(benchmark, expected_url, oss_fuzz_benchmark):
     """Test that we can get the runner image url of a benchmark."""

--- a/docker/build.mk
+++ b/docker/build.mk
@@ -203,7 +203,7 @@ define fuzzer_oss_fuzz_benchmark_template
 	docker build \
     --tag $(BASE_TAG)/builders/$(1)/$(2)-intermediate \
     --file=fuzzers/$(1)/builder.Dockerfile \
-    --build-arg parent_image=gcr.io/fuzzbench/$($(2)-project-name)@sha256:$($(2)-oss-fuzz-builder-hash) \
+    --build-arg parent_image=gcr.io/fuzzbench/oss-fuzz/$($(2)-project-name)@sha256:$($(2)-oss-fuzz-builder-hash) \
     $(call cache_from,${BASE_TAG}/builders/$(1)/$(2)-intermediate) \
     fuzzers/$(1)
 
@@ -287,7 +287,7 @@ debug-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
     -e BENCHMARK=$(2) \
     -e FUZZ_TARGET=$($(2)-fuzz-target) \
     --entrypoint "/bin/bash" \
-    -it $(BASE_TAG)/runners/$(1)/$(2)
+    -it $(BASE_TAG)/unners/$(1)/$(2)
 
 else
 

--- a/docker/build.mk
+++ b/docker/build.mk
@@ -261,7 +261,7 @@ run-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
     -e FUZZER=$(1) \
     -e BENCHMARK=$(2) \
     -e FUZZ_TARGET=$($(2)-fuzz-target) \
-    -it $(BASE_TAG)/oss-fuzz/$(1)/$(2)
+    -it $(BASE_TAG)/runners/$(1)/$(2)
 
 test-run-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
 	docker run \
@@ -274,7 +274,7 @@ test-run-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
     -e FUZZ_TARGET=$($(2)-fuzz-target) \
     -e MAX_TOTAL_TIME=20 \
     -e SNAPSHOT_PERIOD=10 \
-    $(BASE_TAG)/oss-fuzz/$(1)/$(2)
+    $(BASE_TAG)/runners/$(1)/$(2)
 
 debug-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
 	docker run \

--- a/docker/build.mk
+++ b/docker/build.mk
@@ -201,10 +201,10 @@ define fuzzer_oss_fuzz_benchmark_template
 
 .$(1)-$(2)-oss-fuzz-builder-intermediate:
 	docker build \
-    --tag $(BASE_TAG)/oss-fuzz/builders/$(1)/$(2)-intermediate \
+    --tag $(BASE_TAG)/builders/$(1)/$(2)-intermediate \
     --file=fuzzers/$(1)/builder.Dockerfile \
-    --build-arg parent_image=gcr.io/fuzzbench/oss-fuzz/$($(2)-project-name)@sha256:$($(2)-oss-fuzz-builder-hash) \
-    $(call cache_from,${BASE_TAG}/oss-fuzz/builders/$(1)/$(2)-intermediate) \
+    --build-arg parent_image=gcr.io/fuzzbench/$($(2)-project-name)@sha256:$($(2)-oss-fuzz-builder-hash) \
+    $(call cache_from,${BASE_TAG}/builders/$(1)/$(2)-intermediate) \
     fuzzers/$(1)
 
 .pull-$(1)-$(2)-oss-fuzz-builder-intermediate:
@@ -212,40 +212,40 @@ define fuzzer_oss_fuzz_benchmark_template
 
 .$(1)-$(2)-oss-fuzz-builder: .$(1)-$(2)-oss-fuzz-builder-intermediate
 	docker build \
-    --tag $(BASE_TAG)/oss-fuzz/builders/$(1)/$(2) \
+    --tag $(BASE_TAG)/builders/$(1)/$(2) \
     --file=docker/oss-fuzz-builder/Dockerfile \
-    --build-arg parent_image=$(BASE_TAG)/oss-fuzz/builders/$(1)/$(2)-intermediate \
+    --build-arg parent_image=$(BASE_TAG)/builders/$(1)/$(2)-intermediate \
     --build-arg fuzzer=$(1) \
     --build-arg benchmark=$(2) \
     $(call cache_from,${BASE_TAG}/oss-fuzz/builders/$(1)/$(2)) \
     .
 
 .pull-$(1)-$(2)-oss-fuzz-builder: .pull-$(1)-$(2)-oss-fuzz-builder-intermediate
-	docker pull $(BASE_TAG)/oss-fuzz/builders/$(1)/$(2)
+	docker pull $(BASE_TAG)/builders/$(1)/$(2)
 
 ifneq ($(1), coverage)
 
 .$(1)-$(2)-oss-fuzz-intermediate-runner: base-runner
 	docker build \
-    --tag $(BASE_TAG)/oss-fuzz/runners/$(1)/$(2)-intermediate \
+    --tag $(BASE_TAG)/runners/$(1)/$(2)-intermediate \
     --file fuzzers/$(1)/runner.Dockerfile \
-    $(call cache_from,${BASE_TAG}/oss-fuzz/runners/$(1)/$(2)-intermediate) \
+    $(call cache_from,${BASE_TAG}/runners/$(1)/$(2)-intermediate) \
     fuzzers/$(1)
 
 .pull-$(1)-$(2)-oss-fuzz-intermediate-runner: pull-base-runner
-	docker pull $(BASE_TAG)/oss-fuzz/runners/$(1)/$(2)-intermediate
+	docker pull $(BASE_TAG)/runners/$(1)/$(2)-intermediate
 
 .$(1)-$(2)-oss-fuzz-runner: .$(1)-$(2)-oss-fuzz-builder .$(1)-$(2)-oss-fuzz-intermediate-runner
 	docker build \
-    --tag $(BASE_TAG)/oss-fuzz/runners/$(1)/$(2) \
+    --tag $(BASE_TAG)/runners/$(1)/$(2) \
     --build-arg fuzzer=$(1) \
     --build-arg oss_fuzz_project=$(2) \
-    $(call cache_from,${BASE_TAG}/oss-fuzz/runners/$(1)/$(2)) \
+    $(call cache_from,${BASE_TAG}/runners/$(1)/$(2)) \
     --file docker/oss-fuzz-runner/Dockerfile \
     .
 
 .pull-$(1)-$(2)-oss-fuzz-runner: .pull-$(1)-$(2)-oss-fuzz-builder .pull-$(1)-$(2)-oss-fuzz-intermediate-runner
-	docker pull $(BASE_TAG)/oss-fuzz/runners/$(1)/$(2)
+	docker pull $(BASE_TAG)/runners/$(1)/$(2)
 
 build-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
 
@@ -287,7 +287,7 @@ debug-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
     -e BENCHMARK=$(2) \
     -e FUZZ_TARGET=$($(2)-fuzz-target) \
     --entrypoint "/bin/bash" \
-    -it $(BASE_TAG)/oss-fuzz/runners/$(1)/$(2)
+    -it $(BASE_TAG)/runners/$(1)/$(2)
 
 else
 

--- a/docker/build.mk
+++ b/docker/build.mk
@@ -192,7 +192,7 @@ $(1)-oss-fuzz-builder-hash := $(shell cat benchmarks/$(1)/oss-fuzz.yaml | \
                                       grep oss_fuzz_builder_hash | \
                                       cut -d ':' -f2 | tr -d ' ')
 endef
-# Instantiate the above template with all OSS-Fuzz projects.
+# Instantiate the above template with all OSS-Fuzz benchmarks.
 $(foreach oss_fuzz_benchmark,$(OSS_FUZZ_BENCHMARKS), \
   $(eval $(call oss_fuzz_benchmark_template,$(oss_fuzz_benchmark))))
 
@@ -239,7 +239,7 @@ ifneq ($(1), coverage)
 	docker build \
     --tag $(BASE_TAG)/runners/$(1)/$(2) \
     --build-arg fuzzer=$(1) \
-    --build-arg oss_fuzz_project=$(2) \
+    --build-arg benchmark=$(2) \
     $(call cache_from,${BASE_TAG}/runners/$(1)/$(2)) \
     --file docker/oss-fuzz-runner/Dockerfile \
     .
@@ -299,7 +299,7 @@ endif
 endef
 
 # Instantiate the above template with the cross product of all fuzzers and
-# OSS-Fuzz projects.
+# OSS-Fuzz benchmarks.
 $(foreach fuzzer,$(FUZZERS), \
   $(foreach oss_fuzz_benchmark,$(OSS_FUZZ_BENCHMARKS), \
     $(eval $(call fuzzer_oss_fuzz_benchmark_template,$(fuzzer),$(oss_fuzz_benchmark)))))

--- a/docker/build.mk
+++ b/docker/build.mk
@@ -287,7 +287,7 @@ debug-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
     -e BENCHMARK=$(2) \
     -e FUZZ_TARGET=$($(2)-fuzz-target) \
     --entrypoint "/bin/bash" \
-    -it $(BASE_TAG)/unners/$(1)/$(2)
+    -it $(BASE_TAG)/runners/$(1)/$(2)
 
 else
 

--- a/docker/build.mk
+++ b/docker/build.mk
@@ -208,7 +208,7 @@ define fuzzer_oss_fuzz_benchmark_template
     fuzzers/$(1)
 
 .pull-$(1)-$(2)-oss-fuzz-builder-intermediate:
-	docker pull $(BASE_TAG)/oss-fuzz/builders/$(1)/$(2)-intermediate
+	docker pull $(BASE_TAG)/builders/$(1)/$(2)-intermediate
 
 .$(1)-$(2)-oss-fuzz-builder: .$(1)-$(2)-oss-fuzz-builder-intermediate
 	docker build \
@@ -217,7 +217,7 @@ define fuzzer_oss_fuzz_benchmark_template
     --build-arg parent_image=$(BASE_TAG)/builders/$(1)/$(2)-intermediate \
     --build-arg fuzzer=$(1) \
     --build-arg benchmark=$(2) \
-    $(call cache_from,${BASE_TAG}/oss-fuzz/builders/$(1)/$(2)) \
+    $(call cache_from,${BASE_TAG}/builders/$(1)/$(2)) \
     .
 
 .pull-$(1)-$(2)-oss-fuzz-builder: .pull-$(1)-$(2)-oss-fuzz-builder-intermediate
@@ -261,7 +261,7 @@ run-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
     -e FUZZER=$(1) \
     -e BENCHMARK=$(2) \
     -e FUZZ_TARGET=$($(2)-fuzz-target) \
-    -it $(BASE_TAG)/oss-fuzz/runners/$(1)/$(2)
+    -it $(BASE_TAG)/oss-fuzz/$(1)/$(2)
 
 test-run-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
 	docker run \
@@ -274,7 +274,7 @@ test-run-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
     -e FUZZ_TARGET=$($(2)-fuzz-target) \
     -e MAX_TOTAL_TIME=20 \
     -e SNAPSHOT_PERIOD=10 \
-    $(BASE_TAG)/oss-fuzz/runners/$(1)/$(2)
+    $(BASE_TAG)/oss-fuzz/$(1)/$(2)
 
 debug-$(1)-$(2): .$(1)-$(2)-oss-fuzz-runner
 	docker run \

--- a/docker/gcb/oss-fuzz-coverage.yaml
+++ b/docker/gcb/oss-fuzz-coverage.yaml
@@ -19,7 +19,7 @@ steps:
   args:
     - '-c'
     - |
-      docker pull ${_REPO}/oss-fuzz/builders/coverage/${_BENCHMARK}-intermediate || exit 0
+      docker pull ${_REPO}/builders/coverage/${_BENCHMARK}-intermediate || exit 0
 
 - name: 'gcr.io/cloud-builders/docker'
   args: [
@@ -28,15 +28,15 @@ steps:
     # Use two tags so that the image builds properly and we can push it to the
     # correct location.
     '--tag',
-    'gcr.io/fuzzbench/oss-fuzz/builders/coverage/${_BENCHMARK}-intermediate',
+    'gcr.io/fuzzbench/builders/coverage/${_BENCHMARK}-intermediate',
 
     '--tag',
-    '${_REPO}/oss-fuzz/builders/coverage/${_BENCHMARK}-intermediate',
+    '${_REPO}/oss-fuzz/coverage/${_BENCHMARK}-intermediate',
 
     '--file=fuzzers/coverage/builder.Dockerfile',
 
     '--cache-from',
-    '${_REPO}/oss-fuzz/builders/coverage/${_BENCHMARK}-intermediate',
+    '${_REPO}/builders/coverage/${_BENCHMARK}-intermediate',
 
     # Use a hardcoded repo because the parent image is pinned by SHA. Users
     # won't have it.
@@ -52,7 +52,7 @@ steps:
   args:
     - '-c'
     - |
-      docker pull ${_REPO}/oss-fuzz/builders/coverage/${_BENCHMARK} || exit 0
+      docker pull ${_REPO}/builders/coverage/${_BENCHMARK} || exit 0
   id: 'pull-coverage-benchmark-builder'
   wait_for: ['-']
 
@@ -61,18 +61,18 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/oss-fuzz/builders/coverage/${_BENCHMARK}',
+    'gcr.io/fuzzbench/builders/coverage/${_BENCHMARK}',
 
     '--tag',
-    '${_REPO}/oss-fuzz/builders/coverage/${_BENCHMARK}',
+    '${_REPO}/builders/coverage/${_BENCHMARK}',
 
     '--file=docker/oss-fuzz-builder/Dockerfile',
 
     '--cache-from',
-    '${_REPO}/oss-fuzz/builders/coverage/${_BENCHMARK}',
+    '${_REPO}/builders/coverage/${_BENCHMARK}',
 
     '--build-arg',
-    'parent_image=${_REPO}/oss-fuzz/builders/coverage/${_BENCHMARK}-intermediate',
+    'parent_image=${_REPO}/builders/coverage/${_BENCHMARK}-intermediate',
 
     '--build-arg',
     'fuzzer=coverage',
@@ -89,7 +89,7 @@ steps:
     'run',
     '-v',
     '/workspace/out:/host-out',
-    '${_REPO}/oss-fuzz/builders/coverage/${_BENCHMARK}',
+    '${_REPO}/builders/coverage/${_BENCHMARK}',
     '/bin/bash',
     '-c',
     'cd /out; tar -czvf /host-out/coverage-build-${_BENCHMARK}.tar.gz *'
@@ -104,5 +104,5 @@ steps:
   ]
 
 images:
-  - '${_REPO}/oss-fuzz/builders/coverage/${_BENCHMARK}-intermediate'
-  - '${_REPO}/oss-fuzz/builders/coverage/${_BENCHMARK}'
+  - '${_REPO}/builders/coverage/${_BENCHMARK}-intermediate'
+  - '${_REPO}/builders/coverage/${_BENCHMARK}'

--- a/docker/gcb/oss-fuzz-fuzzer.yaml
+++ b/docker/gcb/oss-fuzz-fuzzer.yaml
@@ -39,7 +39,7 @@ steps:
     # Use a hardcoded repo because the parent image is pinned by SHA. Users
     # won't have it.
     '--build-arg',
-    'parent_image=gcr.io/fuzzbench/${_OSS_FUZZ_PROJECT}@sha256:${_OSS_FUZZ_BUILDER_HASH}',
+    'parent_image=gcr.io/fuzzbench/oss-fuzz/${_OSS_FUZZ_PROJECT}@sha256:${_OSS_FUZZ_BUILDER_HASH}',
 
     'fuzzers/${_UNDERLYING_FUZZER}',
   ]

--- a/docker/gcb/oss-fuzz-fuzzer.yaml
+++ b/docker/gcb/oss-fuzz-fuzzer.yaml
@@ -140,7 +140,7 @@ steps:
     '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}',
 
     '--build-arg',
-    'oss_fuzz_project=${_BENCHMARK}',
+    'benchmark=${_BENCHMARK}',
 
     '--file',
     'docker/oss-fuzz-runner/Dockerfile',

--- a/docker/gcb/oss-fuzz-fuzzer.yaml
+++ b/docker/gcb/oss-fuzz-fuzzer.yaml
@@ -19,27 +19,27 @@ steps:
   args:
     - '-c'
     - |
-      docker pull ${_REPO}/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK}-intermediate || exit 0
+      docker pull ${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate || exit 0
 
 - name: 'gcr.io/cloud-builders/docker'
   args: [
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
+    'gcr.io/fuzzbench/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     '--tag',
-    '${_REPO}/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
+    '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     '--file=fuzzers/${_UNDERLYING_FUZZER}/builder.Dockerfile',
 
     '--cache-from',
-    '${_REPO}/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
+    '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     # Use a hardcoded repo because the parent image is pinned by SHA. Users
     # won't have it.
     '--build-arg',
-    'parent_image=gcr.io/fuzzbench/oss-fuzz/${_OSS_FUZZ_PROJECT}@sha256:${_OSS_FUZZ_BUILDER_HASH}',
+    'parent_image=gcr.io/fuzzbench/${_OSS_FUZZ_PROJECT}@sha256:${_OSS_FUZZ_BUILDER_HASH}',
 
     'fuzzers/${_UNDERLYING_FUZZER}',
   ]
@@ -50,7 +50,7 @@ steps:
   args:
     - '-c'
     - |
-      docker pull ${_REPO}/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK} || exit 0
+      docker pull ${_REPO}/builders/${_FUZZER}/${_BENCHMARK} || exit 0
   id: 'pull-fuzzer-benchmark-builder'
   wait_for: ['-']
 
@@ -59,18 +59,18 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK}',
+    'gcr.io/fuzzbench/builders/${_FUZZER}/${_BENCHMARK}',
 
     '--tag',
-    '${_REPO}/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK}',
+    '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}',
 
     '--file=docker/oss-fuzz-builder/Dockerfile',
 
     '--cache-from',
-    '${_REPO}/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK}',
+    '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}',
 
     '--build-arg',
-    'parent_image=${_REPO}/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
+    'parent_image=${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     '--build-arg',
     'fuzzer=${_UNDERLYING_FUZZER}',
@@ -88,7 +88,7 @@ steps:
   args:
     - '-c'
     - |
-      docker pull ${_REPO}/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK}-intermediate || exit 0
+      docker pull ${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate || exit 0
   id: 'pull-fuzzer-benchmark-runner-intermediate'
   wait_for: ['-']
 
@@ -97,16 +97,16 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/oss-fuzz/runners/${_FUZZER}/${_BENCHMARK}-intermediate',
+    'gcr.io/fuzzbench/runners/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     '--tag',
-    '${_REPO}/oss-fuzz/runners/${_FUZZER}/${_BENCHMARK}-intermediate',
+    '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     '--file',
     'fuzzers/${_UNDERLYING_FUZZER}/runner.Dockerfile',
 
     '--cache-from',
-    '${_REPO}/oss-fuzz/runners/${_FUZZER}/${_BENCHMARK}-intermediate',
+    '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     'fuzzers/${_UNDERLYING_FUZZER}',
   ]
@@ -118,7 +118,7 @@ steps:
   args:
     - '-c'
     - |
-      docker pull ${_REPO}/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK} || exit 0
+      docker pull ${_REPO}/builders/${_FUZZER}/${_BENCHMARK} || exit 0
   id: 'pull-fuzzer-benchmark-runner'
   wait_for: ['-']
 
@@ -128,16 +128,16 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/oss-fuzz/runners/${_FUZZER}/${_BENCHMARK}',
+    'gcr.io/fuzzbench/runners/${_FUZZER}/${_BENCHMARK}',
 
     '--tag',
-    '${_REPO}/oss-fuzz/runners/${_FUZZER}/${_BENCHMARK}',
+    '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}',
 
     '--build-arg',
     'fuzzer=${_UNDERLYING_FUZZER}',
 
     '--cache-from',
-    '${_REPO}/oss-fuzz/runners/${_FUZZER}/${_BENCHMARK}',
+    '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}',
 
     '--build-arg',
     'oss_fuzz_project=${_BENCHMARK}',
@@ -150,7 +150,7 @@ steps:
   wait_for: ['pull-fuzzer-benchmark-runner', 'build-fuzzer-benchmark-runner-intermediate']
 
 images:
-  - '${_REPO}/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK}-intermediate'
-  - '${_REPO}/oss-fuzz/builders/${_FUZZER}/${_BENCHMARK}'
-  - '${_REPO}/oss-fuzz/runners/${_FUZZER}/${_BENCHMARK}-intermediate'
-  - '${_REPO}/oss-fuzz/runners/${_FUZZER}/${_BENCHMARK}'
+  - '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate'
+  - '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}'
+  - '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}-intermediate'
+  - '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}'

--- a/docker/oss-fuzz-runner/Dockerfile
+++ b/docker/oss-fuzz-runner/Dockerfile
@@ -39,7 +39,7 @@ FROM gcr.io/fuzzbench/builders/$fuzzer/$benchmark AS builder
 
 # We base the runner image from the intermediate runner image, defined by the
 # runner.Dockerfile of each fuzzer.
-FROM gcr.io/fuzzbench/oss-fuzz/$fuzzer/$benchmark-intermediate
+FROM gcr.io/fuzzbench/runners/$fuzzer/$benchmark-intermediate
 
 # Set up the directory for the build artifacts.
 ENV WORKDIR /out

--- a/docker/oss-fuzz-runner/Dockerfile
+++ b/docker/oss-fuzz-runner/Dockerfile
@@ -23,23 +23,23 @@
 # the following arguments to docker build:
 #
 # $ docker build \
-#   --build-arg oss_fuzz_project=skcms \
+#   --build-arg benchmark=bloaty_fuzz_target \
 #   --build-arg fuzzer=afl \
 #   ...
 
 ARG fuzzer
-ARG oss_fuzz_project
+ARG benchmark
 
 # We use Docker's multi-stage build feature to create a minimal runner image,
 # separate from the sometimes bulky builder images.
 
 # We take the already built builder image for the given fuzzer/benchmark pair
 # and refer to it as "builder", so we can copy the build artifacts from it.
-FROM gcr.io/fuzzbench/builders/$fuzzer/$oss_fuzz_project AS builder
+FROM gcr.io/fuzzbench/builders/$fuzzer/$benchmark AS builder
 
 # We base the runner image from the intermediate runner image, defined by the
 # runner.Dockerfile of each fuzzer.
-FROM gcr.io/fuzzbench/oss-fuzz/$fuzzer/$oss_fuzz_project-intermediate
+FROM gcr.io/fuzzbench/oss-fuzz/$fuzzer/$benchmark-intermediate
 
 # Set up the directory for the build artifacts.
 ENV WORKDIR /out

--- a/docker/oss-fuzz-runner/Dockerfile
+++ b/docker/oss-fuzz-runner/Dockerfile
@@ -35,11 +35,11 @@ ARG oss_fuzz_project
 
 # We take the already built builder image for the given fuzzer/benchmark pair
 # and refer to it as "builder", so we can copy the build artifacts from it.
-FROM gcr.io/fuzzbench/oss-fuzz/builders/$fuzzer/$oss_fuzz_project AS builder
+FROM gcr.io/fuzzbench/builders/$fuzzer/$oss_fuzz_project AS builder
 
 # We base the runner image from the intermediate runner image, defined by the
 # runner.Dockerfile of each fuzzer.
-FROM gcr.io/fuzzbench/oss-fuzz/runners/$fuzzer/$oss_fuzz_project-intermediate
+FROM gcr.io/fuzzbench/oss-fuzz/$fuzzer/$oss_fuzz_project-intermediate
 
 # Set up the directory for the build artifacts.
 ENV WORKDIR /out

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -67,8 +67,8 @@ def pending_trials(db, experiment_config):
     'benchmark,expected_image,expected_target',
     [('benchmark1', 'gcr.io/fuzzbench/runners/variant/benchmark1',
       'fuzz-target'),
-     ('bloaty_fuzz_target', 'gcr.io/fuzzbench/oss-fuzz/runners/variant/bloaty',
-      'fuzz_target')])
+     ('bloaty_fuzz_target',
+      'gcr.io/fuzzbench/runners/variant/bloaty_fuzz_target', 'fuzz_target')])
 def test_create_trial_instance(benchmark, expected_image, expected_target,
                                experiment_config):
     """Test that create_trial_instance invokes create_instance
@@ -103,8 +103,8 @@ docker run \\
     'benchmark,expected_image,expected_target',
     [('benchmark1', 'gcr.io/fuzzbench/runners/variant/benchmark1',
       'fuzz-target'),
-     ('bloaty_fuzz_target', 'gcr.io/fuzzbench/oss-fuzz/runners/variant/bloaty',
-      'fuzz_target')])
+     ('bloaty_fuzz_target',
+      'gcr.io/fuzzbench/runners/variant/bloaty_fuzz_target', 'fuzz_target')])
 def test_create_trial_instance_local_experiment(benchmark, expected_image,
                                                 expected_target,
                                                 experiment_config, environ):


### PR DESCRIPTION
Correct the runner image used on runner bots to use the benchmark-based naming scheme introduced in #254.

It also removes the oss-fuzz prefix from OSS-Fuzz builder (not including the project builder image that is part of OSS-Fuzz and not fuzzbench) and runners to be consistent with fuzzbench fuzzers.
This fixes #288. and likely fixes #285 (they are probably the same issue).
