### PR TITLE
Use fuzzer variants for run-time flags only.

### DIFF
--- a/common/fuzzer_utils.py
+++ b/common/fuzzer_utils.py
@@ -160,7 +160,7 @@ def get_fuzzer_configs(fuzzers=None):
         assert 'variants' in variant_config, (
             'Missing "variants" section of {}'.format(variant_config_path))
         for variant in variant_config['variants']:
-            if not fuzzers or variant['name'] in fuzzers:
+            if fuzzers is None or variant['name'] in fuzzers:
                 assert 'name' in variant, (
                     'Missing name attribute for fuzzer variant in {}'.format(
                         variant_config_path))

--- a/docker/gcb/fuzzer.yaml
+++ b/docker/gcb/fuzzer.yaml
@@ -36,12 +36,12 @@ steps:
     '--tag',
     '${_REPO}/builders/${_FUZZER}',
 
-    '--file=fuzzers/${_UNDERLYING_FUZZER}/builder.Dockerfile',
+    '--file=fuzzers/${_FUZZER}/builder.Dockerfile',
 
     '--cache-from',
     '${_REPO}/builders/${_FUZZER}',
 
-    'fuzzers/${_UNDERLYING_FUZZER}'
+    'fuzzers/${_FUZZER}'
   ]
   id: 'build-fuzzer-builder'
   wait_for: ['pull-fuzzer-builder']  # Start this immediately.
@@ -67,7 +67,7 @@ steps:
     '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}',
 
     '--build-arg',
-    'fuzzer=${_UNDERLYING_FUZZER}',
+    'fuzzer=${_FUZZER}',
 
     '--build-arg',
     'benchmark=${_BENCHMARK}',
@@ -102,12 +102,12 @@ steps:
     '--tag',
     '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}-intermediate',
 
-    '--file=fuzzers/${_UNDERLYING_FUZZER}/runner.Dockerfile',
+    '--file=fuzzers/${_FUZZER}/runner.Dockerfile',
 
     '--cache-from',
     '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}-intermediate',
 
-    './fuzzers/${_UNDERLYING_FUZZER}',
+    './fuzzers/${_FUZZER}',
   ]
   id: 'build-fuzzer-benchmark-intermediate-runner'
   wait_for: ['pull-fuzzer-benchmark-intermediate-runner']
@@ -133,7 +133,7 @@ steps:
     '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}',
 
     '--build-arg',
-    'fuzzer=${_UNDERLYING_FUZZER}',
+    'fuzzer=${_FUZZER}',
 
     '--build-arg',
     'benchmark=${_BENCHMARK}',

--- a/docker/gcb/oss-fuzz-fuzzer.yaml
+++ b/docker/gcb/oss-fuzz-fuzzer.yaml
@@ -31,7 +31,7 @@ steps:
     '--tag',
     '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
 
-    '--file=fuzzers/${_UNDERLYING_FUZZER}/builder.Dockerfile',
+    '--file=fuzzers/${_FUZZER}/builder.Dockerfile',
 
     '--cache-from',
     '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
@@ -41,7 +41,7 @@ steps:
     '--build-arg',
     'parent_image=gcr.io/fuzzbench/oss-fuzz/${_OSS_FUZZ_PROJECT}@sha256:${_OSS_FUZZ_BUILDER_HASH}',
 
-    'fuzzers/${_UNDERLYING_FUZZER}',
+    'fuzzers/${_FUZZER}',
   ]
   id: 'build-fuzzer-benchmark-builder-intermediate'
 
@@ -73,7 +73,7 @@ steps:
     'parent_image=${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     '--build-arg',
-    'fuzzer=${_UNDERLYING_FUZZER}',
+    'fuzzer=${_FUZZER}',
 
     '--build-arg',
     'benchmark=${_BENCHMARK}',
@@ -103,12 +103,12 @@ steps:
     '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     '--file',
-    'fuzzers/${_UNDERLYING_FUZZER}/runner.Dockerfile',
+    'fuzzers/${_FUZZER}/runner.Dockerfile',
 
     '--cache-from',
     '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}-intermediate',
 
