### PR TITLE
Clean up filestore_utils.py API

### DIFF
--- a/common/filestore_utils.py
+++ b/common/filestore_utils.py
@@ -36,24 +36,22 @@ else:
 
 # TODO(zhichengcai): Change all implementations of cp, ls, and rm to stop using
 # special handling of *args. This is error prone now that there are wrappers.
-def cp(*cp_arguments, **kwargs):  # pylint: disable=invalid-name
+def cp(*cp_arguments, parallel=False):  # pylint: disable=invalid-name
     """Copy source to destination."""
-    return filestore_utils_impl.cp(*cp_arguments, **kwargs)
+    return filestore_utils_impl.cp(*cp_arguments, parallel=parallel)
 
 
-def ls(*ls_arguments, must_exist=True, **kwargs):  # pylint: disable=invalid-name
+def ls(*ls_arguments, must_exist=True, parallel=False):  # pylint: disable=invalid-name
     """List files or folders."""
     return filestore_utils_impl.ls(*ls_arguments,
-                                   must_exist=must_exist,
-                                   **kwargs)
+                                   must_exist=must_exist, parallel=parallel)
 
 
-def rm(*rm_arguments, recursive=True, force=False, **kwargs):  # pylint: disable=invalid-name
+def rm(*rm_arguments, recursive=True, force=False, parallel=False):  # pylint: disable=invalid-name
     """Remove files or folders."""
     return filestore_utils_impl.rm(*rm_arguments,
                                    recursive=recursive,
-                                   force=force,
-                                   **kwargs)
+                                   force=force, parallel=parallel)
 
 
 def rsync(  # pylint: disable=too-many-arguments
@@ -63,7 +61,7 @@ def rsync(  # pylint: disable=too-many-arguments
         recursive=True,
         gsutil_options=None,
         options=None,
-        **kwargs):
+        parallel=False):
     """Synchronize source and destination folders."""
     return filestore_utils_impl.rsync(source, destination, delete, recursive,
-                                      gsutil_options, options, **kwargs)
+                                      gsutil_options, options, parallel=parallel)

--- a/common/filestore_utils.py
+++ b/common/filestore_utils.py
@@ -36,22 +36,22 @@ else:
 
 # TODO(zhichengcai): Change all implementations of cp, ls, and rm to stop using
 # special handling of *args. This is error prone now that there are wrappers.
-def cp(*cp_arguments, parallel=False):  # pylint: disable=invalid-name
+def cp(*cp_arguments, parallel=False, expect_zero=True):  # pylint: disable=invalid-name
     """Copy source to destination."""
-    return filestore_utils_impl.cp(*cp_arguments, parallel=parallel)
+    return filestore_utils_impl.cp(*cp_arguments, parallel=parallel, expect_zero=expect_zero)
 
 
-def ls(*ls_arguments, must_exist=True, parallel=False):  # pylint: disable=invalid-name
+def ls(*ls_arguments, expect_zero=True):  # pylint: disable=invalid-name
     """List files or folders."""
