### PR TITLE
Fix argument in handling in filestore_utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ SHELL := /bin/bash
 VENV_ACTIVATE := .venv/bin/activate
 
 ${VENV_ACTIVATE}: requirements.txt
-	rm -rf .venv
 	python3 -m venv .venv
 	source ${VENV_ACTIVATE} && python3 -m pip install --upgrade -r requirements.txt
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SHELL := /bin/bash
 VENV_ACTIVATE := .venv/bin/activate
 
 ${VENV_ACTIVATE}: requirements.txt
+	rm -rf .venv
 	python3 -m venv .venv
 	source ${VENV_ACTIVATE} && python3 -m pip install --upgrade -r requirements.txt
 

--- a/common/filestore_utils.py
+++ b/common/filestore_utils.py
@@ -37,6 +37,8 @@ else:
     from common import gsutil as filestore_utils_impl
 
 
+# TODO(zhichengcai): Change all implementations of cp, ls, and rm to stop using
+# special handling of *args as it is error prone now that there are wrappers.
 def cp(*cp_arguments, **kwargs):  # pylint: disable=invalid-name
     """Copy source to destination."""
     return filestore_utils_impl.cp(*cp_arguments, **kwargs)

--- a/common/filestore_utils.py
+++ b/common/filestore_utils.py
@@ -22,18 +22,18 @@ logger = logs.Logger('filestore_utils')
 def _using_gsutil():
     """Returns True if using Google Cloud Storage for filestore."""
     try:
-        experiment_path_format = experiment_utils.get_cloud_experiment_path()
+        experiment_filestore_path = experiment_utils.get_cloud_experiment_path()
     except KeyError:
         return True
 
-    return experiment_path_format.startswith('gs://')
+    return experiment_filestore_path.startswith('gs://')
 
 
 if _using_gsutil():
     from common import gsutil as filestore_utils_impl
 else:
     # When gsutil is not used in the context, here it should use local_utils.
-    # TODO(zhichengcai): local_utils
+    # TODO(zhichengcai): Implement local_filestore.py and import it here.
     from common import gsutil as filestore_utils_impl
 
 
@@ -44,12 +44,17 @@ def cp(*cp_arguments, **kwargs):  # pylint: disable=invalid-name
 
 def ls(*ls_arguments, must_exist=True, **kwargs):  # pylint: disable=invalid-name
     """List files or folders."""
-    return filestore_utils_impl.ls(*ls_arguments, must_exist, **kwargs)
+    return filestore_utils_impl.ls(*ls_arguments,
+                                   must_exist=must_exist,
+                                   **kwargs)
 
 
 def rm(*rm_arguments, recursive=True, force=False, **kwargs):  # pylint: disable=invalid-name
     """Remove files or folders."""
