### PR TITLE
Add option to drop trials when generating reports

### DIFF
--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -96,10 +96,9 @@ def filter_max_time(experiment_df, max_time):
     return experiment_df[experiment_df['time'] <= max_time]
 
 
-def filter_fuzzer_benchmark_max_trials(experiment_df, max_trials):
+def drop_fuzzer_benchmark_trials_above_max(experiment_df, max_trials):
     """Returns the table without snapshots from trials of a fuzzer-benchmark
     that is greater than |max_trials|."""
-
     # For each fuzzer-benchmark store the set of trials we will include in the
     # result.
     trials = collections.defaultdict(set)

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -158,7 +158,7 @@ def generate_report(experiment_names,
             experiment_df, experiment_names)
 
     if max_num_trials is not None:
-        experiment_df = data_utils.filter_fuzzer_benchmark_max_trials(
+        experiment_df = data_utils.drop_fuzzer_benchmark_trials_above_max(
             experiment_df, max_num_trials)
 
     fuzzer_names = experiment_df.fuzzer.unique()

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -65,6 +65,15 @@ def get_arg_parser():
         type=int,
         help=('The last time (in seconds) during an experiment to include in '
               'the report.'))
+
+    parser.add_argument(
+        '-x',
+        '--max-num-trials',
+        default=None,
+        type=int,
+        help=('The maximum number of trials per fuzzer-benchmark to include in '
+              'the report. Useful if you want to join experiments that used '
+              'different numbers of trials.'))
     parser.add_argument('-f',
                         '--fuzzers',
                         nargs='*',
@@ -115,7 +124,8 @@ def generate_report(experiment_names,
                     from_cached_data=False,
                     in_progress=False,
                     end_time=None,
-                    merge_with_clobber=False):
+                    merge_with_clobber=False,
+                    max_num_trials=None):
     """Generate report helper."""
     report_name = report_name or experiment_names[0]
 
@@ -147,6 +157,10 @@ def generate_report(experiment_names,
         experiment_df = data_utils.clobber_experiments_data(
             experiment_df, experiment_names)
 
+    if max_num_trials is not None:
+        experiment_df = data_utils.filter_fuzzer_benchmark_max_trials(
+            experiment_df, max_num_trials)
+
     fuzzer_names = experiment_df.fuzzer.unique()
     plotter = plotting.Plotter(fuzzer_names, quick)
     experiment_ctx = experiment_results.ExperimentResults(
@@ -177,7 +191,8 @@ def main():
                     quick=args.quick,
                     from_cached_data=args.from_cached_data,
                     end_time=args.end_time,
-                    merge_with_clobber=args.merge_with_clobber)
+                    merge_with_clobber=args.merge_with_clobber,
+                    max_num_trials=args.max_num_trials)
 
 
 if __name__ == '__main__':

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -71,12 +71,12 @@ def test_drop_fuzzer_benchmark_trials_above_max():
         ['libpng', 'libfuzzer'],
         ['libxml', 'afl'],
         ['libxml', 'libfuzzer'],
-    ], columns=columns)
-    trials_per_fuzzer_benchmark = (
-        new_experiment_df[['benchmark', 'fuzzer', 'trial_id']].drop_duplicates()
-    )[columns]
-    assert (trials_per_fuzzer_benchmark.values ==
-            expected_result.values).all()
+    ],
+                                   columns=columns)
+    trials_per_fuzzer_benchmark = (new_experiment_df[[
+        'benchmark', 'fuzzer', 'trial_id'
+    ]].drop_duplicates())[columns]
+    assert (trials_per_fuzzer_benchmark.values == expected_result.values).all()
 
 
 def test_validate_data_missing_columns():

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -56,6 +56,29 @@ def test_validate_data_empty():
         data_utils.validate_data(experiment_df)
 
 
+def test_drop_fuzzer_benchmark_trials_above_max():
+    """Tests that drop_fuzzer_benchmark_trials_above_max drops trials for a
+    fuzzer-benchmark if they are beyond the maximum number of trials per
+    fuzzer-benchmark that we specify."""
+    experiment_df = create_experiment_data()
+    new_experiment_df = data_utils.drop_fuzzer_benchmark_trials_above_max(
+        experiment_df, 1)
+    # Sanity check test.
+    assert len(new_experiment_df) < len(experiment_df)
+    columns = ['benchmark', 'fuzzer']
+    expected_result = pd.DataFrame([
+        ['libpng', 'afl'],
+        ['libpng', 'libfuzzer'],
+        ['libxml', 'afl'],
+        ['libxml', 'libfuzzer'],
+    ], columns=columns)
+    trials_per_fuzzer_benchmark = (
+        new_experiment_df[['benchmark', 'fuzzer', 'trial_id']].drop_duplicates()
+    )[columns]
+    assert (trials_per_fuzzer_benchmark.values ==
+            expected_result.values).all()
+
+
 def test_validate_data_missing_columns():
     experiment_df = create_experiment_data()
     experiment_df.drop(columns=['trial_id', 'time'], inplace=True)
@@ -63,7 +86,7 @@ def test_validate_data_missing_columns():
         data_utils.validate_data(experiment_df)
 
 
-def test_drop_uniteresting_columns():
+def test_drop_uninteresting_columns():
     experiment_df = create_experiment_data()
     cleaned_df = data_utils.drop_uninteresting_columns(experiment_df)
 


### PR DESCRIPTION
This is useful when combining experiments that used different numbers of trials.