### PR TITLE
Show two types of aggregate rankings in default report.

### DIFF
--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -65,31 +65,62 @@
         <div id="summary" class="section scrollspy">
             <h2 class="green-text text-darken-3">experiment summary</h2>
 
+            {% if experiment.rank_by_median_and_average_rank.size < 2 %}
+
+            No aggregate ranking as the data contains a single fuzzer.
+
+            {% elif experiment.benchmarks|length < 2 %}
+
+            No aggregate ranking as the data contains a single benchmark.
+
+            {% else %}
+
             {% block top_level_ranking %}
 
-            {% if experiment.rank_by_mean_and_average_rank.size < 2 %}
-            No ranking as the available data is only for a single fuzzer.
+            We show two different aggreage (cross-benchmark) ranking of fuzzers.
+            The first is based on the average of per-benchmarks scores, where
+            the score represents the percentage of the highest reached median
+            coverage on a given benchmark (higher value is better).
 
-            {% elif experiment.rank_by_mean_and_average_rank.size > 20 %}
-            Showing cross-benchmark ranking as a table, because the critical
-            difference plot currently only supports up to 20 fuzzers. The table
-            shows the average rank (lower better) of fuzzers after ranking them
-            on each benchmark according to the median reached coverages.
+            The second ranking shows the average rank of fuzzers, after we rank
+            them on each benchmark according to their median reached covereges
+            (lower value is better).
+
             <div class="row">
-                <div class="col s7 offset-s3">
-                    {{ experiment.rank_by_mean_and_average_rank.to_frame().to_html() }}
+                <div class="col s5 offset-s1">
+                    <h5 class="center-align">By avg. score</h5>
+                    {{ experiment.rank_by_median_and_average_normalized_score.to_frame().to_html() }}
+                </div>
+                <div class="col s5">
+                    <h5 class="center-align">By avg. rank</h5>
+                    {{ experiment.rank_by_median_and_average_rank.to_frame().to_html() }}
                 </div>
             </div>
 
-            {% elif experiment.benchmarks|length < 2 %}
-            No cross-benchmark ranking as the available data is only for a single benchmark.
+            <ul class="collapsible">
+                <li>
+                    <div class="collapsible-header">
+                        Critical difference diagram
+                    </div>
+                    <div class="collapsible-body">
+
+
+            {% if experiment.rank_by_median_and_average_rank.size > 20 %}
+
+            Too many fuzzers to render the diagram. The critical difference plot
+            currently only supports up to 20 fuzzers.
 
             {% else %}
-            Aggregate critical difference diagram showing average ranks when
-            ranking fuzzers on each benchmark according to their median reached
-            coverages. Critical difference is based on Friedman/Nemenyi post-hoc
-            test. See more in the <a href="https://google.github.io/fuzzbench/reference/report/">
-            documentation</a>.<br>
+
+            The diagram visualizes the second ranking while showing the
+            significance of the differences as well. What is considered a
+            "critical difference" (CD) is based on the Friedman/Nemenyi
+            post-hoc test. See more in the
+            <a href="https://google.github.io/fuzzbench/reference/report/">
+            documentation</a>.
+
+            <br>
+
             <div class="row">
                 <div class="col s7 offset-s3">
                     <img class="responsive-img materialboxed"
@@ -97,14 +128,21 @@
                 </div>
             </div>
 
-            {% endif %}
-            Note: If a fuzzer does not support all benchmarks,
-            its ranking as shown in this diagram can be lower than it should be.
-            So please check the list of supported benchmarks for the fuzzer(s) of your interest.
+            Note: If a fuzzer does not support all benchmarks, its ranking as
+            shown in this diagram can be lower than it should be. So please
+            check the list of supported benchmarks for the fuzzer(s) of your interest.
             The list could be specified in the fuzzer's README.md like
             <a href="https://github.com/google/fuzzbench/blob/master/fuzzers/aflsmart/README.md">this</a>.
 
