### PR TITLE
Add basic support for variants to local builds.

### DIFF
--- a/docker/build.mk
+++ b/docker/build.mk
@@ -18,7 +18,6 @@ OSS_FUZZ_BENCHMARKS := $(notdir $(shell find benchmarks -type f -name oss-fuzz.y
 
 BASE_TAG ?= gcr.io/fuzzbench
 
-
 build-all: $(addsuffix -all, $(addprefix build-,$(FUZZERS)))
 pull-all: $(addsuffix -all, $(addprefix pull-,$(FUZZERS)))
 
@@ -97,6 +96,7 @@ define fuzzer_benchmark_template
     --build-arg fuzzer=$(1) \
     --build-arg benchmark=$(2) \
     $(call cache_from,${BASE_TAG}/builders/$(1)/$(2)) \
+    $(shell python3 docker/get_docker_args.py $1) \
     --file docker/benchmark-builder/Dockerfile \
     .
 

--- a/docker/build.mk
+++ b/docker/build.mk
@@ -18,6 +18,7 @@ OSS_FUZZ_BENCHMARKS := $(notdir $(shell find benchmarks -type f -name oss-fuzz.y
 
 BASE_TAG ?= gcr.io/fuzzbench
 
+
 build-all: $(addsuffix -all, $(addprefix build-,$(FUZZERS)))
 pull-all: $(addsuffix -all, $(addprefix pull-,$(FUZZERS)))
 

--- a/docker/get_docker_args.py
+++ b/docker/get_docker_args.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper script to get docker arguments for local building."""
+
+import os
+import sys
+import yaml
+
+FUZZERS_DIR = os.path.join(os.path.dirname(__file__), os.path.pardir, 'fuzzers')
+
+
+def print_build_arguments(variants, variant_name):
+    """Print the build arguments for the variant named |variant_name|."""
+    for variant in variants:
+        if variant['name'] != variant_name:
+            continue
+        if 'build_arguments' in variant:
+            print(' '.join(variant['build_arguments']))
+        return
+
+
+def main(argv):
+    if 'VARIANT_NAME' not in os.environ:
+        return
+
+    variants_path = os.path.join(FUZZERS_DIR, argv[1], 'variants.yaml')
+    if not os.path.exists(variants_path):
+        return
+
+    with open(variants_path) as file_handle:
+        config = yaml.load(file_handle, yaml.SafeLoader)
+        assert 'variants' in config
+        print_build_arguments(config['variants'], os.environ['VARIANT_NAME'])
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/docker/get_docker_args.py
+++ b/docker/get_docker_args.py
@@ -31,6 +31,7 @@ def print_build_arguments(variants, variant_name):
 
 
 def main(argv):
+    """Script main function."""
     if 'VARIANT_NAME' not in os.environ:
         return
 


### PR DESCRIPTION
This change adds very basic support for variants to make by appending the output from a new script to the docker arguments for the builder. The script parses the appropriate fuzzer's variants.yaml file for one with a name matching a VARIANT_NAME environment variable. This will be documented in a later change.

Let me know if you have any concerns with the general approach. If it looks good it should be easy to add support for this to local experiments as well.