### PR TITLE
local filestore rsync intermediate folders creation

### DIFF
--- a/common/local_filestore.py
+++ b/common/local_filestore.py
@@ -73,6 +73,11 @@ def rsync(  # pylint: disable=too-many-arguments
     defaults that can be overriden."""
     # Add check to behave like `gsutil.rsync`.
     assert os.path.isdir(source), 'filestore_utils.rsync: source should be dir.'
+
+    # Create intermediate folders for `rsync` command to behave like
+    # `gsutil.rsync`.
+    filesystem.create_directory(destination)
+
     command = ['rsync']
     if delete:
         command.append('--delete')

--- a/common/test_local_filestore.py
+++ b/common/test_local_filestore.py
@@ -47,6 +47,16 @@ def test_ls_non_must_exist(tmp_path):
     local_filestore.ls(str(file_path), must_exist=False)
 
 
+def test_ls_one_file_per_line(tmp_path):
+    """Tests ls will list files as one per line."""
+    dir_path = tmp_path
+    file1 = dir_path / 'file1'
+    file2 = dir_path / 'file2'
+    open(file1, "w+").close()
+    open(file2, "w+").close()
+    assert local_filestore.ls(str(dir_path)).output == 'file1\nfile2\n'
+
+
 def test_cp(tmp_path):
     """Tests cp works as expected."""
     source = tmp_path / 'source'
@@ -57,6 +67,19 @@ def test_cp(tmp_path):
     local_filestore.cp(str(source), str(destination))
     with open(destination) as file_handle:
         assert file_handle.read() == data
+
+
+def test_non_exist_dest(tmp_path):
+    """Tests cp and rsync will create intermediate folders for destination."""
+    source_dir = tmp_path / 'source'
+    source_dir.mkdir()
+    source_file = source_dir / 'file1'
+    open(source_file, "w+").close()
+
+    cp_dest_dir = tmp_path / 'cp_test' / 'intermediate' / 'cp_dest'
+    rsync_dest_dir = tmp_path / 'rsync_test' / 'intermediate' / 'rsync_dest'
+    local_filestore.cp(str(source_dir), str(cp_dest_dir), recursive=True)
+    local_filestore.rsync(str(source_dir), str(rsync_dest_dir))
 
 
 SRC = '/src'

--- a/common/test_local_filestore.py
+++ b/common/test_local_filestore.py
@@ -47,16 +47,6 @@ def test_ls_non_must_exist(tmp_path):
     local_filestore.ls(str(file_path), must_exist=False)
 
 
-def test_ls_one_file_per_line(tmp_path):
-    """Tests ls will list files as one per line."""
-    dir_path = tmp_path
-    file1 = dir_path / 'file1'
-    file2 = dir_path / 'file2'
-    open(file1, "w+").close()
-    open(file2, "w+").close()
-    assert local_filestore.ls(str(dir_path)).output == 'file1\nfile2\n'
-
-
 def test_cp(tmp_path):
     """Tests cp works as expected."""
     source = tmp_path / 'source'

--- a/common/test_local_filestore.py
+++ b/common/test_local_filestore.py
@@ -59,19 +59,29 @@ def test_cp(tmp_path):
         assert file_handle.read() == data
 
 
-def test_nonexistent_dest(tmp_path):
-    """Tests cp and rsync will create intermediate folders for destination."""
+def test_cp_nonexistent_dest(tmp_path):
+    """Tests cp will create intermediate folders for destination."""
     source_dir = tmp_path / 'source'
     source_dir.mkdir()
     source_file = source_dir / 'file1'
+    cp_dest_dir = tmp_path / 'cp_test' / 'intermediate' / 'cp_dest'
     with open(source_file, 'w'):
         pass
 
-    cp_dest_dir = tmp_path / 'cp_test' / 'intermediate' / 'cp_dest'
-    rsync_dest_dir = tmp_path / 'rsync_test' / 'intermediate' / 'rsync_dest'
-
     # Should run without exceptions.
     local_filestore.cp(str(source_dir), str(cp_dest_dir), recursive=True)
+
+
+def test_rsync_nonexistent_dest(tmp_path):
+    """Tests cp will create intermediate folders for destination."""
+    source_dir = tmp_path / 'source'
+    source_dir.mkdir()
+    source_file = source_dir / 'file1'
+    rsync_dest_dir = tmp_path / 'rsync_test' / 'intermediate' / 'rsync_dest'
+    with open(source_file, 'w'):
+        pass
+
+    # Should run without exceptions.
     local_filestore.rsync(str(source_dir), str(rsync_dest_dir))
 
 

--- a/common/test_local_filestore.py
+++ b/common/test_local_filestore.py
@@ -59,15 +59,18 @@ def test_cp(tmp_path):
         assert file_handle.read() == data
 
 
-def test_non_exist_dest(tmp_path):
+def test_nonexistent_dest(tmp_path):
     """Tests cp and rsync will create intermediate folders for destination."""
     source_dir = tmp_path / 'source'
     source_dir.mkdir()
     source_file = source_dir / 'file1'
-    open(source_file, "w+").close()
+    with open(source_file, 'w'):
+        pass
 
     cp_dest_dir = tmp_path / 'cp_test' / 'intermediate' / 'cp_dest'
     rsync_dest_dir = tmp_path / 'rsync_test' / 'intermediate' / 'rsync_dest'
+
+    # Should run without exceptions.
     local_filestore.cp(str(source_dir), str(cp_dest_dir), recursive=True)
     local_filestore.rsync(str(source_dir), str(rsync_dest_dir))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`rsync` will fail when the destination folder's parent folder does not exist.
See below:
```
cd /tmp && mkdir test_dir
touch test_dir/hello
rsync -r test_dir/ new_dir/middle_dir/dest_dir
```
Then it shows up:
```
rsync: mkdir "/tmp/new_dir/middle_dir/dest_dir" failed: No such file or directory (2)
rsync error: error in file IO (code 11) at main.c(682) [Receiver=3.1.3]
```
If we create the intermediate folder, it will work
```
mkdir -p new_dir/middle_dir
rsync -r test_dir/ new_dir/middle_dir/dest_dir
```
Then no errors show up.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some current `filestore_utils.rsync` would fail if no this fix. 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Unit test is added.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