-    return filestore_utils_impl.ls(*ls_arguments,
-                                   must_exist=must_exist, parallel=parallel)
+    return filestore_utils_impl.ls(*ls_arguments, expect_zero=expect_zero)
 
 
 def rm(*rm_arguments, recursive=True, force=False, parallel=False):  # pylint: disable=invalid-name
     """Remove files or folders."""
     return filestore_utils_impl.rm(*rm_arguments,
                                    recursive=recursive,
-                                   force=force, parallel=parallel)
+                                   force=force,
+                                   parallel=parallel)
 
 
 def rsync(  # pylint: disable=too-many-arguments
@@ -63,5 +63,10 @@ def rsync(  # pylint: disable=too-many-arguments
         options=None,
         parallel=False):
     """Synchronize source and destination folders."""
-    return filestore_utils_impl.rsync(source, destination, delete, recursive,
-                                      gsutil_options, options, parallel=parallel)
+    return filestore_utils_impl.rsync(source,
+                                      destination,
+                                      delete,
+                                      recursive,
+                                      gsutil_options,
+                                      options,
+                                      parallel=parallel)

--- a/common/filestore_utils.py
+++ b/common/filestore_utils.py
@@ -38,7 +38,9 @@ else:
 # special handling of *args. This is error prone now that there are wrappers.
 def cp(*cp_arguments, parallel=False, expect_zero=True):  # pylint: disable=invalid-name
     """Copy source to destination."""
-    return filestore_utils_impl.cp(*cp_arguments, parallel=parallel, expect_zero=expect_zero)
+    return filestore_utils_impl.cp(*cp_arguments,
+                                   parallel=parallel,
+                                   expect_zero=expect_zero)
 
 
 def ls(*ls_arguments, expect_zero=True):  # pylint: disable=invalid-name

--- a/common/filestore_utils.py
+++ b/common/filestore_utils.py
@@ -36,16 +36,20 @@ else:
 
 # TODO(zhichengcai): Change all implementations of cp, ls, and rm to stop using
 # special handling of *args. This is error prone now that there are wrappers.
-def cp(*cp_arguments, parallel=False, expect_zero=True):  # pylint: disable=invalid-name
-    """Copy source to destination."""
-    return filestore_utils_impl.cp(*cp_arguments,
-                                   parallel=parallel,
-                                   expect_zero=expect_zero)
+def cp(source, destination, recursive=False, parallel=False):  # pylint: disable=invalid-name
+    """Copies |source| to |destination|."""
+    return filestore_utils_impl.cp(source,
+                                   destination,
+                                   recursive=recursive,
+                                   parallel=parallel)
 
 
-def ls(*ls_arguments, expect_zero=True):  # pylint: disable=invalid-name
-    """List files or folders."""
-    return filestore_utils_impl.ls(*ls_arguments, expect_zero=expect_zero)
+def ls(path, must_exist=True):  # pylint: disable=invalid-name
+    """Lists files or folders in |path|. Doesn't except on failure if must_exist
+    is False otherwise can raise subprocess.CalledProcessError.
+    Returns the output of ls split line-by-line (for example ls('directory/')
+    returns every file in the directory."""
+    return filestore_utils_impl.ls(path, must_exist=must_exist)
 
 
 def rm(*rm_arguments, recursive=True, force=False, parallel=False):  # pylint: disable=invalid-name
@@ -64,7 +68,7 @@ def rsync(  # pylint: disable=too-many-arguments
         gsutil_options=None,
         options=None,
         parallel=False):
-    """Synchronize source and destination folders."""
+    """Syncs |source| and |destination| folders."""
     return filestore_utils_impl.rsync(source,
                                       destination,
                                       delete,

--- a/common/gsutil.py
+++ b/common/gsutil.py
@@ -19,12 +19,12 @@ from common import new_process
 logger = logs.Logger('gsutil')
 
 
-def gsutil_command(arguments, *args, parallel=False):
+def gsutil_command(arguments, *args, parallel=False, **kwargs):
     """Executes a gsutil command with |arguments| and returns the result."""
     command = ['gsutil']
     if parallel:
         command.append('-m')
-    return new_process.execute(command + arguments, *args,)
+    return new_process.execute(command + arguments, *args, **kwargs)
 
 
 def cp(*cp_arguments, parallel=False):  # pylint: disable=invalid-name

--- a/common/gsutil.py
+++ b/common/gsutil.py
@@ -19,34 +19,34 @@ from common import new_process
 logger = logs.Logger('gsutil')
 
 
-def gsutil_command(arguments, *args, parallel=False, **kwargs):
+def gsutil_command(arguments, *args, parallel=False):
     """Executes a gsutil command with |arguments| and returns the result."""
     command = ['gsutil']
     if parallel:
         command.append('-m')
-    return new_process.execute(command + arguments, *args, **kwargs)
+    return new_process.execute(command + arguments, *args,)
 
 
-def cp(*cp_arguments, **kwargs):  # pylint: disable=invalid-name
+def cp(*cp_arguments, parallel=False):  # pylint: disable=invalid-name
     """Executes gsutil's "cp" command with |cp_arguments| and returns the
     returncode and the output."""
     command = ['cp']
     command.extend(cp_arguments)
-    return gsutil_command(command, **kwargs)
+    return gsutil_command(command, parallel)
 
 
-def ls(*ls_arguments, must_exist=True, **kwargs):  # pylint: disable=invalid-name
+def ls(*ls_arguments, must_exist=True, parallel=False):  # pylint: disable=invalid-name
     """Executes gsutil's "ls" command with |ls_arguments| and returns the result
     and the returncode. Does not except on nonzero return code if not
     |must_exist|."""
     command = ['ls'] + list(ls_arguments)
-    result = gsutil_command(command, expect_zero=must_exist, **kwargs)
+    result = gsutil_command(command, expect_zero=must_exist, parallel=parallel)
     retcode = result.retcode  # pytype: disable=attribute-error
     output = result.output.splitlines()  # pytype: disable=attribute-error
     return retcode, output
 
 
-def rm(*rm_arguments, recursive=True, force=False, **kwargs):  # pylint: disable=invalid-name
+def rm(*rm_arguments, recursive=True, force=False, parallel=False):  # pylint: disable=invalid-name
     """Executes gsutil's rm command with |rm_arguments| and returns the result.
     Uses -r if |recursive|. If |force|, then uses -f and will not except if
     return code is nonzero."""
@@ -55,7 +55,7 @@ def rm(*rm_arguments, recursive=True, force=False, **kwargs):  # pylint: disable
         command.insert(1, '-r')
     if force:
         command.insert(1, '-f')
-    return gsutil_command(command, expect_zero=(not force), **kwargs)
+    return gsutil_command(command, expect_zero=(not force), parallel=parallel)
 
 
 def rsync(  # pylint: disable=too-many-arguments
@@ -65,7 +65,7 @@ def rsync(  # pylint: disable=too-many-arguments
         recursive=True,
         gsutil_options=None,
         options=None,
-        **kwargs):
+        parallel=False):
     """Does gsutil rsync from |source| to |destination| using sane defaults that
     can be overriden. Prepends any |gsutil_options| before the rsync subcommand
     if provided."""
@@ -78,4 +78,4 @@ def rsync(  # pylint: disable=too-many-arguments
     if options is not None:
         command.extend(options)
     command.extend([source, destination])
-    return gsutil_command(command, **kwargs)
+    return gsutil_command(command, parallel=parallel)

--- a/common/gsutil.py
+++ b/common/gsutil.py
@@ -19,28 +19,28 @@ from common import new_process
 logger = logs.Logger('gsutil')
 
 
-def gsutil_command(arguments, *args, parallel=False, **kwargs):
+def gsutil_command(arguments, parallel=False, **kwargs):
     """Executes a gsutil command with |arguments| and returns the result."""
     command = ['gsutil']
     if parallel:
         command.append('-m')
-    return new_process.execute(command + arguments, *args, **kwargs)
+    return new_process.execute(command + arguments, **kwargs)
 
 
-def cp(*cp_arguments, parallel=False):  # pylint: disable=invalid-name
+def cp(*cp_arguments, parallel=False, expect_zero=True):  # pylint: disable=invalid-name
     """Executes gsutil's "cp" command with |cp_arguments| and returns the
     returncode and the output."""
     command = ['cp']
     command.extend(cp_arguments)
-    return gsutil_command(command, parallel)
+    return gsutil_command(command, parallel=parallel, expect_zero=expect_zero)
 
 
-def ls(*ls_arguments, must_exist=True, parallel=False):  # pylint: disable=invalid-name
+def ls(*ls_arguments, expect_zero=True):  # pylint: disable=invalid-name
     """Executes gsutil's "ls" command with |ls_arguments| and returns the result
     and the returncode. Does not except on nonzero return code if not
     |must_exist|."""
     command = ['ls'] + list(ls_arguments)
-    result = gsutil_command(command, expect_zero=must_exist, parallel=parallel)
+    result = gsutil_command(command, expect_zero=expect_zero)
     retcode = result.retcode  # pytype: disable=attribute-error
     output = result.output.splitlines()  # pytype: disable=attribute-error
     return retcode, output

--- a/common/test_filestore_utils.py
+++ b/common/test_filestore_utils.py
@@ -16,6 +16,7 @@
 from unittest import mock
 
 from common import filestore_utils
+from common import new_process
 
 # TODO(zhichengcai): Figure out how we can test filestore_utils when using
 # the local_filestore implementation.
@@ -32,13 +33,15 @@ def test_keyword_args():
             ['gsutil', '-m', 'rm', '-r', filestore_path], expect_zero=True)
 
     with mock.patch('common.new_process.execute') as mocked_execute:
-        filestore_utils.ls(filestore_path, must_exist=False)
+        mocked_execute.return_value = new_process.ProcessResult(0, '', '')
+        filestore_utils.ls(filestore_path)
         mocked_execute.assert_called_with(['gsutil', 'ls', filestore_path],
-                                          expect_zero=False)
+                                          expect_zero=True)
 
     filestore_path2 = filestore_path + '2'
 
     with mock.patch('common.new_process.execute') as mocked_execute:
         filestore_utils.cp(filestore_path, filestore_path2, parallel=True)
         mocked_execute.assert_called_with(
-            ['gsutil', '-m', 'cp', filestore_path, filestore_path2])
+            ['gsutil', '-m', 'cp', filestore_path, filestore_path2],
+            expect_zero=True)

