### PR TITLE
[woff2] Fix seeds

### DIFF
--- a/benchmarks/woff2-2016-05-06/build.sh
+++ b/benchmarks/woff2-2016-05-06/build.sh
@@ -22,10 +22,13 @@ apt-get update && \
   autoconf \
   libtool
 
+# Get seeds.
+get_git_revision https://github.com/google/oss-fuzz.git e8ffee4077b59e35824a2e97aa214ee95d39ed13 oss-fuzz
+mkdir -p $OUT/seeds
+cp oss-fuzz/projects/woff2/corpus/* $OUT/seeds
+
 get_git_revision https://github.com/google/woff2.git  9476664fd6931ea6ec532c94b816d8fbbe3aed90 SRC
 get_git_revision https://github.com/google/brotli.git 3a9032ba8733532a6cd6727970bade7f7c0e2f52 BROTLI
-get_git_revision https://github.com/FontFaceKit/roboto.git 0e41bf923e2599d651084eece345701e55a8bfde $OUT/seeds
-rm -rf $OUT/seeds/.git  # Remove unneeded .git folder.
 
 rm -f *.o
 for f in font.cc normalize.cc transform.cc woff2_common.cc woff2_dec.cc woff2_enc.cc glyph.cc table_tags.cc variable_length.cc woff2_out.cc; do


### PR DESCRIPTION
Use seeds from OSS-Fuzz instead of getting them manually
(and incorrectly, since there were some non-woff2 files in addition to woff2).
Fixes #463