### PR TITLE
Remove command line fuzzer variants.

### DIFF
--- a/common/fuzzer_config_utils.py
+++ b/common/fuzzer_config_utils.py
@@ -13,26 +13,8 @@
 # limitations under the License.
 """Configuration helper functions."""
 
-import os
-
 from common import experiment_path as exp_path
 from common import yaml_utils
-
-
-def get_by_variant_name(fuzzer_variant_name):
-    """Get a fuzzer config based on a fuzzer's display name."""
-    config_directory = get_fuzzer_configs_dir()
-    for config_filename in os.listdir(config_directory):
-        config_absolute_filename = config_directory / config_filename
-        if fuzzer_variant_name == get_fuzzer_name(config_absolute_filename):
-            return yaml_utils.read(config_absolute_filename)
-
-    return None
-
-
-def get_underlying_fuzzer_name(fuzzer_name):
-    """Get the underlying fuzzer name from the configuration's display name."""
-    return get_by_variant_name(fuzzer_name)['fuzzer']
 
 
 def get_dir():

--- a/common/fuzzer_utils.py
+++ b/common/fuzzer_utils.py
@@ -173,3 +173,12 @@ def get_fuzzer_configs(fuzzers=None):
             names.add(name)
 
     return fuzzer_configs
+
+
+def get_by_variant_name(fuzzer_variant_name):
+    """Get a fuzzer config based on a fuzzer's display name."""
+    fuzzer_configs = get_fuzzer_configs(fuzzers=[fuzzer_variant_name])
+    if not fuzzer_configs:
+        return None
+
+    return fuzzer_configs[0]

--- a/experiment/build/gcb_build.py
+++ b/experiment/build/gcb_build.py
@@ -19,7 +19,7 @@ from typing import Dict, Tuple
 from common import benchmark_utils
 from common import experiment_path as exp_path
 from common import experiment_utils
-from common import fuzzer_config_utils
+from common import fuzzer_utils
 from common import logs
 from common import new_process
 from common import utils
@@ -70,8 +70,7 @@ def _build_benchmark_coverage(benchmark: str) -> Tuple[int, str]:
 def _build_oss_fuzz_project_fuzzer(benchmark: str,
                                    fuzzer: str) -> Tuple[int, str]:
     """Build a |benchmark|, |fuzzer| runner image on GCB."""
-    underlying_fuzzer = fuzzer_config_utils.get_by_variant_name(
-        fuzzer)['fuzzer']
+    underlying_fuzzer = fuzzer_utils.get_by_variant_name(fuzzer)['fuzzer']
     project = benchmark_utils.get_project(benchmark)
     oss_fuzz_builder_hash = benchmark_utils.get_oss_fuzz_builder_hash(benchmark)
     substitutions = {
@@ -89,8 +88,7 @@ def _build_oss_fuzz_project_fuzzer(benchmark: str,
 
 def _build_benchmark_fuzzer(benchmark: str, fuzzer: str) -> Tuple[int, str]:
     """Build a |benchmark|, |fuzzer| runner image on GCB."""
-    underlying_fuzzer = fuzzer_config_utils.get_by_variant_name(
-        fuzzer)['fuzzer']
+    underlying_fuzzer = fuzzer_utils.get_by_variant_name(fuzzer)['fuzzer']
     # See link for why substitutions must begin with an underscore:
     # https://cloud.google.com/cloud-build/docs/configuring-builds/substitute-variable-values#using_user-defined_substitutions
     substitutions = {

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -497,12 +497,6 @@ def main():
                                required=False,
                                default=None,
                                choices=all_fuzzers)
-    fuzzers_group.add_argument('-fc',
-                               '--fuzzer-configs',
-                               help='Fuzzer configurations to use.',
-                               nargs='+',
-                               required=False,
-                               default=[])
     fuzzers_group.add_argument('-cf',
                                '--changed-fuzzers',
                                help=('Use fuzzers that have changed since the '
@@ -515,20 +509,14 @@ def main():
 
     args = parser.parse_args()
 
-    if args.fuzzer_configs:
-        fuzzer_configs = [
-            yaml_utils.read(fuzzer_config)
-            for fuzzer_config in args.fuzzer_configs
-        ]
+    if args.changed_fuzzers:
+        fuzzers = experiment_changes.get_fuzzers_changed_since_last()
+        if not fuzzers:
+            logs.error('No fuzzers changed since last experiment. Exiting.')
+            return 1
     else:
-        if args.changed_fuzzers:
-            fuzzers = experiment_changes.get_fuzzers_changed_since_last()
-            if not fuzzers:
-                logs.error('No fuzzers changed since last experiment. Exiting.')
-                return 1
-        else:
-            fuzzers = args.fuzzers
-        fuzzer_configs = fuzzer_utils.get_fuzzer_configs(fuzzers)
+        fuzzers = args.fuzzers
+    fuzzer_configs = fuzzer_utils.get_fuzzer_configs(fuzzers)
 
     start_experiment(args.experiment_name, args.experiment_config,
                      args.benchmarks, fuzzer_configs)

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -26,7 +26,7 @@ import jinja2
 
 from common import benchmark_utils
 from common import experiment_utils
-from common import fuzzer_config_utils
+from common import fuzzer_utils
 from common import gcloud
 from common import gce
 from common import logs
@@ -708,7 +708,7 @@ def render_startup_script_template(instance_name: str, fuzzer: str,
                                    experiment_config: dict):
     """Render the startup script using the template and the parameters
     provided and return the result."""
-    fuzzer_config = fuzzer_config_utils.get_by_variant_name(fuzzer)
+    fuzzer_config = fuzzer_utils.get_by_variant_name(fuzzer)
     docker_image_url = benchmark_utils.get_runner_image_url(
         benchmark, fuzzer_config['fuzzer'], experiment_config['cloud_project'])
     fuzz_target = benchmark_utils.get_fuzz_target(benchmark)

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -158,7 +158,7 @@ docker run -v ~/.config/gcloud:/root/.config/gcloud \\
 
 
 @mock.patch('common.gcloud.create_instance')
-@mock.patch('common.fuzzer_config_utils.get_by_variant_name')
+@mock.patch('common.fuzzer_utils.get_by_variant_name')
 def _test_create_trial_instance(  # pylint: disable=too-many-locals
         benchmark, expected_image, expected_target, expected_startup_script,
         experiment_config, preemptible, mocked_get_by_variant_name,
@@ -201,7 +201,7 @@ def _test_create_trial_instance(  # pylint: disable=too-many-locals
 
 
 @mock.patch('common.gcloud.create_instance')
-@mock.patch('common.fuzzer_config_utils.get_by_variant_name')
+@mock.patch('common.fuzzer_utils.get_by_variant_name')
 def test_start_trials_not_started(mocked_get_by_variant_name,
                                   mocked_create_instance, pending_trials,
                                   experiment_config):
@@ -215,7 +215,7 @@ def test_start_trials_not_started(mocked_get_by_variant_name,
 
 
 @mock.patch('common.new_process.execute')
-@mock.patch('common.fuzzer_config_utils.get_by_variant_name')
+@mock.patch('common.fuzzer_utils.get_by_variant_name')
 @mock.patch('experiment.scheduler.datetime_now')
 def test_schedule(mocked_datetime_now, mocked_get_by_variant_name,
                   mocked_execute, pending_trials, experiment_config):


### PR DESCRIPTION
Fixes #292.
Regular fuzzer variants only differ by the environment variables
that they set during runtime. So, test_build_changed_fuzzers
should be fine building all the fuzzers. Remove customizable
fuzzer variants through command line.