### PR TITLE
Don't use parallel when using gsutil to copy unchanged-cycles

### DIFF
--- a/common/gsutil.py
+++ b/common/gsutil.py
@@ -19,7 +19,7 @@ from common import new_process
 logger = logs.Logger('gsutil')
 
 
-def gsutil_command(arguments, *args, parallel=True, **kwargs):
+def gsutil_command(arguments, *args, parallel=False, **kwargs):
     """Executes a gsutil command with |arguments| and returns the result."""
     command = ['gsutil']
     if parallel:
@@ -41,10 +41,7 @@ def ls(*ls_arguments, must_exist=True, **kwargs):  # pylint: disable=invalid-nam
     |must_exist|."""
     command = ['ls'] + list(ls_arguments)
     # Don't use parallel as it probably doesn't help at all.
-    result = gsutil_command(command,
-                            parallel=False,
-                            expect_zero=must_exist,
-                            **kwargs)
+    result = gsutil_command(command, expect_zero=must_exist, **kwargs)
     retcode = result.retcode  # pytype: disable=attribute-error
     output = result.output.splitlines()  # pytype: disable=attribute-error
     return retcode, output

--- a/common/test_gsutil.py
+++ b/common/test_gsutil.py
@@ -26,7 +26,7 @@ def test_gsutil_command():
     arguments = ['hello']
     with test_utils.mock_popen_ctx_mgr() as mocked_popen:
         gsutil.gsutil_command(arguments)
-    assert mocked_popen.commands == [['gsutil', '-m'] + arguments]
+    assert mocked_popen.commands == [['gsutil'] + arguments]
 
 
 class TestGsutilRsync:

--- a/experiment/build/build_utils.py
+++ b/experiment/build/build_utils.py
@@ -30,7 +30,6 @@ def store_build_logs(build_config, build_result):
         build_log_filename = build_config + '.txt'
         gsutil.cp(tmp.name,
                   exp_path.gcs(get_build_logs_dir() / build_log_filename),
-                  parallel=False,
                   write_to_stdout=False)
 
 

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -452,7 +452,7 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
                     arcname=os.path.basename(self.crashes_dir))
         gcs_path = exp_path.gcs(
             posixpath.join(self.trial_dir, 'crashes', crashes_archive_name))
-        gsutil.cp(archive, gcs_path, parallel=False)
+        gsutil.cp(archive, gcs_path)
         os.remove(archive)
 
     def update_measured_files(self):
@@ -534,7 +534,6 @@ def measure_snapshot_coverage(fuzzer: str, benchmark: str, trial_num: int,
     if gsutil.cp(corpus_archive_src,
                  corpus_archive_dst,
                  expect_zero=False,
-                 parallel=False,
                  write_to_stdout=False)[0] != 0:
         snapshot_logger.warning('Corpus not found for cycle: %d.', cycle)
         return None
@@ -588,7 +587,6 @@ def set_up_coverage_binary(benchmark):
                                              archive_name)
     gsutil.cp(cloud_bucket_archive_path,
               str(benchmark_coverage_binary_dir),
-              parallel=False,
               write_to_stdout=False)
     archive_path = benchmark_coverage_binary_dir / archive_name
     tar = tarfile.open(archive_path, 'r:gz')

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -148,7 +148,7 @@ def measure_all_trials(experiment: str, max_total_time: int, pool, q) -> bool:  
                 # If "ready" that means pool has finished calling on each
                 # unmeasured_snapshot. Since it is finished and the queue is
                 # empty, we can stop checking the queue for more snapshots.
-                logger.info('ready')
+                logger.debug('ready')
                 break
 
             if len(snapshots) >= SNAPSHOTS_BATCH_SAVE_SIZE * .75:
@@ -157,14 +157,14 @@ def measure_all_trials(experiment: str, max_total_time: int, pool, q) -> bool:  
                 save_snapshots()
                 continue
             else:
-                logger.info('not ready')
+                logger.debug('not ready')
         if len(snapshots) >= SNAPSHOTS_BATCH_SAVE_SIZE and not result.ready():
             save_snapshots()
 
     # If we have any snapshots left save them now.
     save_snapshots()
 
-    logger.info('measured all trials')
+    logger.debug('Measured all trials.')
     return snapshots_measured
 
 
@@ -472,12 +472,12 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
 
 
 def measure_trial_coverage(  # pylint: disable=invalid-name
-        measure_req, max_cycle: int,
-        q: multiprocessing.Queue, i) -> models.Snapshot:
+        measure_req, max_cycle: int, q: multiprocessing.Queue,
+        i) -> models.Snapshot:
     """Measure the coverage obtained by |trial_num| on |benchmark| using
     |fuzzer|."""
     initialize_logs()
-    logger.info('measuring %d', i)
+    logger.debug('Measuring %d.', i)
     min_cycle = measure_req.cycle
     # Add 1 to ensure we measure the last cycle.
     for cycle in range(min_cycle, max_cycle + 1):
@@ -496,7 +496,7 @@ def measure_trial_coverage(  # pylint: disable=invalid-name
                              'trial_id': str(measure_req.trial_id),
                              'cycle': str(cycle),
                          })
-    logger.info('done measuring %d', i)
+    logger.debug('Done measuring %d.', i)
 
 
 def measure_snapshot_coverage(fuzzer: str, benchmark: str, trial_num: int,

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -395,7 +395,6 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
         def copy_unchanged_cycles_file():
             result = gsutil.cp(exp_path.gcs(self.unchanged_cycles_path),
                                self.unchanged_cycles_path,
-                               parallel=False,
                                expect_zero=False)
             return result.retcode == 0
 

--- a/experiment/reporter.py
+++ b/experiment/reporter.py
@@ -45,8 +45,7 @@ def output_report(web_bucket, in_progress=False):
                      web_bucket,
                      gsutil_options=[
                          '-h', 'Cache-Control:public,max-age=0,no-transform'
-                     ],
-                     parallel=False)
+                     ])
         logger.debug('Done generating report.')
     except Exception:  # pylint: disable=broad-except
         logger.error('Error generating HTML report.')

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -264,11 +264,11 @@ def copy_resources_to_bucket(config_dir: str, config: Dict):
          '|^docs/')
     ]
     destination = os.path.join(base_destination, 'src')
-    gsutil.rsync(utils.ROOT_DIR, destination, options=options)
+    gsutil.rsync(utils.ROOT_DIR, destination, options=options, parallel=True)
 
     # Send config files.
     destination = os.path.join(base_destination, 'config')
-    gsutil.rsync(config_dir, destination)
+    gsutil.rsync(config_dir, destination, parallel=True)
 
 
 class BaseDispatcher:

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -229,7 +229,7 @@ class TrialRunner:  # pylint: disable=too-many-instance-attributes
                                                benchmark_fuzzer_directory,
                                                trial)
             # Clean the directory before we use it.
-            gsutil.rm(self.gcs_sync_dir, force=True)
+            gsutil.rm(self.gcs_sync_dir, force=True, parallel=True)
         else:
             self.gcs_sync_dir = None
 
@@ -376,7 +376,7 @@ class TrialRunner:  # pylint: disable=too-many-instance-attributes
         gcs_path = posixpath.join(self.gcs_sync_dir, self.corpus_dir, basename)
 
         # Don't use parallel to avoid stability issues.
-        gsutil.cp(archive, gcs_path, parallel=False)
+        gsutil.cp(archive, gcs_path)
 
         # Delete corpus archive so disk doesn't fill up.
         os.remove(archive)
@@ -399,12 +399,8 @@ class TrialRunner:  # pylint: disable=too-many-instance-attributes
         # in size because the log file containing the fuzzer's output is in this
         # directory and can be written to by the fuzzer at any time.
         results_copy = filesystem.make_dir_copy(self.results_dir)
-
-        # Don't use parallel because it causes stability issues
-        # (crbug.com/1053309).
         gsutil.rsync(results_copy,
-                     posixpath.join(self.gcs_sync_dir, self.results_dir),
-                     parallel=False)
+                     posixpath.join(self.gcs_sync_dir, self.results_dir))
 
 
 def archive_directories(directories, archive_path):

--- a/experiment/test_run_experiment.py
+++ b/experiment/test_run_experiment.py
@@ -217,6 +217,9 @@ def test_copy_resources_to_bucket():
                 ('^\\.git/|^\\.pytype/|^\\.venv/|^.*\\.pyc$|^__pycache__/|'
                  '.*~$|\\.pytest_cache/|.*/test_data/|'
                  '^third_party/oss-fuzz/out/|^docs/')
-            ])
+            ],
+            parallel=True)
         mocked_rsync.assert_any_call(
-            'config', 'gs://gsutil-bucket/experiment/input/config')
+            'config',
+            'gs://gsutil-bucket/experiment/input/config',
+            parallel=True)

--- a/experiment/test_runner.py
+++ b/experiment/test_runner.py
@@ -285,8 +285,10 @@ class TestIntegrationRunner:
 
         local_gcs_corpus_dir_copy = tmp_path / 'gcs_corpus_dir'
         os.mkdir(local_gcs_corpus_dir_copy)
-        gsutil.cp('-r', posixpath.join(gcs_corpus_directory, '*'),
-                  str(local_gcs_corpus_dir_copy))
+        gsutil.cp('-r',
+                  posixpath.join(gcs_corpus_directory, '*'),
+                  str(local_gcs_corpus_dir_copy),
+                  parallel=True)
         archive_size = os.path.getsize(local_gcs_corpus_dir_copy /
                                        'corpus-archive-0001.tar.gz')
 


### PR DESCRIPTION
Using parallel causes hangs. Use nonparallel (as we did with gsutil cat before we replaced it).
Also switch to non-parallel for copying crashes archive.
Also add more logging.
    
Fixes #296.