### PR TITLE
Fix/improve queue-based measuring

### DIFF
--- a/common/queue_utils.py
+++ b/common/queue_utils.py
@@ -15,9 +15,12 @@
 import redis
 import rq
 
+from common import experiment_utils
 
-def initialize_queue(redis_host, queue_name='default'):
+
+def initialize_queue(redis_host):
     """Returns a redis-backed rq queue."""
+    queue_name = experiment_utils.get_experiment_name()
     redis_connection = redis.Redis(host=redis_host)
     queue = rq.Queue(queue_name, connection=redis_connection)
     return queue

--- a/common/queue_utils.py
+++ b/common/queue_utils.py
@@ -14,6 +14,7 @@
 """Code for setting up a work queue with rq."""
 import redis
 import rq
+import rq.job
 
 from common import experiment_utils
 
@@ -24,3 +25,9 @@ def initialize_queue(redis_host):
     redis_connection = redis.Redis(host=redis_host)
     queue = rq.Queue(queue_name, connection=redis_connection)
     return queue
+
+
+def get_all_jobs(queue):
+    """Returns all the jobs in queue."""
+    job_ids = queue.get_job_ids()
+    return rq.job.Job.fetch_many(job_ids, queue.connection)

--- a/docker/measure-worker/startup-worker.sh
+++ b/docker/measure-worker/startup-worker.sh
@@ -14,4 +14,4 @@
 # limitations under the License.
 
 source $VIRTUALENV_DIR/bin/activate
-rq worker --url redis://$REDIS_HOST:6379
+rq worker $EXPERIMENT --url redis://$REDIS_HOST:6379

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -150,9 +150,10 @@ def measure_all_trials(experiment_config: dict, queue) -> bool:  # pylint: disab
     # now because the scheduler quits too early.
     schedule_measure_workers.schedule(experiment_config, queue)
 
-    # Poll the queue for snapshots and save them in batches until the workers
-    # are done processing each unmeasured snapshot. Then save any remaining
-    # snapshots.
+    # Poll the queue for snapshots and save them in batches, for each snapshot
+    # that was measured, schedule another task to measure the next snapshot for
+    # that trial. Do this until there are no more tasks and then save any
+    # remaining snapshots.
     snapshots = []
     snapshots_measured = False
 
@@ -172,7 +173,6 @@ def measure_all_trials(experiment_config: dict, queue) -> bool:  # pylint: disab
         job_ids = initial_jobs.keys()
         jobs = rq.job.Job.fetch_many(job_ids, queue.connection)
 
