### PR TITLE
[make][runner] Use FORCE_LOCAL in debug-, test-run-, run- make targets

### DIFF
--- a/docker/generate_makefile.py
+++ b/docker/generate_makefile.py
@@ -184,6 +184,7 @@ run-{fuzzer}-{benchmark}: .{fuzzer}-{benchmark}-oss-fuzz-runner
     --cap-add SYS_NICE \\
     --cap-add SYS_PTRACE \\
     -e FUZZ_OUTSIDE_EXPERIMENT=1 \\
+    -e FORCE_LOCAL=1 \\
     -e TRIAL_ID=1 \\
     -e FUZZER={fuzzer} \\
     -e BENCHMARK={benchmark} \\
@@ -195,6 +196,7 @@ test-run-{fuzzer}-{benchmark}: .{fuzzer}-{benchmark}-oss-fuzz-runner
     --cap-add SYS_NICE \\
     --cap-add SYS_PTRACE \\
     -e FUZZ_OUTSIDE_EXPERIMENT=1 \\
+    -e FORCE_LOCAL=1 \\
     -e TRIAL_ID=1 \\
     -e FUZZER={fuzzer} \\
     -e BENCHMARK={benchmark} \\
@@ -209,6 +211,7 @@ debug-{fuzzer}-{benchmark}: .{fuzzer}-{benchmark}-oss-fuzz-runner
     --cap-add SYS_NICE \\
     --cap-add SYS_PTRACE \\
     -e FUZZ_OUTSIDE_EXPERIMENT=1 \\
+    -e FORCE_LOCAL=1 \\
     -e TRIAL_ID=1 \\
     -e FUZZER={fuzzer} \\
     -e BENCHMARK={benchmark} \\


### PR DESCRIPTION
They targets are only used locally, and FORCE_LOCAL won't be propagated
from the user's environment to the docker container unless we do this.
So best to assume it is needed.
Fixes #412.