### PR TITLE
Small plotting fixes.

### DIFF
--- a/analysis/plotting.py
+++ b/analysis/plotting.py
@@ -22,7 +22,6 @@ import seaborn as sns
 from analysis import data_utils
 from common import experiment_utils
 
-_DEFAULT_SPINE_OFFSET = 10
 _DEFAULT_TICKS_COUNT = 12
 _DEFAULT_LABEL_ROTATION = 30
 
@@ -157,7 +156,7 @@ class Plotter:
         axes.set_xticks(ticks)
         axes.set_xticklabels([_formatted_hour_min(t) for t in ticks])
 
-        sns.despine(ax=axes, offset=_DEFAULT_SPINE_OFFSET, trim=True)
+        sns.despine(ax=axes, trim=True)
 
     def write_coverage_growth_plot(self, benchmark_df, image_path, wide=False):
         """Writes coverage growth plot."""
@@ -193,10 +192,11 @@ class Plotter:
         axes.set_title(_formatted_title(benchmark_snapshot_df))
         axes.set(ylabel='Reached edge coverage')
         axes.set(xlabel='Fuzzer (highest median coverage on the left)')
-        plt.xticks(rotation=_DEFAULT_LABEL_ROTATION,
-                   horizontalalignment='right')
+        axes.set_xticklabels(axes.get_xticklabels(),
+                             rotation=_DEFAULT_LABEL_ROTATION,
+                             horizontalalignment='right')
 
-        sns.despine(ax=axes, offset=_DEFAULT_SPINE_OFFSET, trim=True)
+        sns.despine(ax=axes, trim=True)
 
     def write_violin_plot(self, benchmark_snapshot_df, image_path):
         """Writes violin plot."""
@@ -228,8 +228,9 @@ class Plotter:
 
         axes.set(xlabel='Edge coverage')
         axes.set(ylabel='Density')
-        plt.xticks(rotation=_DEFAULT_LABEL_ROTATION,
-                   horizontalalignment='right')
+        axes.set_xticklabels(axes.get_xticklabels(),
+                             rotation=_DEFAULT_LABEL_ROTATION,
+                             horizontalalignment='right')
 
     def write_distribution_plot(self, benchmark_snapshot_df, image_path):
         """Writes distribution plot."""
@@ -259,11 +260,11 @@ class Plotter:
         axes.set_title(_formatted_title(benchmark_snapshot_df))
         axes.set(ylabel='Reached edge coverage')
         axes.set(xlabel='Fuzzer (highest median coverage on the left)')
+        axes.set_xticklabels(axes.get_xticklabels(),
+                             rotation=_DEFAULT_LABEL_ROTATION,
+                             horizontalalignment='right')
 
-        plt.xticks(rotation=_DEFAULT_LABEL_ROTATION,
-                   horizontalalignment='right')
-
-        sns.despine(ax=axes, offset=_DEFAULT_SPINE_OFFSET, trim=True)
+        sns.despine(ax=axes, trim=True)
 
     def write_ranking_plot(self, benchmark_snapshot_df, image_path):
         """Writes ranking plot."""
@@ -286,8 +287,9 @@ class Plotter:
         axes.set(ylabel='If green, then fuzzer in the row')
         xlabel = 'is statistically significantly better than fuzzer in column.'
         axes.set(xlabel=xlabel)
-        plt.xticks(rotation=_DEFAULT_LABEL_ROTATION,
-                   horizontalalignment='right')
+        axes.set_xticklabels(axes.get_xticklabels(),
+                             rotation=_DEFAULT_LABEL_ROTATION,
+                             horizontalalignment='right')
 
     def write_better_than_plot(self, better_than_table, image_path):
         """Writes better than plot."""


### PR DESCRIPTION
- Avoid using `plt.xticks()`, which relies on global state. Instead, set tick
  labels directly on the `axes` object.
- Remove unnecessary spine offset (having an offset has no use and only causing
  issues).