-            {% endblock %}
+            {% endif %} {# show critical difference diagram #}
+
+                    </div>
+                </li>
+            </ul>
+
+            {% endblock %} {# top_level_ranking #}
+
+            {% endif %} {# data is available for top level ranking #}
 
             <ul class="collapsible">
                 <li>

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -112,11 +112,11 @@
 
             {% else %}
 
-            The diagram visualizes the second ranking while showing the
-            significance of the differences as well. What is considered a
-            "critical difference" (CD) is based on the Friedman/Nemenyi
-            post-hoc test. See more in the
-            <a href="https://google.github.io/fuzzbench/reference/report/">
+            The diagram visualizes the average rank of fuzzers (second ranking
+            above) while showing the significance of the differences as well.
+            What is considered a "critical difference" (CD) is based on the
+            Friedman/Nemenyi post-hoc test. See more in the <a
+            href="https://google.github.io/fuzzbench/reference/report/">
             documentation</a>.
 
             <br>

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -89,11 +89,11 @@
             <div class="row">
                 <div class="col s5 offset-s1">
                     <h5 class="center-align">By avg. score</h5>
-                    {{ experiment.rank_by_median_and_average_normalized_score.to_frame().to_html() }}
+                    {{ experiment.rank_by_median_and_average_normalized_score.round(2).to_frame().to_html() }}
                 </div>
                 <div class="col s5">
                     <h5 class="center-align">By avg. rank</h5>
-                    {{ experiment.rank_by_median_and_average_rank.to_frame().to_html() }}
+                    {{ experiment.rank_by_median_and_average_rank.round(2).to_frame().to_html() }}
                 </div>
             </div>
 

--- a/analysis/report_templates/experimental.html
+++ b/analysis/report_templates/experimental.html
@@ -18,7 +18,7 @@
 
 {% block top_level_ranking %}
 
-<h5>Rank by median on benchmarks, then by avereage normalized score</h5>
+<h5>Rank by median on benchmarks, then by average normalized score</h5>
 <div class="row">
     <div class="col s7 offset-s3">
         {{ experiment.rank_by_median_and_average_normalized_score.to_frame().to_html() }}
@@ -32,21 +32,14 @@
     </div>
 </div>
 
-<h5>Rank by mean on benchmarks, then by average rank</h5>
-<div class="row">
-    <div class="col s7 offset-s3">
-        {{ experiment.rank_by_mean_and_average_rank.to_frame().to_html() }}
-    </div>
-</div>
-
-<h5>Rank by pair-wise statistical test wins on benchmarks, then by average rank</h5>
+<h5>Rank by pairwise statistical test wins on benchmarks, then by average rank</h5>
 <div class="row">
     <div class="col s7 offset-s3">
         {{ experiment.rank_by_stat_test_wins_and_average_rank.to_frame().to_html() }}
     </div>
 </div>
 
-<h5>Rank by average rank on benchmarks, then by avereage rank</h5>
+<h5>Rank by average rank on benchmarks, then by average rank</h5>
 <div class="row">
     <div class="col s7 offset-s3">
         {{ experiment.rank_by_average_rank_and_average_rank.to_frame().to_html() }}

--- a/analysis/report_templates/experimental.html
+++ b/analysis/report_templates/experimental.html
@@ -18,20 +18,31 @@
 
 {% block top_level_ranking %}
 
-<h5>Rank by median on benchmarks, then by average rank (Critical difference)</h5>
-{{ super() }}
+<h5>Rank by median on benchmarks, then by avereage normalized score</h5>
+<div class="row">
+    <div class="col s7 offset-s3">
+        {{ experiment.rank_by_median_and_average_normalized_score.to_frame().to_html() }}
+    </div>
+</div>
+
+<h5>Rank by median on benchmarks, then by average rank</h5>
+<div class="row">
+    <div class="col s7 offset-s3">
+        {{ experiment.rank_by_median_and_average_rank.to_frame().to_html() }}
+    </div>
+</div>
+
+<h5>Rank by mean on benchmarks, then by average rank</h5>
+<div class="row">
+    <div class="col s7 offset-s3">
+        {{ experiment.rank_by_mean_and_average_rank.to_frame().to_html() }}
+    </div>
+</div>
 
 <h5>Rank by pair-wise statistical test wins on benchmarks, then by average rank</h5>
 <div class="row">
     <div class="col s7 offset-s3">
         {{ experiment.rank_by_stat_test_wins_and_average_rank.to_frame().to_html() }}
-    </div>
-</div>
-
-<h5>Rank by median on benchmarks, then by avereage normalized score</h5>
-<div class="row">
-    <div class="col s7 offset-s3">
-        {{ experiment.rank_by_median_and_average_normalized_score.to_frame().to_html() }}
     </div>
 </div>
 


### PR DESCRIPTION
- Show ranking based on average normalized score.
- Show ranking based on average rank (previous default).
- Show critical difference diagram in a collapsible.
- Clean up pre-conditions for showing aggregate ranking.
- Experimental report shows all 6 types of aggregate ranking.

Fixes https://github.com/google/fuzzbench/issues/366.