### PR TITLE
[scheduler] Scale measurers horizontally using queue-based arch

### DIFF
--- a/common/gce.py
+++ b/common/gce.py
@@ -100,13 +100,14 @@ def get_instance_group_size(instance_group: str, project: str,
     return request.execute()['targetSize']
 
 
-def resize_instance_group(instance_group, size, project, zone):
+def resize_instance_group(size, instance_group, project, zone):
     """Changes the number of instances running in |instance_group| to |size|."""
     assert size >= 1
     managers = thread_local.service.instanceGroupManagers()
-    request = managers.get(instanceGroupManager=instance_group,
-                           project=project,
-                           zone=zone)
+    request = managers.resize(instanceGroupManager=instance_group,
+                              size=size,
+                              project=project,
+                              zone=zone)
     return request.execute()
 
 
@@ -116,4 +117,22 @@ def delete_instance_group(instance_group, project, zone):
     request = managers.delete(instanceGroupManager=instance_group,
                               zone=zone,
                               project=project)
+    return request.execute()
+
+
+def create_instance_group(name: str, instance_template_url: str,
+                          experiment: str, project: str, zone: str):
+    """Creates an instance group named |name| from the template specified by
+    |instance_template_url|."""
+    managers = thread_local.service.instanceGroupManagers()
+    target_size = 1  # !!!
+    base_instance_name = 'w-' + experiment
+
+    body = {
+        'baseInstanceName': base_instance_name,
+        'targetSize': target_size,
+        'name': name,
+        'instanceTemplate': instance_template_url
+    }
+    request = managers.insert(body=body, project=project, zone=zone)
     return request.execute()

--- a/common/gce.py
+++ b/common/gce.py
@@ -90,10 +90,15 @@ def get_instance_from_preempted_operation(operation, base_target_link) -> str:
     return operation['targetLink'][len(base_target_link):]
 
 
+def get_instance_group_managers():
+    """Returns the instance group managers resource."""
+    return thread_local.service.instanceGroupManagers()
+
+
 def get_instance_group_size(instance_group: str, project: str,
                             zone: str) -> int:
     """Returns the number of instances running in |instance_group|."""
-    managers = thread_local.service.instanceGroupManagers()
+    managers = get_instance_group_managers()
     request = managers.get(instanceGroupManager=instance_group,
                            project=project,
                            zone=zone)
@@ -103,7 +108,7 @@ def get_instance_group_size(instance_group: str, project: str,
 def resize_instance_group(size, instance_group, project, zone):
     """Changes the number of instances running in |instance_group| to |size|."""
     assert size >= 1
-    managers = thread_local.service.instanceGroupManagers()
+    managers = get_instance_group_managers()
     request = managers.resize(instanceGroupManager=instance_group,
                               size=size,
                               project=project,
@@ -113,7 +118,7 @@ def resize_instance_group(size, instance_group, project, zone):
 
 def delete_instance_group(instance_group, project, zone):
     """Deletes |instance_group|."""
-    managers = thread_local.service.instanceGroupManagers()
+    managers = get_instance_group_managers()
     request = managers.delete(instanceGroupManager=instance_group,
                               zone=zone,
                               project=project)
@@ -124,8 +129,8 @@ def create_instance_group(name: str, instance_template_url: str,
                           experiment: str, project: str, zone: str):
     """Creates an instance group named |name| from the template specified by
     |instance_template_url|."""
-    managers = thread_local.service.instanceGroupManagers()
-    target_size = 1  # !!!
+    managers = get_instance_group_managers()
+    target_size = 1
     base_instance_name = 'w-' + experiment
 
     body = {

--- a/common/gce.py
+++ b/common/gce.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Module for using the Google Compute Engine (GCE) API."""
 import threading
-from typing import Dict
 
 import dateutil.parser
 
@@ -91,43 +90,30 @@ def get_instance_from_preempted_operation(operation, base_target_link) -> str:
     return operation['targetLink'][len(base_target_link):]
 
 
-def create_instance_template(
-    name: str, docker_image: str, env: Dict[str, str], project: str):
-    templates = service.instanceTemplates()
-    properties = {'disks': [{'initializeParams': 'diskSizeGb': '50'}]}
-    return request.execute() # !!! return the url.
-
-
-
-def create_instance_group(name: str, instance_template_url: str, experiment: str, zone: str):
-    managers = service.instanceGroupManagers()
-    target_size = 1 # !!!
-    base_instance_name = 'w-' + experiment
-
-    body = {
-        'baseInstanceName': base_instance_name,
-        'targetSize': target_size,
-        'name': name
-        'instanceTemplate': instance_template_url
-    }
-    request = managers.insert(
-        targetSize=target_size,
-        baseInstanceName=base_instance_name,
-        instanceTemplate=instance_template_url,
-        project=project)
-    return request.execute()
-
-
-def get_instance_group_size(
-    instance_group: str, project: str, zone: str) -> int:
-    managers = service.instanceGroupManagers()
-    request = managers.get(
-        instanceGroupManager=instance_group, project=project, zone=zone)
+def get_instance_group_size(instance_group: str, project: str,
+                            zone: str) -> int:
+    """Returns the number of instances running in |instance_group|."""
+    managers = thread_local.service.instanceGroupManagers()
+    request = managers.get(instanceGroupManager=instance_group,
+                           project=project,
+                           zone=zone)
     return request.execute()['targetSize']
 
 
 def resize_instance_group(instance_group, size, project, zone):
-    managers = service.instanceGroupManagers()
-    request = managers.get(
-        instanceGroupManager=instance_group, project=project, zone=zone)
+    """Changes the number of instances running in |instance_group| to |size|."""
+    assert size >= 1
+    managers = thread_local.service.instanceGroupManagers()
+    request = managers.get(instanceGroupManager=instance_group,
+                           project=project,
+                           zone=zone)
+    return request.execute()
+
+
+def delete_instance_group(instance_group, project, zone):
+    """Deletes |instance_group|."""
+    managers = thread_local.service.instanceGroupManagers()
+    request = managers.delete(instanceGroupManager=instance_group,
+                              zone=zone,
+                              project=project)
     return request.execute()

--- a/common/gce.py
+++ b/common/gce.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Module for using the Google Compute Engine (GCE) API."""
 import threading
+from typing import Dict
 
 import dateutil.parser
 
@@ -88,3 +89,45 @@ def get_base_target_link(experiment_config):
 def get_instance_from_preempted_operation(operation, base_target_link) -> str:
     """Returns the instance name from a preempted |operation|."""
     return operation['targetLink'][len(base_target_link):]
+
+
+def create_instance_template(
+    name: str, docker_image: str, env: Dict[str, str], project: str):
+    templates = service.instanceTemplates()
+    properties = {'disks': [{'initializeParams': 'diskSizeGb': '50'}]}
+    return request.execute() # !!! return the url.
+
+
+
+def create_instance_group(name: str, instance_template_url: str, experiment: str, zone: str):
+    managers = service.instanceGroupManagers()
+    target_size = 1 # !!!
+    base_instance_name = 'w-' + experiment
+
+    body = {
+        'baseInstanceName': base_instance_name,
+        'targetSize': target_size,
+        'name': name
+        'instanceTemplate': instance_template_url
+    }
+    request = managers.insert(
+        targetSize=target_size,
+        baseInstanceName=base_instance_name,
+        instanceTemplate=instance_template_url,
+        project=project)
+    return request.execute()
+
+
+def get_instance_group_size(
+    instance_group: str, project: str, zone: str) -> int:
+    managers = service.instanceGroupManagers()
+    request = managers.get(
+        instanceGroupManager=instance_group, project=project, zone=zone)
+    return request.execute()['targetSize']
+
+
+def resize_instance_group(instance_group, size, project, zone):
+    managers = service.instanceGroupManagers()
+    request = managers.get(
+        instanceGroupManager=instance_group, project=project, zone=zone)
+    return request.execute()

--- a/common/gce.py
+++ b/common/gce.py
@@ -126,12 +126,11 @@ def delete_instance_group(instance_group, project, zone):
 
 
 def create_instance_group(name: str, instance_template_url: str,
-                          experiment: str, project: str, zone: str):
+                          base_instance_name: str, project: str, zone: str):
     """Creates an instance group named |name| from the template specified by
     |instance_template_url|."""
     managers = get_instance_group_managers()
     target_size = 1
-    base_instance_name = 'w-' + experiment
 
     body = {
         'baseInstanceName': base_instance_name,

--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -144,7 +144,7 @@ def run_local_instance(startup_script: str = None) -> bool:
     return new_process.ProcessResult(0, '', False)
 
 
-def create_instance_template(template_name, project, docker_image, zone, env):
+def create_instance_template(template_name, docker_image, env, project, zone):
     """Returns a ProcessResult from running the command to create an instance
     template."""
     command = [
@@ -156,7 +156,7 @@ def create_instance_template(template_name, project, docker_image, zone, env):
         '--preemptible', '--container-image', docker_image
     ]
     for item in env.items():
-        command.extend(['--container-arg', '-e %s=%s' % item])
+        command.extend(['--container-env', '%s=%s' % item])
     new_process.execute(command)
     return posixpath.join(
         'https://www.googleapis.com/compute/v1/projects/{}/global/'

--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -22,10 +22,9 @@ from common import experiment_utils
 from common import logs
 from common import new_process
 
-# Constants for dispatcher specs.
-DISPATCHER_MACHINE_TYPE = 'n1-standard-96'
-DISPATCHER_BOOT_DISK_SIZE = '4TB'
-DISPATCHER_BOOT_DISK_TYPE = 'pd-ssd'
+# TODO(metzman): Lower this when we figure out how else we can take advantage
+# of the 30 concurrent GCB builds.
+DISPATCHER_MACHINE_TYPE = 'n1-standard-32'
 
 # Constants for runner specs.
 RUNNER_MACHINE_TYPE = 'n1-standard-1'
@@ -92,11 +91,7 @@ def create_instance(instance_name: str,
         '--scopes=cloud-platform',
     ]
     if instance_type == InstanceType.DISPATCHER:
-        command.extend([
-            '--machine-type=%s' % DISPATCHER_MACHINE_TYPE,
-            '--boot-disk-size=%s' % DISPATCHER_BOOT_DISK_SIZE,
-            '--boot-disk-type=%s' % DISPATCHER_BOOT_DISK_TYPE,
-        ])
+        command.append('--machine-type=%s' % DISPATCHER_MACHINE_TYPE)
     else:
         command.extend([
             '--no-address',

--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -163,7 +163,7 @@ def create_instance_template(template_name, docker_image, env, project, zone):
         'instanceTemplates/', template_name).format(project)
 
 
-def delete_measure_worker_template(template_name: str):
+def delete_instance_template(template_name: str):
     """Returns a ProcessResult from running the command to delete the
     measure_worker template for this |experiment|."""
     command = [

--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -25,6 +25,7 @@ from common import new_process
 # TODO(metzman): Lower this when we figure out how else we can take advantage
 # of the 30 concurrent GCB builds.
 DISPATCHER_MACHINE_TYPE = 'n1-standard-32'
+DISPATCHER_BOOT_DISK_SIZE = '500GB'
 
 # Constants for runner specs.
 RUNNER_MACHINE_TYPE = 'n1-standard-1'
@@ -91,7 +92,10 @@ def create_instance(instance_name: str,
         '--scopes=cloud-platform',
     ]
     if instance_type == InstanceType.DISPATCHER:
-        command.append('--machine-type=%s' % DISPATCHER_MACHINE_TYPE)
+        command.extend([
+            '--machine-type=%s' % DISPATCHER_MACHINE_TYPE,
+            '--boot-disk-size=%s' % DISPATCHER_BOOT_DISK_SIZE
+        ])
     else:
         command.extend([
             '--no-address',

--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -161,9 +161,8 @@ def create_instance_template(template_name, docker_image, env, project, zone):
     for item in env.items():
         command.extend(['--container-env', '%s=%s' % item])
     new_process.execute(command)
-    return posixpath.join(
-        'https://www.googleapis.com/compute/v1/projects/{}/global/'
-        'instanceTemplates/', template_name).format(project)
+    return posixpath.join('https://www.googleapis.com/compute/v1/projects/',
+                          project, 'global', 'instanceTemplates', template_name)
 
 
 def delete_instance_template(template_name: str):

--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -147,6 +147,9 @@ def run_local_instance(startup_script: str = None) -> bool:
 def create_instance_template(template_name, docker_image, env, project, zone):
     """Returns a ProcessResult from running the command to create an instance
     template."""
+    # Creating an instance template cannot be done using the GCE API because
+    # there is no public API for handling some docker related functionality that
+    # we need.
     command = [
         'gcloud', 'compute', '--project', project, 'instance-templates',
         'create-with-container', template_name, '--no-address',

--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -165,7 +165,8 @@ def create_measure_worker_template(experiment, project, docker_image, zone,
     ]
     for item in env.items():
         command.extend(['--container-arg', '-e %s=%s' % item])
-    return new_process.execute(command)
+    new_process.execute(command)
+    return template_name
 
 
 def delete_measure_worker_template(experiment: str):

--- a/common/queue_utils.py
+++ b/common/queue_utils.py
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Code for setting up a work queue with rq."""
+import redis
+import rq
+
+
+def initialize_queue(redis_host, queue_name='default'):
+    """Returns a redis-backed rq queue."""
+    redis_connection = redis.Redis(host=redis_host)
+    queue = rq.Queue(queue_name, connection=redis_connection)
+    return queue

--- a/common/test_gce.py
+++ b/common/test_gce.py
@@ -12,9 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for gce.py."""
+from unittest import mock
 import posixpath
 
 from common import gce
+
+PROJECT = 'my-cloud-project'
+ZONE = 'my-compute-zone'
+INSTANCE_GROUP = 'my-instance-group'
+INSTANCE_TEMPLATE_URL = 'resource/my-instance-group'
+EXPERIMENT = 'my-experiment'
 
 
 def test_get_instance_from_preempted_operation():
@@ -28,3 +35,68 @@ def test_get_instance_from_preempted_operation():
         operation, base_target_link)
 
     assert instance == expected_instance
+
+
+@mock.patch('common.gce.get_instance_group_managers')
+def test_delete_instance_group(mocked_get_instance_group_managers):
+    """Tests that delete_instance_group uses the GCE API correctly."""
+    mock_managers = mock.Mock()
+    mocked_get_instance_group_managers.return_value = mock_managers
+    gce.delete_instance_group(INSTANCE_GROUP, PROJECT, ZONE)
+    assert mock_managers.delete.call_args_list == [
+        mock.call(instanceGroupManager=INSTANCE_GROUP,
+                  project=PROJECT,
+                  zone=ZONE)
+    ]
+
+
+@mock.patch('common.gce.get_instance_group_managers')
+def test_resize_instance_group(mocked_get_instance_group_managers):
+    """Tests that resize_instance_group uses the GCE API correctly."""
+    size = 10
+    mock_managers = mock.Mock()
+    mocked_get_instance_group_managers.return_value = mock_managers
+    gce.resize_instance_group(size, INSTANCE_GROUP, PROJECT, ZONE)
+    assert mock_managers.resize.call_args_list == [
+        mock.call(instanceGroupManager=INSTANCE_GROUP,
+                  size=size,
+                  project=PROJECT,
+                  zone=ZONE)
+    ]
+
+
+@mock.patch('common.gce.get_instance_group_managers')
+def test_create_instance_group(mocked_get_instance_group_managers):
+    """Tests that create_instance_group uses the GCE API correctly."""
+    mock_managers = mock.Mock()
+    mocked_get_instance_group_managers.return_value = mock_managers
+    gce.create_instance_group(INSTANCE_GROUP, INSTANCE_TEMPLATE_URL, EXPERIMENT,
+                              PROJECT, ZONE)
+    body = {
+        'baseInstanceName': 'w-' + EXPERIMENT,
+        'targetSize': 1,
+        'name': INSTANCE_GROUP,
+        'instanceTemplate': INSTANCE_TEMPLATE_URL,
+    }
+    assert mock_managers.insert.call_args_list == [
+        mock.call(body=body, project=PROJECT, zone=ZONE)
+    ]
+
+
+@mock.patch('common.gce.get_instance_group_managers')
+def test_get_instance_group_size(mocked_get_instance_group_managers):
+    """Tests that get_instance_group_size uses the GCE API correctly and returns
+    the right value."""
+    mock_managers = mock.Mock()
+    mocked_get_instance_group_managers.return_value = mock_managers
+    mock_req = mock.Mock()
+    mock_managers.get.return_value = mock_req
+    size = 1
+    mock_req.execute.return_value = {'targetSize': size}
+    result = gce.get_instance_group_size(INSTANCE_GROUP, PROJECT, ZONE)
+    assert mock_managers.get.call_args_list == [
+        mock.call(instanceGroupManager=INSTANCE_GROUP,
+                  project=PROJECT,
+                  zone=ZONE)
+    ]
+    assert result == size

--- a/common/test_gce.py
+++ b/common/test_gce.py
@@ -70,10 +70,11 @@ def test_create_instance_group(mocked_get_instance_group_managers):
     """Tests that create_instance_group uses the GCE API correctly."""
     mock_managers = mock.Mock()
     mocked_get_instance_group_managers.return_value = mock_managers
-    gce.create_instance_group(INSTANCE_GROUP, INSTANCE_TEMPLATE_URL, EXPERIMENT,
-                              PROJECT, ZONE)
+    base_instance_name = 'm-' + EXPERIMENT
+    gce.create_instance_group(INSTANCE_GROUP, INSTANCE_TEMPLATE_URL,
+                              base_instance_name, PROJECT, ZONE)
     body = {
-        'baseInstanceName': 'w-' + EXPERIMENT,
+        'baseInstanceName': 'm-' + EXPERIMENT,
         'targetSize': 1,
         'name': INSTANCE_GROUP,
         'instanceTemplate': INSTANCE_TEMPLATE_URL,

--- a/common/test_gcloud.py
+++ b/common/test_gcloud.py
@@ -84,9 +84,7 @@ def test_create_instance():
             '--image-project=cos-cloud',
             '--zone=zone-a',
             '--scopes=cloud-platform',
-            '--machine-type=n1-standard-96',
-            '--boot-disk-size=4TB',
-            '--boot-disk-type=pd-ssd',
+            '--machine-type=n1-standard-32',
         ]]
 
 

--- a/common/test_gcloud.py
+++ b/common/test_gcloud.py
@@ -85,6 +85,7 @@ def test_create_instance():
             '--zone=zone-a',
             '--scopes=cloud-platform',
             '--machine-type=n1-standard-32',
+            '--boot-disk-size=500GB',
         ]]
 
 

--- a/common/test_gcloud.py
+++ b/common/test_gcloud.py
@@ -190,3 +190,42 @@ def test_delete_instances_fail(mocked_execute):
     result = gcloud.delete_instances(instances, zone)
     assert not result
     mocked_execute.assert_called_with(expected_command, expect_zero=False)
+
+
+@mock.patch('common.new_process.execute')
+def test_create_instance_template(mocked_execute):
+    """Tests that create_instance_template uses the correct gcloud command and
+    returns the correct instance template URL."""
+    template_name = 'my-template'
+    docker_image = 'docker_image'
+    env = {'ENV_VAR': 'value'}
+    project = 'fuzzbench'
+    result = gcloud.create_instance_template(template_name, docker_image, env,
+                                             project, ZONE)
+    expected_command = [
+        'gcloud', 'compute', '--project', project, 'instance-templates',
+        'create-with-container', template_name, '--no-address',
+        '--image-family=cos-stable', '--image-project=cos-cloud',
+        '--region=zone-a', '--scopes=cloud-platform',
+        '--machine-type=n1-standard-1', '--boot-disk-size=50GB',
+        '--preemptible', '--container-image', docker_image, '--container-env',
+        'ENV_VAR=value'
+    ]
+    mocked_execute.assert_called_with(expected_command)
+    expected_result = (
+        'https://www.googleapis.com/compute/v1/projects/{project}'
+        '/global/instanceTemplates/{name}').format(project=project,
+                                                   name=template_name)
+    assert result == expected_result
+
+
+@mock.patch('common.new_process.execute')
+def test_delete_instance_template(mocked_execute):
+    """Tests that delete_instance_template uses the correct gcloud command to
+    delete an instance template."""
+    template_name = 'my-template'
+    gcloud.delete_instance_template(template_name)
+    expected_command = [
+        'gcloud', 'compute', 'instance-templates', 'delete', template_name
+    ]
+    mocked_execute.assert_called_with(expected_command)

--- a/docker/gcb/base-images.yaml
+++ b/docker/gcb/base-images.yaml
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 # The order of execution is as follows:
-# 1. Pull base-image, base-builder, base-runner.
+# 1. Pull base-image, base-builder, base-runner, measure-worker.
 # 2. After pulling base-image completes: Build base-image.
 # 3. After pulling base-builder and building base-image completes: Build base-builder.
 # 3. After pulling base-runner and building base-image completes: Build base-runner.
+# 3. After pulling measure-worker and building base-runner completes: Build measure-worker.
 # This is optimized to take advantage of concurrency and caching as much as
 # possible. When nothing changes, this does build takes two minutes to complete
-# instead of ten.'
+# instead of ten.
 # See https://cloud.google.com/cloud-build/docs/speeding-up-builds for a discussion
 # on using caching.
 # See https://cloud.google.com/cloud-build/docs/configuring-builds/configure-build-step-order
@@ -96,7 +97,7 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/base-builder',
+    'gcr.io/fuzzbench/base-runner',
 
     '--tag',
     '${_REPO}/base-runner',
@@ -108,6 +109,7 @@ steps:
   ]
   # Wait for pull and building base-image to finish.
   wait_for: ['base-image', 'base-runner-pull']
+  id: 'base-runner'
 
 
 # Pull base-runner to fill cache.
@@ -132,6 +134,9 @@ steps:
 
     '--cache-from',
     '${_REPO}/measure-worker',
+
+    '--file',
+    'docker/measure-worker/Dockerfile',
 
     '.'
   ]

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -19,14 +19,13 @@ import sys
 import time
 from typing import List
 
-import redis
-import rq
 from sqlalchemy import func
 from sqlalchemy import orm
 
 from common import experiment_utils
 from common import experiment_path as exp_path
 from common import logs
+from common import queue_utils
 from database import utils as db_utils
 from database import models
 from experiment.build import build_utils
@@ -56,8 +55,7 @@ def measure_loop(experiment: str, max_total_time: int, redis_host: str):
         set_up_coverage_binaries(pool, experiment)
     # Using Multiprocessing.Queue will fail with a complaint about
     # inheriting queue.
-    redis_connection = redis.Redis(host=redis_host)
-    queue = rq.Queue(connection=redis_connection)
+    queue = queue_utils.initialize_queue(redis_host)
     while True:
         try:
             # Get whether all trials have ended before we measure to prevent

--- a/experiment/measurer/measure_worker.py
+++ b/experiment/measurer/measure_worker.py
@@ -309,10 +309,10 @@ def measure_trial_coverage(measure_req) -> models.Snapshot:
     """Measure the coverage obtained by |trial_num| on |benchmark| using
     |fuzzer|."""
     initialize_logs()
-    set_up_coverage_binary(measure_req.benchmark)
-    logger.debug('Measuring trial: %d.', measure_req.trial_id)
 
     try:
+        set_up_coverage_binary(measure_req.benchmark)
+        logger.debug('Measuring trial: %d.', measure_req.trial_id)
         snapshot = measure_snapshot_coverage(measure_req.fuzzer,
                                              measure_req.benchmark,
                                              measure_req.trial_id,

--- a/experiment/schedule_measure_workers.py
+++ b/experiment/schedule_measure_workers.py
@@ -85,6 +85,7 @@ def schedule(experiment_config: dict, queue):
         return
 
     if num_instances_needed != num_instances:
-        # !!! TODO(metzman): Add limits.
+        # TODO(metzman): Add some limits so always have some measurers but not
+        # too many.
         gce.resize_instance_group(num_instances_needed, instance_group_name,
                                   project, zone)

--- a/experiment/schedule_measure_workers.py
+++ b/experiment/schedule_measure_workers.py
@@ -1,0 +1,84 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module for starting instances to run measure workers."""
+import posixpath
+
+from common import gcloud
+from common import gce
+from common import logs
+from common import queue_utils
+
+logger = logs.Logger('scheduler')  # pylint: disable=invalid-name
+
+
+def get_instance_group_name(experiment: str):
+    """Returns the name of the instance group of measure workers for
+    |experiment|."""
+    return experiment + '-measure-worker'
+
+def get_measure_worker_instance_template_name(experiment: str):
+    """Returns an instance template name for measurer workers running in
+    |experiment|."""
+    return experiment + '-measure-worker'
+
+
+def initialize(experiment_config: dict):
+    """Initialize everything that will be needed to schedule measurers."""
+    redis_host = experiment_config['redis_host']
+    queue = queue_utils.initialize_queue(redis_host)
+    experiment = experiment_config['experiment']
+    instance_template_name = get_measure_worker_instance_template_name(
+        experiment)
+    project = experiment_config['cloud_project']
+    docker_image = posixpath.join('gcr.io', project, 'measure-worker')
+    env = {'REDIS_HOST': redis_host} # !!!
+    instance_template_url = gcloud.create_instance_template(
+        instance_template_name, project, env, docker_image)
+    instance_group_name = get_instance_group_name(experiment)
+    create_instance_group(instance_group_name, instance_template_url, project)
+    return queue
+
+
+def teardown(experiment_config: dict):
+    instance_group_name = get_instance_group_name(
+        experiment_config['experiment'])
+    gce.delete_instance_group(instance_group_name)
+    gcloud.delete_measure_worker_template(experiment_config['experiment'])
+
+
+def schedule(experiment_config: dict, queue):
+    """Schedule measurer workers. This cannot be called before
+    initialize_measurers."""
+    jobs = queue.get_jobs()
+    counts = collections.defaultdict(int)
+    for job in jobs:
+        counts[job.get_status()] += 1
+
+    num_instances_needed = counts['queued'] + counts['started']
+    instance_group_name = gce.get_instance_group_name(
+        experiment_config['experiment'])
+    project = experiment_config['cloud_project']
+    zone = experiment_config['zone']
+    num_instances = gce.get_instance_group_size(
+        instance_group_name,
+        project,
+        zone)
+
+    if num_instance_needed < num_instances and num_instances == 1:
+        # Can't go below 1 instance per group.
+        return
+
+    if num_instance_needed != num_instances:
+        # !!! TODO(metzman): Add limits.
+        gce.resize_instance_group(instance_group, project, zone)

--- a/experiment/schedule_measure_workers.py
+++ b/experiment/schedule_measure_workers.py
@@ -61,7 +61,7 @@ def teardown(experiment_config: dict):
     project = experiment_config['cloud_project']
     zone = experiment_config['cloud_compute_zone']
     gce.delete_instance_group(instance_group_name, project, zone)
-    gcloud.delete_measure_worker_template(experiment_config['experiment'])
+    gcloud.delete_instance_template(experiment_config['experiment'])
 
 
 def schedule(experiment_config: dict, queue):

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -579,7 +579,7 @@ def schedule(experiment_config: dict, pool, queue):
     schedule_measurers(queue)
     return started_trials
 
-
+# TODO(metzman): Move measurer scheduling code into seperate module.
 def schedule_measurers(queue):
     """Schedule measurer workers. This cannot be called before
     initialize_measurers."""
@@ -606,6 +606,10 @@ def initialize_measurers(experiment_config: dict):
     queue = queue_utils.initialize_queue(experiment_config['redis_host'])
     # !!! INSTANCE GROUP.
     return queue
+
+
+def teardown_measurers(experiment_config):
+    gcloud.delete_measure_worker_template(experiment_config['experiment'])
 
 
 def schedule_loop(experiment_config: dict):

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -591,11 +591,12 @@ def schedule_measurers(queue):
     num_instances = None
 
     queued_count = counts['queued']
+    started_count = counts['started']
     if queued_count > num_instances:
         # !!! UP INSTANCES.
         return
 
-    started_count = counts['started']
+
     if started_count < num_instances:
         # !!! DOWN instances.
         pass

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Code for starting and ending trials."""
-import collections
 import datetime
 import math
 import multiprocessing

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,12 @@ google-api-python-client==1.8.2
 google-auth==1.14.0
 google-cloud-error-reporting==0.33.0
 google-cloud-logging==1.14.0
+grpcio==1.29.0
 Jinja2==2.11.1
 numpy==1.18.1
 oauth2client==4.1.3
+opencensus-ext-stackdriver==0.7.2
+opencensus==0.7.7
 Orange3==3.24.1
 pandas==1.0.1
 psycopg2-binary==2.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,9 @@ google-api-python-client==1.8.2
 google-auth==1.14.0
 google-cloud-error-reporting==0.33.0
 google-cloud-logging==1.14.0
-grpcio==1.29.0
 Jinja2==2.11.1
 numpy==1.18.1
 oauth2client==4.1.3
-opencensus-ext-stackdriver==0.7.2
-opencensus==0.7.7
 Orange3==3.24.1
 pandas==1.0.1
 psycopg2-binary==2.8.4


### PR DESCRIPTION
Make measure worker scheduling its own module: experiment/schedule_measure_worker.py
Also:
Use an n1-standard-32 for the Dispatcher.
Fix some errors building measure-worker on GCB.
Move queue initialization code to new module, common/queue_utils.py