### PR TITLE
afl++ performance fix

### DIFF
--- a/fuzzers/aflplusplus/builder.Dockerfile
+++ b/fuzzers/aflplusplus/builder.Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && git checkout dev && \
-    git checkout fc26001b50d27a276d2d50af1dbcd4dfa3886de5 && \
+    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     cd llvm_mode && make

--- a/fuzzers/aflplusplus_optimal/builder.Dockerfile
+++ b/fuzzers/aflplusplus_optimal/builder.Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && \
-    git checkout fc26001b50d27a276d2d50af1dbcd4dfa3886de5 && \
+    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     cd llvm_mode && LLVM_CONFIG=llvm-config-11 REAL_CC=gcc-9 REAL_CXX=g++-9 make && \

--- a/fuzzers/aflplusplus_optimal_shmem/builder.Dockerfile
+++ b/fuzzers/aflplusplus_optimal_shmem/builder.Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && \
-    git checkout fc26001b50d27a276d2d50af1dbcd4dfa3886de5 && \
+    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     cd llvm_mode && LLVM_CONFIG=llvm-config-11 REAL_CC=gcc-9 REAL_CXX=g++-9 make && \

--- a/fuzzers/aflplusplus_qemu/builder.Dockerfile
+++ b/fuzzers/aflplusplus_qemu/builder.Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && git checkout dev && \
-    git checkout fc26001b50d27a276d2d50af1dbcd4dfa3886de5 && \
+    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     cd qemu_mode && ./build_qemu_support.sh && cd .. && \

--- a/fuzzers/aflplusplus_shmem/builder.Dockerfile
+++ b/fuzzers/aflplusplus_shmem/builder.Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && git checkout dev && \
-    git checkout fc26001b50d27a276d2d50af1dbcd4dfa3886de5 && \
+    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     make -C llvm_mode && \


### PR DESCRIPTION
When I integrated AFLfast 13 months ago I blindly copied the code and that activated a change that had a lasting performance impact - for every single fuzzing attempt there would be a hash performed on the result map and compared to all queue entries. this resulted in an 10-15% performance descrease, also if non AFLfast schedules were used.

This performance impact is the reason why AFLfast does not perform as well as AFL here on fuzzbench.

Today I finally found that cause and fixed it to only be done on AFfast schedules. And now afl++ is faster than afl :)

@mboehme
