### PR TITLE
Preserve gsutil rsync and cp with file permissions.

### DIFF
--- a/common/gsutil.py
+++ b/common/gsutil.py
@@ -30,7 +30,7 @@ def gsutil_command(arguments, *args, parallel=False, **kwargs):
 def cp(*cp_arguments, **kwargs):  # pylint: disable=invalid-name
     """Executes gsutil's "cp" command with |cp_arguments| and returns the
     returncode and the output."""
-    command = ['cp']
+    command = ['cp', '-P']
     command.extend(cp_arguments)
     return gsutil_command(command, **kwargs)
 
@@ -72,6 +72,7 @@ def rsync(  # pylint: disable=too-many-arguments
     if provided."""
     command = [] if gsutil_options is None else gsutil_options
     command.append('rsync')
+    command.append('-P')
     if delete:
         command.append('-d')
     if recursive:

--- a/common/test_gsutil.py
+++ b/common/test_gsutil.py
@@ -40,7 +40,7 @@ class TestGsutilRsync:
                 'common.gsutil.gsutil_command') as mocked_gsutil_command:
             gsutil.rsync(self.SRC, self.DST)
         mocked_gsutil_command.assert_called_with(
-            ['rsync', '-d', '-r', '/src', 'gs://dst'])
+            ['rsync', '-P', '-d', '-r', '/src', 'gs://dst'])
 
     def test_gsutil_options(self):
         """Tests that rsync works as intended when supplied a gsutil_options

--- a/experiment/test_reporter.py
+++ b/experiment/test_reporter.py
@@ -33,7 +33,8 @@ def test_output_report_bucket(fs, experiment):
             reports_dir = os.path.join(os.environ['WORK'], 'reports')
             assert mocked_popen.commands == [[
                 'gsutil', '-h', 'Cache-Control:public,max-age=0,no-transform',
-                'rsync', '-d', '-r', reports_dir, 'gs://web-bucket/experiment'
+                'rsync', '-P', '-d', '-r', reports_dir,
+                'gs://web-bucket/experiment'
             ]]
             mocked_generate_report.assert_called_with(
                 [os.environ['EXPERIMENT']], reports_dir, in_progress=False)

--- a/experiment/test_runner.py
+++ b/experiment/test_runner.py
@@ -95,7 +95,7 @@ def test_save_corpus_archive(_, trial_runner, fs):
     with test_utils.mock_popen_ctx_mgr() as mocked_popen:
         trial_runner.save_corpus_archive(archive_name)
         assert mocked_popen.commands == [[
-            'gsutil', 'cp', archive_name,
+            'gsutil', 'cp', '-P', archive_name,
             posixpath.join(
                 'gs://bucket/experiment-name/experiment-folders/'
                 'benchmark-1-fuzzer-name-a/trial-1/corpus', archive_name)
@@ -123,7 +123,7 @@ def test_do_sync_unchanged(mocked_is_corpus_dir_same, mocked_debug,
     with test_utils.mock_popen_ctx_mgr() as mocked_popen:
         trial_runner.do_sync()
         assert mocked_popen.commands == [[
-            'gsutil', 'rsync', '-d', '-r', 'results-copy',
+            'gsutil', 'rsync', '-P', '-d', '-r', 'results-copy',
             ('gs://bucket/experiment-name/experiment-folders/'
              'benchmark-1-fuzzer-name-a/trial-1/results')
         ]]
@@ -149,13 +149,13 @@ def test_do_sync_changed(mocked_execute, mocked_is_corpus_dir_same, fs,
     trial_runner.do_sync()
     assert mocked_execute.call_args_list == [
         mock.call([
-            'gsutil', 'cp', 'corpus-archives/corpus-archive-1337.tar.gz',
+            'gsutil', 'cp', '-P', 'corpus-archives/corpus-archive-1337.tar.gz',
             ('gs://bucket/experiment-name/experiment-folders/'
              'benchmark-1-fuzzer-name-a/trial-1/corpus/'
              'corpus-archive-1337.tar.gz')
         ]),
         mock.call([
-            'gsutil', 'rsync', '-d', '-r', 'results-copy',
+            'gsutil', 'rsync', '-P', '-d', '-r', 'results-copy',
             ('gs://bucket/experiment-name/experiment-folders/'
              'benchmark-1-fuzzer-name-a/trial-1/results')
         ])


### PR DESCRIPTION
This is needed when source is copied from local to gcs when running
an experiment.

Fixes #316