### PR TITLE
Fix bug copying unchanged-cycles in measurer

### DIFF
--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -391,7 +391,7 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
 
         def copy_unchanged_cycles_file():
             result = gsutil.cp(exp_path.gcs(self.unchanged_cycles_path),
-                               self.unchanged_cycles_path)
+                               self.unchanged_cycles_path, expect_zero=False)
             return result.retcode == 0
 
         if not os.path.exists(self.unchanged_cycles_path):

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -391,7 +391,8 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
 
         def copy_unchanged_cycles_file():
             result = gsutil.cp(exp_path.gcs(self.unchanged_cycles_path),
-                               self.unchanged_cycles_path, expect_zero=False)
+                               self.unchanged_cycles_path,
+                               expect_zero=False)
             return result.retcode == 0
 
         if not os.path.exists(self.unchanged_cycles_path):

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -154,9 +154,8 @@ def test_measure_all_trials_no_more(mocked_directories_have_same_files,
         queue.Queue())
 
 
-@mock.patch('common.gsutil.cp')
-@mock.patch('common.filesystem.read')
-def test_is_cycle_unchanged_first_copy(mocked_read, mocked_cp, experiment):
+@mock.patch('subprocess.Popen.__init__')
+def test_is_cycle_unchanged_doesnt_exist(mocked_init, experiment):
     """Test that is_cycle_unchanged can properly determine if a cycle is
     unchanged or not when it needs to copy the file for the first time."""
     snapshot_measurer = measurer.SnapshotMeasurer(FUZZER, BENCHMARK, TRIAL_NUM,
@@ -164,11 +163,10 @@ def test_is_cycle_unchanged_first_copy(mocked_read, mocked_cp, experiment):
     this_cycle = 100
     unchanged_cycles_file_contents = (
         '\n'.join([str(num) for num in range(10)] + [str(this_cycle)]))
-    mocked_read.return_value = unchanged_cycles_file_contents
-    mocked_cp.return_value = new_process.ProcessResult(0, '', False)
 
-    assert snapshot_measurer.is_cycle_unchanged(this_cycle)
-    assert not snapshot_measurer.is_cycle_unchanged(this_cycle + 1)
+    mocked_init.side_effect = subprocess.CalledProcessError('returned nonzero')
+
+    assert not snapshot_measurer.is_cycle_unchanged(this_cycle)
 
 
 def test_is_cycle_unchanged_update(fs, experiment):

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -16,6 +16,7 @@
 import datetime
 import os
 import shutil
+import subprocess
 from unittest import mock
 import queue
 
@@ -154,19 +155,14 @@ def test_measure_all_trials_no_more(mocked_directories_have_same_files,
         queue.Queue())
 
 
-@mock.patch('subprocess.Popen.__init__')
-def test_is_cycle_unchanged_doesnt_exist(mocked_init, experiment):
+def test_is_cycle_unchanged_doesnt_exist(experiment):
     """Test that is_cycle_unchanged can properly determine if a cycle is
     unchanged or not when it needs to copy the file for the first time."""
     snapshot_measurer = measurer.SnapshotMeasurer(FUZZER, BENCHMARK, TRIAL_NUM,
                                                   SNAPSHOT_LOGGER)
-    this_cycle = 100
-    unchanged_cycles_file_contents = (
-        '\n'.join([str(num) for num in range(10)] + [str(this_cycle)]))
-
-    mocked_init.side_effect = subprocess.CalledProcessError('returned nonzero')
-
-    assert not snapshot_measurer.is_cycle_unchanged(this_cycle)
+    this_cycle = 1
+    with test_utils.mock_popen_ctx_mgr(returncode=1):
+        assert not snapshot_measurer.is_cycle_unchanged(this_cycle)
 
 
 def test_is_cycle_unchanged_update(fs, experiment):

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -163,6 +163,7 @@ def test_is_cycle_unchanged_doesnt_exist(experiment):
     with test_utils.mock_popen_ctx_mgr(returncode=1):
         assert not snapshot_measurer.is_cycle_unchanged(this_cycle)
 
+
 @mock.patch('common.gsutil.cp')
 @mock.patch('common.filesystem.read')
 def test_is_cycle_unchanged_first_copy(mocked_read, mocked_cp, experiment):

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -16,7 +16,6 @@
 import datetime
 import os
 import shutil
-import subprocess
 from unittest import mock
 import queue
 

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -163,6 +163,22 @@ def test_is_cycle_unchanged_doesnt_exist(experiment):
     with test_utils.mock_popen_ctx_mgr(returncode=1):
         assert not snapshot_measurer.is_cycle_unchanged(this_cycle)
 
+@mock.patch('common.gsutil.cp')
+@mock.patch('common.filesystem.read')
+def test_is_cycle_unchanged_first_copy(mocked_read, mocked_cp, experiment):
+    """Test that is_cycle_unchanged can properly determine if a cycle is
+    unchanged or not when it needs to copy the file for the first time."""
+    snapshot_measurer = measurer.SnapshotMeasurer(FUZZER, BENCHMARK, TRIAL_NUM,
+                                                  SNAPSHOT_LOGGER)
+    this_cycle = 100
+    unchanged_cycles_file_contents = (
+        '\n'.join([str(num) for num in range(10)] + [str(this_cycle)]))
+    mocked_read.return_value = unchanged_cycles_file_contents
+    mocked_cp.return_value = new_process.ProcessResult(0, '', False)
+
+    assert snapshot_measurer.is_cycle_unchanged(this_cycle)
+    assert not snapshot_measurer.is_cycle_unchanged(this_cycle + 1)
+
 
 def test_is_cycle_unchanged_update(fs, experiment):
     """Test that is_cycle_unchanged can properly determine that a


### PR DESCRIPTION
The code assumed that an unchanged-cycles file always exists.