### PR TITLE
Add option for log scale coverage growth plot.

### DIFF
--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -54,6 +54,11 @@ def get_arg_parser():
         default=False,
         help='If set, plots are created faster, but contain less details.')
     parser.add_argument(
+        '--log-scale',
+        action='store_true',
+        default=False,
+        help='If set, the time axis of the coverage growth plot is log scale.')
+    parser.add_argument(
         '-b',
         '--benchmarks',
         nargs='*',
@@ -112,6 +117,7 @@ def generate_report(experiment_names,
                     fuzzers=None,
                     report_type='default',
                     quick=False,
+                    log_scale=False,
                     from_cached_data=False,
                     in_progress=False,
                     end_time=None,
@@ -148,7 +154,7 @@ def generate_report(experiment_names,
             experiment_df, experiment_names)
 
     fuzzer_names = experiment_df.fuzzer.unique()
-    plotter = plotting.Plotter(fuzzer_names, quick)
+    plotter = plotting.Plotter(fuzzer_names, quick, log_scale)
     experiment_ctx = experiment_results.ExperimentResults(
         experiment_df, report_directory, plotter, experiment_name=report_name)
 
@@ -175,6 +181,7 @@ def main():
                     fuzzers=args.fuzzers,
                     report_type=args.report_type,
                     quick=args.quick,
+                    log_scale=args.log_scale,
                     from_cached_data=args.from_cached_data,
                     end_time=args.end_time,
                     merge_with_clobber=args.merge_with_clobber)

--- a/common/experiment_utils.py
+++ b/common/experiment_utils.py
@@ -18,13 +18,13 @@ import posixpath
 
 from common import environment
 
-_DEFAULT_SNAPSHOT_SECONDS = 15 * 60  # Seconds.
+DEFAULT_SNAPSHOT_SECONDS = 15 * 60  # Seconds.
 
 
 def get_snapshot_seconds():
     """Returns the amount of time in seconds between snapshots of a
     fuzzer's corpus during an experiment."""
-    return environment.get('SNAPSHOT_PERIOD', _DEFAULT_SNAPSHOT_SECONDS)
+    return environment.get('SNAPSHOT_PERIOD', DEFAULT_SNAPSHOT_SECONDS)
 
 
 def get_work_dir():


### PR DESCRIPTION
Example:

Linear:
![image](https://user-images.githubusercontent.com/1070168/81753055-f1b33600-9480-11ea-8175-718d0e5705b7.png)

Log scale:
![image](https://user-images.githubusercontent.com/1070168/81752437-72713280-947f-11ea-84b6-e5050d49d56b.png)