-        logger.info('len(results): %d', len(jobs))
         for job in jobs:
             if job is None:
                 logger.error('job is None. Others: %s',

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -175,12 +175,13 @@ def measure_all_trials(experiment_config: dict, queue) -> bool:  # pylint: disab
         logger.info('len(results): %d', len(jobs))
         for job in jobs:
             if job is None:
-                logger.info('job is None, %s', all(j is None for j in jobs))
+                logger.error('job is None. Others: %s',
+                             all(j is None for j in jobs))
                 initial_jobs = {}
                 break
             status = job.get_status(refresh=False)
             if status is None:
-                logger.info('%s returned None', job.get_call_string())
+                logger.error('%s returned None', job.get_call_string())
                 del initial_jobs[job.id]
                 continue
 
@@ -196,6 +197,9 @@ def measure_all_trials(experiment_config: dict, queue) -> bool:  # pylint: disab
 
             del initial_jobs[job.id]
             if job.return_value is None:
+                # The task completed successfully but was not able to measure
+                # the snapshot. This could have happened because the snapshot
+                # does not exist yet.
                 continue
 
             snapshot = job.return_value

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -68,7 +68,7 @@ def measure_loop(experiment_config: dict):
                     # Given that we couldn't measure any snapshots, we won't
                     # be able to measure any the future, so stop now.
                     break
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             logger.error('Error occurred during measuring.')
 
             time.sleep(FAIL_WAIT_SECONDS)

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -80,7 +80,7 @@ def measure_loop(experiment_config: dict):
 
 def get_job_timeout():
     """Returns the timeout for an rq job."""
-    return experiment_utils.get_snapshot_seconds() + 5
+    return experiment_utils.get_snapshot_seconds() + 2 * 60
 
 
 def enqueue_measure_jobs_for_unmeasured(experiment_config: dict, queue):
@@ -167,7 +167,6 @@ def measure_all_trials(experiment_config: dict, queue) -> bool:  # pylint: disab
         nonlocal snapshots_measured
         snapshots_measured = True
 
-    # TODO(metzman): Why does this seem to loop forever?
     while True:
         all_finished = True
         job_ids = initial_jobs.keys()

--- a/experiment/measurer/measure_worker.py
+++ b/experiment/measurer/measure_worker.py
@@ -25,11 +25,11 @@ import time
 from typing import List, Set
 
 from common import benchmark_utils
-from common import experiment_utils
 from common import experiment_path as exp_path
+from common import experiment_utils
 from common import filesystem
-from common import fuzzer_utils
 from common import filestore_utils
+from common import fuzzer_utils
 from common import logs
 from common import utils
 from database import models
@@ -46,8 +46,9 @@ SnapshotMeasureRequest = collections.namedtuple(
 def initialize_logs():
     """Initialize logs. This must be called on process start."""
     logs.initialize(default_extras={
-        'component': 'dispatcher',
+        'component': 'worker',
         'subcomponent': 'measurer',
+        'experiment': experiment_utils.get_experiment_name()
     })
 
 
@@ -409,7 +410,7 @@ def set_up_coverage_binary(benchmark):
     if os.path.exists(benchmark_coverage_binary_dir):
         return
 
-    os.mkdir(benchmark_coverage_binary_dir)
+    filesystem.create_directory(benchmark_coverage_binary_dir)
     archive_name = 'coverage-build-%s.tar.gz' % benchmark
     cloud_bucket_archive_path = exp_path.gcs(coverage_binaries_dir /
                                              archive_name)

--- a/experiment/measurer/measure_worker.py
+++ b/experiment/measurer/measure_worker.py
@@ -45,11 +45,12 @@ SnapshotMeasureRequest = collections.namedtuple(
 
 def initialize_logs():
     """Initialize logs. This must be called on process start."""
-    logs.initialize(default_extras={
-        'component': 'worker',
-        'subcomponent': 'measurer',
-        'experiment': experiment_utils.get_experiment_name()
-    })
+    logs.initialize(
+        default_extras={
+            'component': 'worker',
+            'subcomponent': 'measurer',
+            'experiment': experiment_utils.get_experiment_name()
+        })
 
 
 def extract_corpus(corpus_archive: str, sha_blacklist: Set[str],

--- a/experiment/measurer/test_measure_manager.py
+++ b/experiment/measurer/test_measure_manager.py
@@ -53,11 +53,10 @@ def test_measure_all_trials_no_more(mocked_directories_have_same_files,
 
 
 @mock.patch('experiment.scheduler.all_trials_ended')
-@mock.patch('experiment.measurer.measure_manager.set_up_coverage_binaries')
 @mock.patch('experiment.measurer.measure_manager.measure_all_trials')
 @mock.patch('multiprocessing.Manager')
 @mock.patch('multiprocessing.pool')
-def test_measure_loop_end(_, mocked_manager, mocked_measure_all_trials, __,
+def test_measure_loop_end(_, mocked_manager, mocked_measure_all_trials,
                           mocked_all_trials_ended):
     """Tests that measure_loop stops when there is nothing left to measure."""
     call_count = 0

--- a/experiment/measurer/test_measure_manager.py
+++ b/experiment/measurer/test_measure_manager.py
@@ -53,8 +53,8 @@ def test_measure_all_trials_no_more(mocked_directories_have_same_files,
 @mock.patch('experiment.schedule_measure_workers.initialize')
 @mock.patch('experiment.scheduler.all_trials_ended')
 @mock.patch('experiment.measurer.measure_manager.measure_all_trials')
-def test_measure_loop_end(mocked_measure_all_trials,
-                          mocked_all_trials_ended, _, __, experiment_config):
+def test_measure_loop_end(mocked_measure_all_trials, mocked_all_trials_ended, _,
+                          __, experiment_config):
     """Tests that measure_loop stops when there is nothing left to measure."""
     call_count = 0
 

--- a/experiment/schedule_measure_workers.py
+++ b/experiment/schedule_measure_workers.py
@@ -25,7 +25,7 @@ from common import logs
 from common import queue_utils
 from common import yaml_utils
 
-logger = logs.Logger('scheduler')  # pylint: disable=invalid-name
+logger = logs.Logger('schedule_measure_workers')  # pylint: disable=invalid-name
 
 MAX_INSTANCES_PER_GROUP = 1000
 

--- a/experiment/schedule_measure_workers.py
+++ b/experiment/schedule_measure_workers.py
@@ -26,17 +26,19 @@ logger = logs.Logger('scheduler')  # pylint: disable=invalid-name
 def get_instance_group_name(experiment: str):
     """Returns the name of the instance group of measure workers for
     |experiment|."""
-    return experiment + '-measure-worker'
+    # "worker-" needs to come first because name cannot start with number.
+    return 'worker-' + experiment
 
 
 def get_measure_worker_instance_template_name(experiment: str):
     """Returns an instance template name for measurer workers running in
     |experiment|."""
-    return experiment + '-measure-worker'
+    return 'worker-' + experiment
 
 
 def initialize(experiment_config: dict):
     """Initialize everything that will be needed to schedule measurers."""
+    logger.info('Initializing worker scheduling.')
     experiment = experiment_config['experiment']
     instance_template_name = get_measure_worker_instance_template_name(
         experiment)
@@ -79,6 +81,7 @@ def schedule(experiment_config: dict, queue):
         counts[job.get_status()] += 1
 
     num_instances_needed = counts['queued'] + counts['started']
+    logger.info('Scheduling %d workers.', num_instances_needed)
     instance_group_name = get_instance_group_name(
         experiment_config['experiment'])
     project = experiment_config['cloud_project']

--- a/experiment/schedule_measure_workers.py
+++ b/experiment/schedule_measure_workers.py
@@ -29,18 +29,18 @@ logger = logs.Logger('scheduler')  # pylint: disable=invalid-name
 
 MAX_INSTANCES_PER_GROUP = 1000
 
-# !!!
+
 def get_instance_group_name(experiment: str):
     """Returns the name of the instance group of measure workers for
     |experiment|."""
     # "worker-" needs to come first because name cannot start with number.
-    return 'worker2-' + experiment
+    return 'worker-' + experiment
 
 
 def get_measure_worker_instance_template_name(experiment: str):
     """Returns an instance template name for measurer workers running in
     |experiment|."""
-    return 'worker2-' + experiment
+    return 'worker-' + experiment
 
 
 def initialize(experiment_config: dict):

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -100,8 +100,7 @@ def get_expired_trials(experiment: str, max_total_time: int):
 
 
 def all_trials_ended(experiment: str) -> bool:
-    """Return a bool if there are any trials in |experiment| that have not
-    started."""
+    """Returns True if all trials for |experiment| have ended."""
     return not get_experiment_trials(experiment).filter(
         models.Trial.time_ended.is_(None)).all()
 

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -42,7 +42,7 @@ from experiment import schedule_measure_workers
 # minutes is an arbitrary amount of time.
 GRACE_TIME_SECONDS = 5 * 60
 
-FAIL_WAIT_SECONDS = 10 * 60
+WAIT_SECONDS = 5 * 60
 
 logger = logs.Logger('scheduler')  # pylint: disable=invalid-name
 
@@ -623,7 +623,7 @@ def _schedule_loop(experiment_config: dict):
             # - We have not been able to start trials and still have some
             #   remaining. This can happen when we run out of instance quota.
             # In these cases, sleep before retrying again.
-            time.sleep(FAIL_WAIT_SECONDS)
+            time.sleep(WAIT_SECONDS)
 
     schedule_measure_workers.teardown(experiment_config)
     logger.info('Finished scheduling.')

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -41,7 +41,7 @@ from database import utils as db_utils
 # minutes is an arbitrary amount of time.
 GRACE_TIME_SECONDS = 5 * 60
 
-WAIT_SECONDS = 5 * 60
+WAIT_SECONDS = 10 * 60
 
 logger = logs.Logger('scheduler')  # pylint: disable=invalid-name
 

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -217,9 +217,7 @@ def test_start_trials_not_started(mocked_get_by_variant_name,
 @mock.patch('common.new_process.execute')
 @mock.patch('common.fuzzer_config_utils.get_by_variant_name')
 @mock.patch('experiment.scheduler.datetime_now')
-@mock.patch('experiment.schedule_measure_workers.initialize')
-@mock.patch('experiment.schedule_measure_workers.schedule')
-def test_schedule_trials(_, __, mocked_datetime_now, mocked_get_by_variant_name,
+def test_schedule_trials(mocked_datetime_now, mocked_get_by_variant_name,
                          mocked_execute, pending_trials, experiment_config):
     """Tests that schedule() ends expired trials and starts new ones as
     needed."""
@@ -237,9 +235,8 @@ def test_schedule_trials(_, __, mocked_datetime_now, mocked_get_by_variant_name,
         datetime.timedelta(seconds=(experiment_config['max_total_time'] +
                                     scheduler.GRACE_TIME_SECONDS * 2)))
 
-    queue = None
     with ThreadPool() as pool:
-        scheduler.schedule(experiment_config, pool, queue)
+        scheduler.schedule(experiment_config, pool)
     assert db_utils.query(models.Trial).filter(
         models.Trial.time_started.in_(
             datetimes_first_experiments_started)).all() == (db_utils.query(


### PR DESCRIPTION
1. Fix some bugs in naming templates/groups.
2. Use an experiment-specific queue so that multiple experiments can run at the same time
without interfering with one another.
3. (temporary) Move measurer worker scheduling into the measure because the scheduler usually
quits before the measurer is finished.
4. Try to measure next cycle after previous cycle is measured successfully. This reduces
bottlenecks. Since 3 can make some workers live longer than they need to, this reduces
the amount of time they are idle by ensuring we don't wait around for the last few tasks
to finish before reducing the number of tasks.
4. Rename FAIL_WAIT_SECONDS to WAIT_SECONDS in scheduler as it is done even on success.
5. Use a separate process for the scheduler.