### PR TITLE
set related environ var for local running

### DIFF
--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -287,6 +287,7 @@ def copy_resources_to_bucket(config_dir: str, config: Dict):
             return None
         return tar_info
 
+    # Set environment variables to use corresponding filestore_utils.
     os.environ['EXPERIMENT_FILESTORE'] = config['experiment_filestore']
     os.environ['EXPERIMENT'] = config['experiment']
     experiment_filestore_path = experiment_utils.get_experiment_filestore_path()

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -287,8 +287,10 @@ def copy_resources_to_bucket(config_dir: str, config: Dict):
             return None
         return tar_info
 
-    experiment_filestore_path = os.path.join(config['experiment_filestore'],
-                                             config['experiment'])
+    os.environ['EXPERIMENT_FILESTORE'] = config['experiment_filestore']
+    os.environ['EXPERIMENT'] = config['experiment']
+    experiment_filestore_path = experiment_utils.get_experiment_filestore_path()
+
     base_destination = os.path.join(experiment_filestore_path, 'input')
 
     # Send the local source repository to the cloud for use by dispatcher.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When running locally, the following `filestore_utils.cp` and `filestore_utils.rsync` rely on two environment variables value to switch on `local_filestore` to use:

https://github.com/google/fuzzbench/blob/69feb9c327094033ced66ec2aea362c54bbbbb2a/experiment/run_experiment.py#L299-L304

where the logic is calling `_using_gsutil`
https://github.com/google/fuzzbench/blob/69feb9c327094033ced66ec2aea362c54bbbbb2a/common/filestore_utils.py#L19-L23

And then `get_experiment_filestore_path()` will need to get `os.environ['EXPERIMENT']` and `os.environ['EXPERIMENT_FILESTORE']`:
https://github.com/google/fuzzbench/blob/69feb9c327094033ced66ec2aea362c54bbbbb2a/common/experiment_utils.py#L45-L48
https://github.com/google/fuzzbench/blob/69feb9c327094033ced66ec2aea362c54bbbbb2a/common/experiment_utils.py#L35-L37

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

It will not change the behavior for cloud running, when `experiment_filestore` starts with `gs://`.