### PR TITLE
Add experimental report type.

### DIFF
--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -39,7 +39,7 @@ def get_arg_parser():
     parser.add_argument(
         '-t',
         '--report-type',
-        choices=['default'],
+        choices=['default', 'experimental'],
         default='default',
         help='Type of the report (which template to use). Default: default.')
     parser.add_argument(

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -64,6 +64,9 @@
 
         <div id="summary" class="section scrollspy">
             <h2 class="green-text text-darken-3">experiment summary</h2>
+
+            {% block top_level_ranking %}
+
             {% if experiment.rank_by_mean_and_average_rank.size < 2 %}
             No ranking as the available data is only for a single fuzzer.
 
@@ -100,6 +103,8 @@
             So please check the list of supported benchmarks for the fuzzer(s) of your interest.
             The list could be specified in the fuzzer's README.md like
             <a href="https://github.com/google/fuzzbench/blob/master/fuzzers/aflsmart/README.md">this</a>.
+
+            {% endblock %}
 
             <ul class="collapsible">
                 <li>

--- a/analysis/report_templates/experimental.html
+++ b/analysis/report_templates/experimental.html
@@ -1,0 +1,37 @@
+{% extends "default.html" %}
+
+{% block top_level_ranking %}
+
+<h5>Rank by median on benchmarks, then by average rank (Critical difference)</h5>
+{{ super() }}
+
+<h5>Rank by pair-wise statistical test wins on benchmarks, then by average rank</h5>
+<div class="row">
+    <div class="col s7 offset-s3">
+        {{ experiment.rank_by_stat_test_wins_and_average_rank.to_frame().to_html() }}
+    </div>
+</div>
+
+<h5>Rank by median on benchmarks, then by avereage normalized score</h5>
+<div class="row">
+    <div class="col s7 offset-s3">
+        {{ experiment.rank_by_median_and_average_normalized_score.to_frame().to_html() }}
+    </div>
+</div>
+
+<h5>Rank by average rank on benchmarks, then by avereage rank</h5>
+<div class="row">
+    <div class="col s7 offset-s3">
+        {{ experiment.rank_by_average_rank_and_average_rank.to_frame().to_html() }}
+    </div>
+</div>
+
+<h5>Rank by median on benchmarks, then by nubmer of wins</h5>
+<div class="row">
+    <div class="col s7 offset-s3">
+        {{ experiment.rank_by_median_and_number_of_firsts.to_frame().to_html() }}
+    </div>
+</div>
+
+{% endblock %}
+

--- a/analysis/report_templates/experimental.html
+++ b/analysis/report_templates/experimental.html
@@ -1,3 +1,19 @@
+<!--
+     Copyright 2020 Google LLC
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
 {% extends "default.html" %}
 
 {% block top_level_ranking %}

--- a/docs/developing-fuzzbench/custom_analysis_and_reports.md
+++ b/docs/developing-fuzzbench/custom_analysis_and_reports.md
@@ -48,8 +48,14 @@ PYTHONPATH=<fuzzbench_root> python3 analysis/generate_report.py \
 You can find the link to the raw data file at the bottom of each [previously
 published report](https://www.fuzzbench.com/reports/index.html).
 
-You can also create a custom report using a template of your own (see
-`--report_type` option). See all command line options with:
+You can generate different types of reports (see available
+[templates](https://github.com/google/fuzzbench/tree/master/analysis/report_templates)).
+For example, to generate a more detailed report with more analysis results
+(i.e., multiple ranking methods and statistical tests), use the `--report_type
+experimental` flag. We also encourage you to add your own templates and report
+types to the library.
+
+Check out the rest of the command line options of the tool with:
 
 ```bash
 PYTHONPATH=<fuzzbench_root> python3 analysis/generate_report.py --help


### PR DESCRIPTION
This contains multiple different top level ranking results.

Fixes https://github.com/google/fuzzbench/issues/267, and can be extended later with more analysis results.