### PR TITLE
MOpt fix

### DIFF
--- a/fuzzers/aflplusplus/builder.Dockerfile
+++ b/fuzzers/aflplusplus/builder.Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && git checkout dev && \
-    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
+    git checkout 394d8ade15cc5044f71ad12f025223d3e0c61d13 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     cd llvm_mode && make

--- a/fuzzers/aflplusplus/builder.Dockerfile
+++ b/fuzzers/aflplusplus/builder.Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && git checkout dev && \
-    git checkout fc26001b50d27a276d2d50af1dbcd4dfa3886de5 && \
+    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     cd llvm_mode && make

--- a/fuzzers/aflplusplus_optimal/builder.Dockerfile
+++ b/fuzzers/aflplusplus_optimal/builder.Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && \
-    git checkout fc26001b50d27a276d2d50af1dbcd4dfa3886de5 && \
+    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     cd llvm_mode && LLVM_CONFIG=llvm-config-11 REAL_CC=gcc-9 REAL_CXX=g++-9 make && \

--- a/fuzzers/aflplusplus_optimal/builder.Dockerfile
+++ b/fuzzers/aflplusplus_optimal/builder.Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && \
-    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
+    git checkout 394d8ade15cc5044f71ad12f025223d3e0c61d13 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     cd llvm_mode && LLVM_CONFIG=llvm-config-11 REAL_CC=gcc-9 REAL_CXX=g++-9 make && \

--- a/fuzzers/aflplusplus_optimal/fuzzer.py
+++ b/fuzzers/aflplusplus_optimal/fuzzer.py
@@ -84,7 +84,7 @@ def fuzz(input_corpus, output_corpus, target_binary):  # pylint: disable=too-man
     if benchmark_name == 'bloaty_fuzz_target':
         run_options = ["-L", "0"]
     elif benchmark_name == 'curl_curl_fuzzer_http':
-        run_options = ["-L", "-0"]
+        run_options = ["-L", "0"]
     elif benchmark_name == 'jsoncpp_jsoncpp_fuzzer':
         run_options = ["-L", "0"]
     elif benchmark_name == 'lcms-2017-03-21':

--- a/fuzzers/aflplusplus_optimal_shmem/builder.Dockerfile
+++ b/fuzzers/aflplusplus_optimal_shmem/builder.Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && \
-    git checkout fc26001b50d27a276d2d50af1dbcd4dfa3886de5 && \
+    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     cd llvm_mode && LLVM_CONFIG=llvm-config-11 REAL_CC=gcc-9 REAL_CXX=g++-9 make && \

--- a/fuzzers/aflplusplus_optimal_shmem/builder.Dockerfile
+++ b/fuzzers/aflplusplus_optimal_shmem/builder.Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && \
-    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
+    git checkout 394d8ade15cc5044f71ad12f025223d3e0c61d13 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     cd llvm_mode && LLVM_CONFIG=llvm-config-11 REAL_CC=gcc-9 REAL_CXX=g++-9 make && \

--- a/fuzzers/aflplusplus_qemu/builder.Dockerfile
+++ b/fuzzers/aflplusplus_qemu/builder.Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && git checkout dev && \
-    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
+    git checkout 394d8ade15cc5044f71ad12f025223d3e0c61d13 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     cd qemu_mode && ./build_qemu_support.sh && cd .. && \

--- a/fuzzers/aflplusplus_qemu/builder.Dockerfile
+++ b/fuzzers/aflplusplus_qemu/builder.Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && git checkout dev && \
-    git checkout fc26001b50d27a276d2d50af1dbcd4dfa3886de5 && \
+    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     cd qemu_mode && ./build_qemu_support.sh && cd .. && \

--- a/fuzzers/aflplusplus_shmem/builder.Dockerfile
+++ b/fuzzers/aflplusplus_shmem/builder.Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && git checkout dev && \
-    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
+    git checkout 394d8ade15cc5044f71ad12f025223d3e0c61d13 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     make -C llvm_mode && \

--- a/fuzzers/aflplusplus_shmem/builder.Dockerfile
+++ b/fuzzers/aflplusplus_shmem/builder.Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
     cd /afl && git checkout dev && \
-    git checkout fc26001b50d27a276d2d50af1dbcd4dfa3886de5 && \
+    git checkout 9c293b5b7b941d8046e77989f100d084a516d029 && \
     unset CFLAGS && unset CXXFLAGS && \
     AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
     make -C llvm_mode && \


### PR DESCRIPTION
@jonathanmetzman all _optimal* targets with MOpt will crash, because at that commit a non-working addition from upstream was ported in the code.
I dont think the just started testrun make sense - better abort it and run it again with this PR applied.
sorry!