### PR TITLE
Add initial support for preemptible trial runners

### DIFF
--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -103,9 +103,9 @@ def create_instance(instance_name: str,
             '--machine-type=%s' % RUNNER_MACHINE_TYPE,
             '--boot-disk-size=%s' % RUNNER_BOOT_DISK_SIZE,
         ])
-        if config.get('preemptible_runners', False):
+        if config.get('preemptible_runners'):
             # TODO(metzman): Make runners signal to scheduler that they were
-            # preempted.
+            # preempted, and make scheduler+measurer tolerate preemption.
             command.append('--preemptible')
 
     if metadata:

--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -29,7 +29,6 @@ DISPATCHER_BOOT_DISK_TYPE = 'pd-ssd'
 
 # Constants for runner specs.
 RUNNER_MACHINE_TYPE = 'n1-standard-1'
-PREEMPTIBLE_RUNNER_MACHINE_TYPE = 'n1-standard-1-preemptible'
 RUNNER_BOOT_DISK_SIZE = '30GB'
 
 # Number of instances to process at once.
@@ -69,14 +68,6 @@ class InstanceType(enum.Enum):
     RUNNER = 1
 
 
-def get_runner_machine_type(config: dict) -> str:
-    """Returns the name  of the runner machine type we  should tell Google Cloud
-    to use for trials in this experiment."""
-    if not config.get('preemptible_runners', False):
-        return RUNNER_MACHINE_TYPE
-    return PREEMPTIBLE_RUNNER_MACHINE_TYPE
-
-
 def create_instance(instance_name: str,
                     instance_type: InstanceType,
                     config: dict,
@@ -109,9 +100,14 @@ def create_instance(instance_name: str,
     else:
         command.extend([
             '--no-address',
-            '--machine-type=%s' % get_runner_machine_type(config),
+            '--machine-type=%s' % RUNNER_MACHINE_TYPE,
             '--boot-disk-size=%s' % RUNNER_BOOT_DISK_SIZE,
         ])
+        if config.get('preemptible_runners', False):
+            # TODO(metzman): Make runners signal to scheduler that they were
+            # preempted.
+            command.append('--preemptible')
+
     if metadata:
         metadata_str = ','.join('{key}={value}'.format(key=key, value=value)
                                 for key, value in metadata.items())

--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -29,6 +29,7 @@ DISPATCHER_BOOT_DISK_TYPE = 'pd-ssd'
 
 # Constants for runner specs.
 RUNNER_MACHINE_TYPE = 'n1-standard-1'
+PREEMPTIBLE_RUNNER_MACHINE_TYPE = 'n1-standard-1-preemptible'
 RUNNER_BOOT_DISK_SIZE = '30GB'
 
 # Number of instances to process at once.
@@ -68,6 +69,14 @@ class InstanceType(enum.Enum):
     RUNNER = 1
 
 
+def get_runner_machine_type(config: dict) -> str:
+    """Returns the name  of the runner machine type we  should tell Google Cloud
+    to use for trials in this experiment."""
+    if not config.get('preemptible_runners', False):
+        return RUNNER_MACHINE_TYPE
+    return PREEMPTIBLE_RUNNER_MACHINE_TYPE
+
+
 def create_instance(instance_name: str,
                     instance_type: InstanceType,
                     config: dict,
@@ -100,7 +109,7 @@ def create_instance(instance_name: str,
     else:
         command.extend([
             '--no-address',
-            '--machine-type=%s' % RUNNER_MACHINE_TYPE,
+            '--machine-type=%s' % get_runner_machine_type(config),
             '--boot-disk-size=%s' % RUNNER_BOOT_DISK_SIZE,
         ])
     if metadata:

--- a/common/test_gcloud.py
+++ b/common/test_gcloud.py
@@ -89,8 +89,9 @@ def test_create_instance():
             '--boot-disk-type=pd-ssd',
         ]]
 
-def _get_expected_create_runner_command(instance_type):
-    return [
+
+def _get_expected_create_runner_command(is_preemptible):
+    command = [
         'gcloud',
         'compute',
         'instances',
@@ -101,13 +102,15 @@ def _get_expected_create_runner_command(instance_type):
         '--zone=zone-a',
         '--scopes=cloud-platform',
         '--no-address',
-        '--machine-type=%s' % instance_type,
+        '--machine-type=n1-standard-1',
         '--boot-disk-size=30GB',
-        ]
-@pytest.mark.parametrize(('preemptible_runners'),
-                         [
-                             None, False
-                         ]) # yapf: disable
+    ]
+    if is_preemptible:
+        command.append('--preemptible')
+    return command
+
+
+@pytest.mark.parametrize(('preemptible_runners'), [None, False])
 def test_create_instance_not_preemptible(preemptible_runners):
     """Tests create_instance doesn't specify preemptible when it isn't supposed
     to."""
@@ -118,8 +121,9 @@ def test_create_instance_not_preemptible(preemptible_runners):
         gcloud.create_instance(INSTANCE_NAME, gcloud.InstanceType.RUNNER,
                                config)
         assert mocked_popen.commands == [
-            _get_expected_create_runner_command('n1-standard-1')
+            _get_expected_create_runner_command(bool(preemptible_runners))
         ]
+
 
 def test_create_instance_preemptible():
     """Tests create_instance doesn't specify preemptible when it isn't supposed
@@ -130,7 +134,7 @@ def test_create_instance_preemptible():
         gcloud.create_instance(INSTANCE_NAME, gcloud.InstanceType.RUNNER,
                                config)
         assert mocked_popen.commands == [
-            _get_expected_create_runner_command('n1-standard-1-preemptible')
+            _get_expected_create_runner_command(True)
         ]
 
 


### PR DESCRIPTION
This change will use preemptible GCE instances when `preemptible_runners: true` is specified in experiment-config.yaml.
Using preemptible instances is much cheaper but comes with the following cost:
1. Trials can last only up to 24 hours (probably less if we include start up time)
2. Some trials will be preempted and thus not terminate.

This patch doesn't change parts of the scheduler that assume that it shuts down all runners. As a result if a trial is preempted the scheduler (and the measurer) will run forever. Thus the dispatcher will need to be terminated manually. For large experiments, the cost of the dispatcher running for some extra time unnecessarily is unlikely to outweigh the savings from using preemptible instances. Proper support
for preemptibles will come in a later CL.