### PR TITLE
Add build arguments to the fuzzer build step as well.

### DIFF
--- a/docker/generate_makefile.py
+++ b/docker/generate_makefile.py
@@ -31,6 +31,7 @@ FUZZER_TEMPLATE = """
     --tag {base_tag}/builders/{fuzzer} \\
     --file fuzzers/{fuzzer}/builder.Dockerfile \\
     $(call cache_from,{base_tag}/builders/{fuzzer}) \\
+    {build_arguments} \\
     fuzzers/{fuzzer}
 
 .pull-{fuzzer}-builder: pull-base-builder
@@ -228,7 +229,10 @@ endif
 def generate_fuzzer(fuzzer, benchmarks, oss_fuzz_benchmarks, build_arguments):
     """Output make rules for a single fuzzer."""
     # Generate build rules for the fuzzer itself.
-    print(FUZZER_TEMPLATE.format(fuzzer=fuzzer, base_tag=BASE_TAG))
+    print(
+        FUZZER_TEMPLATE.format(fuzzer=fuzzer,
+                               base_tag=BASE_TAG,
+                               build_arguments=BUILD_ARGUMENTS))
 
     # Generate rules for fuzzer/benchmark pairs.
     for benchmark in benchmarks:


### PR DESCRIPTION
This isn't a complete change (I'll also need to update it for cloud build if this turns out to be important) but I have a few questions and figured that being able to point to this would help explain the issues. When you have time, please take a look and let me know what you think. Once some of these issues are sorted out, it will be much easier to finish converting an example variant over.

1) It makes sense that the benchmark builder will always need to have docker arguments plumbed through to it. Do we expect the fuzzer builder to expect the same arguments? Do we care if we end up plumbing unused arguments through for the sake of avoiding something like a fuzzer_environment/benchmark_build_args/fuzzer_build_args split instead of the two we have now? I've been trying to make enough sense of the aflplusplus scripts to convert aflplusplus_shmem over, and it doesn't seem likely that we'd want to use the same builder.Dockerfile for both. For what it's worth, I'm also not 100% sure that they need to be different in this case (though they are at the moment) but it seems like a reasonable use case, and we should decide how to handle it now.

2. It seems like it's considered bad style to include conditional execution in a Dockerfile. If we do end up needing to branch in the builder.Dockerfile, do you suggest we just do it, or pass a build-arg that provides something like the name of a bash script to execute for the particular variant's build steps instead? This is really just a question of how the Dockerfiles are implemented rather than the variants, so it would be on each project's integrator, but I want to make sure we're doing whatever we think best in our examples.

3. Do we ever want to pass command line arguments to docker other than --build-arg based on the variant config? This code could be simplified if that's the case, as right now we'd have to define something like "--build-arg K=V" in the build arguments list, but could just define "K=V" instead.