### PR TITLE
Dont run test_measure_snapshot_coverage by default

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -16,4 +16,4 @@ jobs:
         python-version: 3.7
     - name: Run presubmit checks
       run: |
-        make presubmit
+        FUZZBENCH_TEST_INTEGRATION=1 make presubmit

--- a/common/test_filesystem.py
+++ b/common/test_filesystem.py
@@ -25,10 +25,10 @@ DESTINATION_DIR = 'dst'
 # pylint: disable=invalid-name,unused-argument
 
 
-def test_recreate_directory_existing(tmp_path):
+def test_recreate_directory_existing(fs):
     """Tests that recreate_directory recreates a directory that already
     exists."""
-    new_directory = os.path.join(tmp_path, 'new-directory')
+    new_directory = 'new-directory'
     os.mkdir(new_directory)
     new_file = os.path.join(new_directory, 'file')
     with open(new_file, 'w') as file_handle:
@@ -39,10 +39,10 @@ def test_recreate_directory_existing(tmp_path):
     assert not os.path.exists(new_file)
 
 
-def test_recreate_directory_not_existing(tmp_path):
+def test_recreate_directory_not_existing(fs):
     """Tests that recreate_directory creates a directory that does not already
     exist."""
-    new_directory = os.path.join(tmp_path, 'new-directory')
+    new_directory = 'new-directory'
     filesystem.recreate_directory(new_directory)
     assert os.path.exists(new_directory)
 

--- a/conftest.py
+++ b/conftest.py
@@ -75,7 +75,7 @@ def environ():
 @pytest.fixture
 def experiment(environ):  # pylint: disable=redefined-outer-name,unused-argument
     """Mock an experiment."""
-    os.environ['WORK'] = '/directory-not-on-host'
+    os.environ['WORK'] = '/work'
     os.environ['EXPERIMENT'] = 'test-experiment'
     os.environ['CLOUD_EXPERIMENT_BUCKET'] = 'gs://experiment-data'
     os.environ['CLOUD_WEB_BUCKET'] = 'gs://web-bucket'

--- a/conftest.py
+++ b/conftest.py
@@ -73,9 +73,9 @@ def environ():
 
 
 @pytest.fixture
-def experiment(tmp_path, environ):  # pylint: disable=redefined-outer-name,unused-argument
+def experiment(environ):  # pylint: disable=redefined-outer-name,unused-argument
     """Mock an experiment."""
-    os.environ['WORK'] = str(tmp_path)
+    os.environ['WORK'] = '/directory-not-on-host'
     os.environ['EXPERIMENT'] = 'test-experiment'
     os.environ['CLOUD_EXPERIMENT_BUCKET'] = 'gs://experiment-data'
     os.environ['CLOUD_WEB_BUCKET'] = 'gs://web-bucket'

--- a/experiment/build/test_builder.py
+++ b/experiment/build/test_builder.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 import pytest
 
+from common import utils
 from experiment.build import builder
 
 SRC_ROOT = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
@@ -65,9 +66,10 @@ def get_benchmarks_or_fuzzers(benchmarks_or_fuzzers_directory, filename,
 @mock.patch('time.sleep')
 @pytest.mark.parametrize('build_measurer_return_value', [True, False])
 def test_build_all_measurers(_, mocked_build_measurer,
-                             build_measurer_return_value, experiment):
+                             build_measurer_return_value, experiment, fs):
     """Tests that build_all_measurers works as intendend when build_measurer
     calls fail."""
+    fs.add_real_directory(utils.ROOT_DIR)
     mocked_build_measurer.return_value = build_measurer_return_value
     benchmarks = get_regular_benchmarks()
     result = builder.build_all_measurers(benchmarks)

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -298,6 +298,8 @@ def create_measurer(experiment):
 class TestIntegrationMeasurement:
     """Integration tests for measurement."""
 
+    @pytest.mark.skipif(not os.getenv('FUZZBENCH_TEST_INTEGRATION'),
+                        reason='Not running integration tests.')
     @mock.patch('experiment.measurer.SnapshotMeasurer.is_cycle_unchanged')
     def test_measure_snapshot_coverage(  # pylint: disable=too-many-locals
             self, mocked_is_cycle_unchanged, create_measurer, db, experiment):

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -286,6 +286,8 @@ def get_test_data_path(*subpaths):
 class TestIntegrationMeasurement:
     """Integration tests for measurement."""
 
+    # TODO(metzman): Get this test working everywhere by using docker or a more
+    # portable binary.
     @pytest.mark.skipif(not os.getenv('FUZZBENCH_TEST_INTEGRATION'),
                         reason='Not running integration tests.')
     @mock.patch('experiment.measurer.SnapshotMeasurer.is_cycle_unchanged')

--- a/experiment/test_run_coverage.py
+++ b/experiment/test_run_coverage.py
@@ -31,14 +31,14 @@ def _get_test_data_dir(directory):
 
 
 def _make_crashes_dir(parent_path):
-    """Makes a crashes dir in |tmp_path| and returns it."""
+    """Makes a crashes dir in |parent_path| and returns it."""
     crashes_dir = os.path.join(str(parent_path), 'crashes')
     os.mkdir(crashes_dir)
     return crashes_dir
 
 
 def _make_sancov_dir(parent_path):
-    """Makes a sancov dir in |tmp_path| and returns it."""
+    """Makes a sancov dir in |parent_path| and returns it."""
     sancov_dir = os.path.join(str(parent_path), 'sancov')
     os.mkdir(sancov_dir)
     return sancov_dir

--- a/experiment/test_runner.py
+++ b/experiment/test_runner.py
@@ -298,10 +298,10 @@ class TestIntegrationRunner:
         mocked_error.assert_not_called()
 
 
-def test_clean_seed_corpus(tmp_path, fs):
+def test_clean_seed_corpus(fs):
     """Test that seed corpus files are moved to root directory and deletes files
     exceeding 1 MB limit."""
-    seed_corpus_dir = tmp_path / 'seeds'
+    seed_corpus_dir = '/seeds'
     fs.create_dir(seed_corpus_dir)
 
     fs.create_file(os.path.join(seed_corpus_dir, 'a', 'abc'), contents='abc')


### PR DESCRIPTION
The test relies on a binary that may not run on everyone's machine.
Run it in CI though.
Fixes #308.

Also, avoid using tmp_path with fakefs. Change the experiment
fixture to not use tmp_path. Combining the two causes weird errors.