-    return filestore_utils_impl.rm(*rm_arguments, recursive, force, **kwargs)
+    return filestore_utils_impl.rm(*rm_arguments,
+                                   recursive=recursive,
+                                   force=force,
+                                   **kwargs)
 
 
 def rsync(  # pylint: disable=too-many-arguments

--- a/common/filestore_utils.py
+++ b/common/filestore_utils.py
@@ -38,7 +38,7 @@ else:
 
 
 # TODO(zhichengcai): Change all implementations of cp, ls, and rm to stop using
-# special handling of *args as it is error prone now that there are wrappers.
+# special handling of *args. This is error prone now that there are wrappers.
 def cp(*cp_arguments, **kwargs):  # pylint: disable=invalid-name
     """Copy source to destination."""
     return filestore_utils_impl.cp(*cp_arguments, **kwargs)

--- a/common/gsutil.py
+++ b/common/gsutil.py
@@ -19,9 +19,10 @@ from common import new_process
 logger = logs.Logger('gsutil')
 
 
-def gsutil_command(arguments, *args, parallel=False, **kwargs):
+def gsutil_command(arguments, *args, **kwargs):
     """Executes a gsutil command with |arguments| and returns the result."""
     command = ['gsutil']
+    parallel = kwargs.pop('parallel', False)
     if parallel:
         command.append('-m')
     return new_process.execute(command + arguments, *args, **kwargs)
@@ -40,7 +41,6 @@ def ls(*ls_arguments, must_exist=True, **kwargs):  # pylint: disable=invalid-nam
     and the returncode. Does not except on nonzero return code if not
     |must_exist|."""
     command = ['ls'] + list(ls_arguments)
-    # Don't use parallel as it probably doesn't help at all.
     result = gsutil_command(command, expect_zero=must_exist, **kwargs)
     retcode = result.retcode  # pytype: disable=attribute-error
     output = result.output.splitlines()  # pytype: disable=attribute-error

--- a/common/gsutil.py
+++ b/common/gsutil.py
@@ -19,10 +19,9 @@ from common import new_process
 logger = logs.Logger('gsutil')
 
 
-def gsutil_command(arguments, *args, **kwargs):
+def gsutil_command(arguments, *args, parallel=False, **kwargs):
     """Executes a gsutil command with |arguments| and returns the result."""
     command = ['gsutil']
-    parallel = kwargs.pop('parallel', False)
     if parallel:
         command.append('-m')
     return new_process.execute(command + arguments, *args, **kwargs)

--- a/common/test_filestore_utils.py
+++ b/common/test_filestore_utils.py
@@ -33,18 +33,20 @@ def test_keyword_args():
 
     with mock.patch('common.new_process.execute') as mocked_execute:
         filestore_utils.ls(filestore_path, must_exist=False)
-        mocked_execute.assert_called_with(
-            ['gsutil', 'ls', filestore_path], expect_zero=False)
+        mocked_execute.assert_called_with(['gsutil', 'ls', filestore_path],
+                                          expect_zero=False)
 
     filestore_path2 = filestore_path + '2'
 
     with mock.patch('common.new_process.execute') as mocked_execute:
         filestore_utils.cp(filestore_path, filestore_path2, parallel=True)
         mocked_execute.assert_called_with(
-            ['gsutil', '-m', 'cp', filestore_path, filestore_path2 ])
+            ['gsutil', '-m', 'cp', filestore_path, filestore_path2])
 
     with mock.patch('common.new_process.execute') as mocked_execute:
-        filestore_utils.cp(filestore_path,  filestore_path2, write_to_stdout=False)
+        filestore_utils.cp(filestore_path,
+                           filestore_path2,
+                           write_to_stdout=False)
         mocked_execute.assert_called_with(
             ['gsutil', 'cp', filestore_path, filestore_path2],
             write_to_stdout=False)

--- a/common/test_filestore_utils.py
+++ b/common/test_filestore_utils.py
@@ -21,11 +21,30 @@ from common import filestore_utils
 # the local_filestore implementation.
 
 
-@mock.patch('common.new_process.execute')
-def test_keyword_args(mocked_execute):
+def test_keyword_args():
     """Tests that keyword args, and in particular 'parallel' are handled
     correctly."""
     filestore_path = 'gs://fake_dir'
-    filestore_utils.rm(filestore_path, recursive=True, parallel=True)
-    mocked_execute.assert_called_with(
-        ['gsutil', '-m', 'rm', '-r', 'gs://fake_dir'], expect_zero=True)
+
+    with mock.patch('common.new_process.execute') as mocked_execute:
+        filestore_utils.rm(filestore_path, recursive=True, parallel=True)
+        mocked_execute.assert_called_with(
+            ['gsutil', '-m', 'rm', '-r', filestore_path], expect_zero=True)
+
+    with mock.patch('common.new_process.execute') as mocked_execute:
+        filestore_utils.ls(filestore_path, must_exist=False)
+        mocked_execute.assert_called_with(
+            ['gsutil', 'ls', filestore_path], expect_zero=False)
+
+    filestore_path2 = filestore_path + '2'
+
+    with mock.patch('common.new_process.execute') as mocked_execute:
+        filestore_utils.cp(filestore_path, filestore_path2, parallel=True)
+        mocked_execute.assert_called_with(
+            ['gsutil', '-m', 'cp', filestore_path, filestore_path2 ])
+
+    with mock.patch('common.new_process.execute') as mocked_execute:
+        filestore_utils.cp(filestore_path,  filestore_path2, write_to_stdout=False)
+        mocked_execute.assert_called_with(
+            ['gsutil', 'cp', filestore_path, filestore_path2],
+            write_to_stdout=False)

--- a/common/test_filestore_utils.py
+++ b/common/test_filestore_utils.py
@@ -20,6 +20,7 @@ from common import filestore_utils
 # TODO(zhichengcai): Figure out how we can test filestore_utils when using
 # the local_filestore implementation.
 
+
 @mock.patch('common.new_process.execute')
 def test_keyword_args(mocked_execute):
     """Tests that keyword args, and in particular 'parallel' are handled
@@ -27,5 +28,4 @@ def test_keyword_args(mocked_execute):
     filestore_path = 'gs://fake_dir'
     filestore_utils.rm(filestore_path, recursive=True, parallel=True)
     mocked_execute.assert_called_with(
-        ['gsutil', '-m', 'rm', '-r', 'gs://fake_dir'],
-        expect_zero=True)
+        ['gsutil', '-m', 'rm', '-r', 'gs://fake_dir'], expect_zero=True)

