### PR TITLE
Revert "Enable huge pages on runner instances. (#247)"

### DIFF
--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -15,9 +15,6 @@
 
 ## Configure the host.
 
-# Enable 8 2MB huge pages.
-echo 8 > /proc/sys/vm/nr_hugepages
-
 # Make everything ptrace-able.
 echo 0 > /proc/sys/kernel/yama/ptrace_scope
 


### PR DESCRIPTION
This reverts commit 625e0298a7700e9bf849c7d8c7449248bda6a576.

I'm already running the experiment for fastcgs with this commit, we don't need it anymore.