### PR TITLE
[NFC] Replace uses of side_effect with return_value.

### DIFF
--- a/experiment/test_run_experiment.py
+++ b/experiment/test_run_experiment.py
@@ -64,7 +64,7 @@ class TestReadAndValdiateExperimentConfig(unittest.TestCase):
         # All but cloud_compute_zone.
         del self.config['cloud_compute_zone']
         with mock.patch('common.yaml_utils.read') as mocked_read_yaml:
-            mocked_read_yaml.side_effect = lambda config_filename: self.config
+            mocked_read_yaml.return_value = self.config
             with pytest.raises(run_experiment.ValidationError):
                 run_experiment.read_and_validate_experiment_config(
                     'config_file')
@@ -100,7 +100,7 @@ class TestReadAndValdiateExperimentConfig(unittest.TestCase):
         self.config['cloud_experiment_bucket'] = 1
         self.config['cloud_web_bucket'] = None
         with mock.patch('common.yaml_utils.read') as mocked_read_yaml:
-            mocked_read_yaml.side_effect = lambda config_filename: self.config
+            mocked_read_yaml.return_value = self.config
             with pytest.raises(run_experiment.ValidationError):
                 run_experiment.read_and_validate_experiment_config(
                     'config_file')
@@ -119,7 +119,7 @@ class TestReadAndValdiateExperimentConfig(unittest.TestCase):
         # Don't parameterize this function, it would be too messsy.
         self.config[param] = value
         with mock.patch('common.yaml_utils.read') as mocked_read_yaml:
-            mocked_read_yaml.side_effect = lambda config_filename: self.config
+            mocked_read_yaml.return_value = self.config
             with pytest.raises(run_experiment.ValidationError):
                 run_experiment.read_and_validate_experiment_config(
                     'config_file')
@@ -130,7 +130,7 @@ class TestReadAndValdiateExperimentConfig(unittest.TestCase):
         """Tests that read_and_validat_experiment_config works as intended when
         config is valid."""
         with mock.patch('common.yaml_utils.read') as mocked_read_yaml:
-            mocked_read_yaml.side_effect = lambda config_filename: self.config
+            mocked_read_yaml.return_value = self.config
             assert (self.config == run_experiment.
                     read_and_validate_experiment_config('config_file'))
 


### PR DESCRIPTION
return_value is clearer and simpler and can be used in these cases.