-    'fuzzers/${_UNDERLYING_FUZZER}',
+    'fuzzers/${_FUZZER}',
   ]
   id: 'build-fuzzer-benchmark-runner-intermediate'
   wait_for: ['pull-fuzzer-benchmark-runner-intermediate', 'build-fuzzer-benchmark-builder']
@@ -134,7 +134,7 @@ steps:
     '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}',
 
     '--build-arg',
-    'fuzzer=${_UNDERLYING_FUZZER}',
+    'fuzzer=${_FUZZER}',
 
     '--cache-from',
     '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}',

--- a/docker/generate_makefile.py
+++ b/docker/generate_makefile.py
@@ -245,7 +245,7 @@ def generate_fuzzer(fuzzer,
                     fuzzer_variant=None):
     """Output make rules for a single fuzzer."""
     if fuzzer_variant:
-        fuzzer_variant_name = fuzzer + '_' + fuzzer_variant['name']
+        fuzzer_variant_name = fuzzer_variant['name']
         fuzzer_variant_env = ' '.join([
             '-e {k}={v}'.format(k=k, v=shlex.quote(str(v)))
             for k, v in fuzzer_variant['env'].items()

--- a/docker/generate_makefile.py
+++ b/docker/generate_makefile.py
@@ -101,7 +101,7 @@ test-run-{fuzzer_variant_name}-{benchmark}: .{fuzzer}-{benchmark}-runner
     -e MAX_TOTAL_TIME=20 \\
     -e SNAPSHOT_PERIOD=10 \\
     {fuzzer_variant_env} \\
-    -it {base_tag}/runners/{fuzzer}/{benchmark}
+    {base_tag}/runners/{fuzzer}/{benchmark}
 
 debug-{fuzzer_variant_name}-{benchmark}: .{fuzzer}-{benchmark}-runner
 	docker run \\
@@ -205,7 +205,7 @@ test-run-{fuzzer_variant_name}-{benchmark}: .{fuzzer}-{benchmark}-oss-fuzz-runne
     -e MAX_TOTAL_TIME=20 \\
     -e SNAPSHOT_PERIOD=10 \\
     {fuzzer_variant_env} \\
-    -it {base_tag}/runners/{fuzzer}/{benchmark}
+    {base_tag}/runners/{fuzzer}/{benchmark}
 
 debug-{fuzzer_variant_name}-{benchmark}: .{fuzzer}-{benchmark}-oss-fuzz-runner
 	docker run \\

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -157,7 +157,7 @@ def validate_fuzzer(fuzzer: str):
 
 def validate_fuzzer_config(fuzzer_config):
     """Validate |fuzzer_config|."""
-    allowed_fields = ['name', 'fuzzer_environment', 'build_arguments', 'fuzzer']
+    allowed_fields = ['name', 'fuzzer_environment', 'fuzzer']
     if 'fuzzer' not in fuzzer_config:
         raise Exception('Fuzzer configuration must include the "fuzzer" field.')
 
@@ -168,10 +168,6 @@ def validate_fuzzer_config(fuzzer_config):
     if ('fuzzer_environment' in fuzzer_config and
             not isinstance(fuzzer_config['fuzzer_environment'], list)):
         raise Exception('Fuzzer environment must be a list.')
-
-    if ('build_arguments' in fuzzer_config and
-            not isinstance(fuzzer_config['build_arguments'], list)):
-        raise Exception('Builder arguments must be a list.')
 
     name = fuzzer_config.get('name')
     if name:

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -157,7 +157,7 @@ def validate_fuzzer(fuzzer: str):
 
 def validate_fuzzer_config(fuzzer_config):
     """Validate |fuzzer_config|."""
-    allowed_fields = ['name', 'fuzzer_environment', 'fuzzer']
+    allowed_fields = ['name', 'env', 'fuzzer']
     if 'fuzzer' not in fuzzer_config:
         raise Exception('Fuzzer configuration must include the "fuzzer" field.')
 
@@ -165,9 +165,8 @@ def validate_fuzzer_config(fuzzer_config):
         if key not in allowed_fields:
             raise Exception('Invalid entry "%s" in fuzzer configuration.' % key)
 
-    if ('fuzzer_environment' in fuzzer_config and
-            not isinstance(fuzzer_config['fuzzer_environment'], list)):
-        raise Exception('Fuzzer environment must be a list.')
+    if ('env' in fuzzer_config and not isinstance(fuzzer_config['env'], dict)):
+        raise Exception('Fuzzer environment "env" must be a dict.')
 
     name = fuzzer_config.get('name')
     if name:

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -710,7 +710,7 @@ def render_startup_script_template(instance_name: str, fuzzer: str,
     provided and return the result."""
     fuzzer_config = fuzzer_config_utils.get_by_variant_name(fuzzer)
     docker_image_url = benchmark_utils.get_runner_image_url(
-        benchmark, fuzzer, experiment_config['cloud_project'])
+        benchmark, fuzzer_config['fuzzer'], experiment_config['cloud_project'])
     fuzz_target = benchmark_utils.get_fuzz_target(benchmark)
 
     # Convert additional environment variables from configuration to arguments

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -718,7 +718,7 @@ def render_startup_script_template(instance_name: str, fuzzer: str,
     additional_env = ''
     if 'env' in fuzzer_config:
         additional_env = ' '.join([
-            '-e {k}={v}'.format(k=k, v=shlex.quote(v))
+            '-e {k}={v}'.format(k=k, v=shlex.quote(str(v)))
             for k, v in fuzzer_config['env'].items()
         ])
 

--- a/experiment/test_run_experiment.py
+++ b/experiment/test_run_experiment.py
@@ -161,7 +161,7 @@ class TestReadAndValdiateExperimentConfig(unittest.TestCase):
 def test_validate_fuzzer_config():
     """Tests that validate_fuzzer_config says that a valid fuzzer config name is
     valid and that an invalid one is not."""
-    config = {'fuzzer': 'afl', 'name': 'name', 'fuzzer_environment': []}
+    config = {'fuzzer': 'afl', 'name': 'name', 'env': {'a': 'b'}}
     run_experiment.validate_fuzzer_config(config)
 
     with pytest.raises(Exception) as exception:
@@ -182,9 +182,9 @@ def test_validate_fuzzer_config():
     del config['invalid_key']
 
     with pytest.raises(Exception) as exception:
-        config['fuzzer_environment'] = {'a': 'b'}
+        config['env'] = []
         run_experiment.validate_fuzzer_config(config)
-    assert 'must be a list' in str(exception.value)
+    assert 'must be a dict' in str(exception.value)
 
 
 def test_variant_configs_valid():

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -83,10 +83,10 @@ def pending_trials(db, experiment_config):
 
 @pytest.mark.parametrize(
     'benchmark,expected_image,expected_target',
-    [('benchmark1', 'gcr.io/fuzzbench/runners/variant/benchmark1',
+    [('benchmark1', 'gcr.io/fuzzbench/runners/fuzzer-a/benchmark1',
       'fuzz-target'),
      ('bloaty_fuzz_target',
-      'gcr.io/fuzzbench/runners/variant/bloaty_fuzz_target', 'fuzz_target')])
+      'gcr.io/fuzzbench/runners/fuzzer-a/bloaty_fuzz_target', 'fuzz_target')])
 def test_create_trial_instance(benchmark, expected_image, expected_target,
                                experiment_config):
     """Test that create_trial_instance invokes create_instance
@@ -121,10 +121,10 @@ docker run \\
 
 @pytest.mark.parametrize(
     'benchmark,expected_image,expected_target',
-    [('benchmark1', 'gcr.io/fuzzbench/runners/variant/benchmark1',
+    [('benchmark1', 'gcr.io/fuzzbench/runners/fuzzer-a/benchmark1',
       'fuzz-target'),
      ('bloaty_fuzz_target',
-      'gcr.io/fuzzbench/runners/variant/bloaty_fuzz_target', 'fuzz_target')])
+      'gcr.io/fuzzbench/runners/fuzzer-a/bloaty_fuzz_target', 'fuzz_target')])
 def test_create_trial_instance_local_experiment(benchmark, expected_image,
                                                 expected_target,
                                                 experiment_config, environ):

--- a/service/automatic_run_experiment.py
+++ b/service/automatic_run_experiment.py
@@ -82,6 +82,11 @@ def _get_experiment_name(experiment_config: dict) -> str:
     return str(experiment_config['experiment'])
 
 
+def _get_requested_experiments():
+    """Return requested experiments."""
+    return yaml_utils.read(REQUESTED_EXPERIMENTS_PATH)
+
+
 def validate_experiment_name(experiment_name):
     """Returns True if |experiment_name| is valid."""
     return EXPERIMENT_NAME_REGEX.match(experiment_name) is not None
@@ -164,7 +169,7 @@ def validate_experiment_requests(experiment_requests):
 def run_requested_experiment(dry_run):
     """Run the oldest requested experiment that hasn't been run yet in
     experiment-requests.yaml."""
-    requested_experiments = yaml_utils.read(REQUESTED_EXPERIMENTS_PATH)
+    requested_experiments = _get_requested_experiments()
 
     # TODO(metzman): Look into supporting benchmarks as an optional parameter so
     # that people can add fuzzers that don't support everything.

--- a/service/test_automatic_run_experiment.py
+++ b/service/test_automatic_run_experiment.py
@@ -37,15 +37,17 @@ EXPERIMENT_REQUESTS = [{
 
 @mock.patch('experiment.run_experiment.start_experiment')
 @mock.patch('common.logs.warning')
-@mock.patch('common.yaml_utils.read')
-def test_run_requested_experiment_pause_service(mocked_read, mocked_warning,
-                                                mocked_start_experiment, db):
+@mock.patch('service.automatic_run_experiment._get_requested_experiments')
+def test_run_requested_experiment_pause_service(
+        mocked_get_requested_experiments, mocked_warning,
+        mocked_start_experiment, db):
     """Tests that run_requested_experiment doesn't run an experiment when a
     pause is requested."""
     experiment_requests_with_pause = EXPERIMENT_REQUESTS.copy()
     experiment_requests_with_pause.append(
         automatic_run_experiment.PAUSE_SERVICE_KEYWORD)
-    mocked_read.return_value = experiment_requests_with_pause
+    mocked_get_requested_experiments.return_value = (
+        experiment_requests_with_pause)
 
     assert (automatic_run_experiment.run_requested_experiment(dry_run=False) is
             None)
@@ -56,12 +58,13 @@ def test_run_requested_experiment_pause_service(mocked_read, mocked_warning,
 
 @mock.patch('experiment.run_experiment.start_experiment')
 @mock.patch('experiment.stop_experiment.stop_experiment')
-@mock.patch('common.yaml_utils.read')
-def test_run_requested_experiment(mocked_read, mocked_stop_experiment,
+@mock.patch('service.automatic_run_experiment._get_requested_experiments')
+def test_run_requested_experiment(mocked_get_requested_experiments,
+                                  mocked_stop_experiment,
                                   mocked_start_experiment, db):
     """Tests that run_requested_experiment starts and stops the experiment
     properly."""
-    mocked_read.return_value = EXPERIMENT_REQUESTS
+    mocked_get_requested_experiments.return_value = EXPERIMENT_REQUESTS
     expected_experiment_name = '2020-06-05'
     expected_fuzzers = ['honggfuzz', 'afl']
     automatic_run_experiment.run_requested_experiment(dry_run=False)


### PR DESCRIPTION
Remove complex and unmaintainable build argument support.
For fuzzers needing different build time variants should
be just use a different fuzzer directory e.g.
"fuzzer_build_config_1"