--- a/common/test_filestore_utils.py
+++ b/common/test_filestore_utils.py
@@ -42,11 +42,3 @@ def test_keyword_args():
         filestore_utils.cp(filestore_path, filestore_path2, parallel=True)
         mocked_execute.assert_called_with(
             ['gsutil', '-m', 'cp', filestore_path, filestore_path2])
-
-    with mock.patch('common.new_process.execute') as mocked_execute:
-        filestore_utils.cp(filestore_path,
-                           filestore_path2,
-                           write_to_stdout=False)
-        mocked_execute.assert_called_with(
-            ['gsutil', 'cp', filestore_path, filestore_path2],
-            write_to_stdout=False)

--- a/common/test_gsutil.py
+++ b/common/test_gsutil.py
@@ -40,7 +40,7 @@ class TestGsutilRsync:
                 'common.gsutil.gsutil_command') as mocked_gsutil_command:
             gsutil.rsync(self.SRC, self.DST)
         mocked_gsutil_command.assert_called_with(
-            ['rsync', '-d', '-r', '/src', 'gs://dst'])
+            ['rsync', '-d', '-r', '/src', 'gs://dst'], parallel=False)
 
     def test_gsutil_options(self):
         """Tests that rsync works as intended when supplied a gsutil_options

--- a/common/test_gsutil.py
+++ b/common/test_gsutil.py
@@ -34,9 +34,8 @@ def test_ls_not_must_exist(mocked_gsutil_command):
     """Tests that ls makes a correct call to new_process.execute when
     must_exist=False."""
     gsutil.ls('gs://hello', must_exist=False)
-    mocked_gsutil_command.assert_called_with(
-        ['gsutil', 'ls', 'gs://hello'],
-        expect_zero=False)
+    mocked_gsutil_command.assert_called_with(['gsutil', 'ls', 'gs://hello'],
+                                             expect_zero=False)
 
 
 class TestGsutilRsync:

--- a/common/test_gsutil.py
+++ b/common/test_gsutil.py
@@ -29,6 +29,16 @@ def test_gsutil_command():
     assert mocked_popen.commands == [['gsutil'] + arguments]
 
 
+@mock.patch('common.new_process.execute')
+def test_ls_not_must_exist(mocked_gsutil_command):
+    """Tests that ls makes a correct call to new_process.execute when
+    must_exist=False."""
+    gsutil.ls('gs://hello', must_exist=False)
+    mocked_gsutil_command.assert_called_with(
+        ['gsutil', 'ls', 'gs://hello'],
+        expect_zero=False)
+
+
 class TestGsutilRsync:
     """Tests for gsutil_command works as expected."""
     SRC = '/src'

--- a/experiment/build/build_utils.py
+++ b/experiment/build/build_utils.py
@@ -28,10 +28,8 @@ def store_build_logs(build_config, build_result):
         tmp.flush()
 
         build_log_filename = build_config + '.txt'
-        filestore_utils.cp(tmp.name,
-                           exp_path.gcs(get_build_logs_dir() /
-                                        build_log_filename),
-                           write_to_stdout=False)
+        filestore_utils.cp(
+            tmp.name, exp_path.gcs(get_build_logs_dir() / build_log_filename))
 
 
 def get_coverage_binaries_dir():

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -63,7 +63,7 @@ def get_experiment_folders_dir():
 
 def remote_dir_exists(directory: pathlib.Path) -> bool:
     """Does |directory| exist in the CLOUD_EXPERIMENT_BUCKET."""
-    return filestore_utils.ls(exp_path.gcs(directory), must_exist=False)[0] == 0
+    return filestore_utils.ls(exp_path.gcs(directory), expect_zero=False)[0] == 0
 
 
 def measure_loop(experiment: str, max_total_time: int):

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -63,7 +63,8 @@ def get_experiment_folders_dir():
 
 def remote_dir_exists(directory: pathlib.Path) -> bool:
     """Does |directory| exist in the CLOUD_EXPERIMENT_BUCKET."""
-    return filestore_utils.ls(exp_path.gcs(directory), expect_zero=False)[0] == 0
+    return filestore_utils.ls(exp_path.gcs(directory),
+                              expect_zero=False)[0] == 0
 
 
 def measure_loop(experiment: str, max_total_time: int):

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -51,9 +51,11 @@ FILTER_SOURCE_REGEX = re.compile(r'('
                                  r'^.*\.pyc$|'
                                  r'^__pycache__/|'
                                  r'.*~$|'
+                                 r'\#*\#$|'
                                  r'\.pytest_cache/|'
                                  r'.*/test_data/|'
                                  r'^third_party/oss-fuzz/build/|'
+                                 r'^docker/generated.mk$|'
                                  r'^docs/)')
 
 CONFIG_DIR = 'config'

--- a/experiment/test_run_experiment.py
+++ b/experiment/test_run_experiment.py
@@ -200,8 +200,13 @@ def test_validate_experiment_name_invalid(experiment_name):
     assert 'is invalid. Must match' in str(exception.value)
 
 
-def test_copy_resources_to_bucket():
+# This test takes up to a minute to complete.
+@pytest.mark.long
+def test_copy_resources_to_bucket(tmp_path):
     """Tests that copy_resources_to_bucket copies the correct resources."""
+    # Do this so that Ctrl-C doesn't pollute the repo.
+    os.chdir(tmp_path)
+
     config_dir = 'config'
     config = {
         'cloud_experiment_bucket': 'gs://gsutil-bucket',

--- a/experiment/test_runner.py
+++ b/experiment/test_runner.py
@@ -153,12 +153,14 @@ def test_do_sync_changed(mocked_execute, mocked_is_corpus_dir_same, fs,
             ('gs://bucket/experiment-name/experiment-folders/'
              'benchmark-1-fuzzer-name-a/trial-1/corpus/'
              'corpus-archive-1337.tar.gz')
-        ]),
+        ],
+                  expect_zero=True),
         mock.call([
             'gsutil', 'rsync', '-d', '-r', 'results-copy',
             ('gs://bucket/experiment-name/experiment-folders/'
              'benchmark-1-fuzzer-name-a/trial-1/results')
-        ])
+        ],
+                  expect_zero=True)
     ]
     unchanged_cycles_path = os.path.join(trial_runner.results_dir,
                                          'unchanged-cycles')
@@ -272,10 +274,7 @@ class TestIntegrationRunner:
                 runner.main()
 
         gcs_corpus_directory = posixpath.join(gcs_directory, 'corpus')
-        returncode, snapshots = filestore_utils.ls(gcs_corpus_directory)
-
-        # Ensure that test works.
-        assert returncode == 0, 'gsutil ls %s failed.' % gcs_corpus_directory
+        snapshots = filestore_utils.ls(gcs_corpus_directory)
 
         assert len(snapshots) >= 2
 
@@ -285,9 +284,9 @@ class TestIntegrationRunner:
 
         local_gcs_corpus_dir_copy = tmp_path / 'gcs_corpus_dir'
         os.mkdir(local_gcs_corpus_dir_copy)
-        filestore_utils.cp('-r',
-                           posixpath.join(gcs_corpus_directory, '*'),
+        filestore_utils.cp(posixpath.join(gcs_corpus_directory, '*'),
                            str(local_gcs_corpus_dir_copy),
+                           recursive=True,
                            parallel=True)
         archive_size = os.path.getsize(local_gcs_corpus_dir_copy /
                                        'corpus-archive-0001.tar.gz')


### PR DESCRIPTION
Make the following changes to the API:
1. Don't use `*cp_args` for `cp`, *ls_args` for `ls`, `*rm_args` for `rm`. This is adds complexity and can cause errors because it exposes details of the `cp` and `ls` implementations to callers.
2. Make `parallel` an explicit parameter in the API instead of implicitly passing it to `command/gsutil_command` by passing it `**kwargs`
3. Don't pass `**kwargs` from API users or API functions to `new_process.execute`. This also adds complexity.
4. Don't pass `*args` from API functions to `new_process.execute`. This is very bug prone.
5. Don't rely on `expect_zero=False` in functions other than `ls`. Because we no longer pass `**kwargs` to `execute` (or `gsutil_command`/`command`) we must explicitly support `expect_zero=False` in functions where they were needed. Rather than support it, make callers catch exceptions from `execute`.