--- a/common/test_filestore_utils.py
+++ b/common/test_filestore_utils.py
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for filestore_utils.py."""
+
+from unittest import mock
+
+from common import filestore_utils
+
+# TODO(zhichengcai): Figure out how we can test filestore_utils when using
+# the local_filestore implementation.
+
+@mock.patch('common.new_process.execute')
+def test_keyword_args(mocked_execute):
+    """Tests that keyword args, and in particular 'parallel' are handled
+    correctly."""
+    filestore_path = 'gs://fake_dir'
+    filestore_utils.rm(filestore_path, recursive=True, parallel=True)
+    mocked_execute.assert_called_with(
+        ['gsutil', '-m', 'rm', '-r', 'gs://fake_dir'],
+        expect_zero=True)

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -396,8 +396,8 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
         unchanged-cycles file. This file is written to by the trial's runner."""
 
         def copy_unchanged_cycles_file():
-            result = filestore_utils.cp(exp_path.gcs(
-                self.unchanged_cycles_path),
+            unchanged_cyles_gcs_path = exp_path.gcs(self.unchanged_cycles_path)
+            result = filestore_utils.cp(unchanged_cyles_gcs_path,
                                         self.unchanged_cycles_path,
                                         expect_zero=False)
             return result.retcode == 0

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -374,3 +374,16 @@ def test_measure_loop_loop_until_end(mocked_measure_all_trials, _, __, ___,
     mocked_measure_all_trials.side_effect = mock_measure_all_trials
     measurer.measure_loop(experiment_config, 100)
     assert call_count == loop_iterations
+
+
+@mock.patch('common.new_process.execute')
+def test_remote_dir_exists(mocked_execute, environ):
+    """Tests that remote_dir_exists calls gsutil properly."""
+    work_dir = '/work'
+    os.environ['WORK'] = work_dir
+    os.environ['CLOUD_EXPERIMENT_BUCKET'] = 'gs://cloud-bucket'
+    os.environ['EXPERIMENT'] = 'example-experiment'
+    measurer.remote_dir_exists(work_dir)
+    mocked_execute.assert_called_with(
+        ['gsutil', 'ls', 'gs://cloud-bucket/example-experiment'],
+        expect_zero=False)


### PR DESCRIPTION
Fix bugs in how `filestore_utils` handled keyword args. ls and rm
accept *args, certain keyword arguments and then `kwargs`. These
keyword arguments, such as `force`, must be passed in the format
`force=force` when calling the `gsutil` implementations. For example
this works:
```
gsutil.rm(*rm_args, force=force, **kwargs)
```

While this doesn't:
```
gsutil.rm(*rm_args, force, **kwargs)
```