### PR TITLE
Add pull-clang as depdendency of base-builder.

### DIFF
--- a/docker/build.mk
+++ b/docker/build.mk
@@ -39,15 +39,15 @@ base-image:
 pull-base-image:
 	docker pull $(BASE_TAG)/base-image
 
-base-builder: base-image
+pull-base-clang:
+	docker pull gcr.io/oss-fuzz-base/base-clang
+
+base-builder: base-image pull-base-clang
 	docker build \
     --tag $(BASE_TAG)/base-builder \
     $(call cache_from_base,${BASE_TAG}/base-builder) \
     $(call cache_from_base,gcr.io/oss-fuzz-base/base-clang) \
     docker/base-builder
-
-pull-base-clang:
-	docker pull gcr.io/oss-fuzz-base/base-clang
 
 pull-base-builder: pull-base-image pull-base-clang
 	docker pull $(BASE_TAG)/base-builder


### PR DESCRIPTION
Otherwise, a stale clang might be used that is different from the one
used in CI and in experiments.