### PR TITLE
Use a startup script for launching the dispatcher

### DIFF
--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -35,33 +35,6 @@ RUNNER_BOOT_DISK_SIZE = '30GB'
 INSTANCE_BATCH_SIZE = 100
 
 
-def ssh(instance: str, *args, **kwargs):
-    """SSH into |instance|."""
-    zone = kwargs.pop('zone', None)
-    command = kwargs.pop('command', None)
-    ssh_command = ['gcloud', 'beta', 'compute', 'ssh', instance]
-    if command:
-        ssh_command.append('--command=%s' % command)
-    if zone:
-        ssh_command.append('--zone=%s' % zone)
-    return new_process.execute(ssh_command, *args, **kwargs)
-
-
-def robust_begin_gcloud_ssh(instance_name: str, zone: str):
-    """Try to SSH into an instance, |instance_name| in |zone| that might not be
-    ready."""
-    for _ in range(10):
-        result = ssh(instance_name,
-                     zone=zone,
-                     command='echo ping',
-                     expect_zero=False)
-        if result.retcode == 0:
-            return
-        logs.info('GCP instance isn\'t ready yet. Rerunning SSH momentarily.')
-        time.sleep(5)
-    raise Exception('Couldn\'t SSH to instance.')
-
-
 class InstanceType(enum.Enum):
     """Types of instances we need for the experiment."""
     DISPATCHER = 0

--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -15,11 +15,9 @@
 
 import enum
 import subprocess
-import time
 from typing import List
 
 from common import experiment_utils
-from common import logs
 from common import new_process
 
 # Constants for dispatcher specs.

--- a/common/test_gcloud.py
+++ b/common/test_gcloud.py
@@ -15,8 +15,6 @@
 
 from unittest import mock
 
-import pytest
-
 from common import gcloud
 from common import new_process
 from test_libs import utils as test_utils
@@ -24,49 +22,6 @@ from test_libs import utils as test_utils
 INSTANCE_NAME = 'instance-a'
 ZONE = 'zone-a'
 CONFIG = {'cloud_compute_zone': ZONE, 'service_account': 'blah'}
-
-
-def test_ssh():
-    """Tests that ssh works as expected."""
-    with test_utils.mock_popen_ctx_mgr() as mocked_popen:
-        gcloud.ssh(INSTANCE_NAME)
-        assert mocked_popen.commands == [[
-            'gcloud', 'beta', 'compute', 'ssh', INSTANCE_NAME
-        ]]
-
-
-@pytest.mark.parametrize(('kwargs_for_ssh', 'expected_argument'),
-                         [
-                             ({'command': 'ls'}, '--command=ls'),
-                             ({'zone': ZONE}, '--zone=' + ZONE),
-                         ]) # yapf: disable
-def test_ssh_optional_arg(kwargs_for_ssh, expected_argument):
-    """Tests that ssh works as expected when given an optional argument."""
-    with test_utils.mock_popen_ctx_mgr() as mocked_popen:
-        gcloud.ssh(INSTANCE_NAME, **kwargs_for_ssh)
-        assert expected_argument in mocked_popen.commands[0]
-
-
-@mock.patch('time.sleep')
-@mock.patch('common.gcloud.ssh')
-def test_robust_begin_gcloud_ssh_fail(_, mocked_ssh):
-    """Tests that ssh works as expected."""
-    with pytest.raises(Exception) as exception:
-        gcloud.robust_begin_gcloud_ssh(INSTANCE_NAME, ZONE)
-        assert mocked_ssh.call_count == 10
-        assert exception.value == 'Couldn\'t SSH to instance.'
-
-
-@mock.patch('time.sleep')
-@mock.patch('common.gcloud.ssh')
-def test_robust_begin_gcloud_ssh_pass(mocked_ssh, _):
-    """Tests robust_begin_gcloud_ssh works as intended on google cloud."""
-    mocked_ssh.return_value = new_process.ProcessResult(0, None, False)
-    gcloud.robust_begin_gcloud_ssh(INSTANCE_NAME, ZONE)
-    mocked_ssh.assert_called_with('instance-a',
-                                  command='echo ping',
-                                  expect_zero=False,
-                                  zone='zone-a')
 
 
 def test_create_instance():

--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -159,6 +159,7 @@ def dispatcher_main():
     logs.info('Dispatcher finished.')
     scheduler_loop_thread.join()
     measurer_loop_process.join()
+    return experiment.config
 
 
 def main():
@@ -168,10 +169,14 @@ def main():
     })
 
     try:
-        dispatcher_main()
+        experiment_config = dispatcher_main()
     except Exception as error:
         logs.error('Error conducting experiment.')
         raise error
+    stop_experiment.stop_experiment(experiment_config['experiment'],
+                                    experiment_config)
+
+    return 0
 
 
 if __name__ == '__main__':

--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -34,6 +34,7 @@ from experiment.build import builder
 from experiment import measurer
 from experiment import reporter
 from experiment import scheduler
+from experiment import stop_experiment
 
 LOOP_WAIT_SECONDS = 5 * 60
 

--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -177,11 +177,11 @@ def main():
                                                'experiment.yaml')
 
     experiment_utils.is_local_experiment()
-    if stop_experiment.stop_experiment(experiment_config['experiment'],
-                                       experiment_config):
+    if stop_experiment.stop_experiment(experiment_utils.get_experiment_name(),
+                                       experiment_config_file_path):
         return 0
-    else:
-        return 1
+
+    return 1
 
 
 if __name__ == '__main__':

--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -176,7 +176,9 @@ def main():
     experiment_config_file_path = os.path.join(fuzzer_config_utils.get_dir(),
                                                'experiment.yaml')
 
-    experiment_utils.is_local_experiment()
+    if experiment_utils.is_local_experiment():
+        return 0
+
     if stop_experiment.stop_experiment(experiment_utils.get_experiment_name(),
                                        experiment_config_file_path):
         return 0

--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -117,7 +117,7 @@ def dispatcher_main():
     # reason.
     multiprocessing.set_start_method('spawn')
     db_utils.initialize()
-    if os.getenv('LOCAL_EXPERIMENT'):
+    if experiment_utils.is_local_experiment():
         models.Base.metadata.create_all(db_utils.engine)
 
     experiment_config_file_path = os.path.join(fuzzer_config_utils.get_dir(),
@@ -160,7 +160,6 @@ def dispatcher_main():
     logs.info('Dispatcher finished.')
     scheduler_loop_thread.join()
     measurer_loop_process.join()
-    return experiment.config
 
 
 def main():
@@ -170,14 +169,19 @@ def main():
     })
 
     try:
-        experiment_config = dispatcher_main()
+        dispatcher_main()
     except Exception as error:
         logs.error('Error conducting experiment.')
         raise error
-    stop_experiment.stop_experiment(experiment_config['experiment'],
-                                    experiment_config)
+    experiment_config_file_path = os.path.join(fuzzer_config_utils.get_dir(),
+                                               'experiment.yaml')
 
-    return 0
+    experiment_utils.is_local_experiment()
+    if stop_experiment.stop_experiment(experiment_config['experiment'],
+                                       experiment_config):
+        return 0
+    else:
+        return 1
 
 
 if __name__ == '__main__':

--- a/experiment/resources/dispatcher-startup-script-template.sh
+++ b/experiment/resources/dispatcher-startup-script-template.sh
@@ -23,5 +23,3 @@ docker run --rm \
   --cap-add=SYS_PTRACE --cap-add=SYS_NICE \
   -v /var/run/docker.sock:/var/run/docker.sock --name=dispatcher-container \
   {{docker_registry}}/dispatcher-image /work/startup-dispatcher.sh
-
-

--- a/experiment/resources/dispatcher-startup-script-template.sh
+++ b/experiment/resources/dispatcher-startup-script-template.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+docker run --rm \
+  -e INSTANCE_NAME={{instance_name}} -e EXPERIMENT={{experiment}} \
+  -e CLOUD_PROJECT={{cloud_project}} \
+  -e EXPERIMENT_FILESTORE={{experiment_filestore}} \
+  -e POSTGRES_PASSWORD={{postgres_password}} \
+  -e CLOUD_SQL_INSTANCE_CONNECTION_NAME={{cloud_sql_instance_connection_name}} \
+  --cap-add=SYS_PTRACE --cap-add=SYS_NICE \
+  -v /var/run/docker.sock:/var/run/docker.sock --name=dispatcher-container \
+  {{docker_registry}}/dispatcher-image /work/startup-dispatcher.sh
+
+

--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-## Configure the host.
+# Configure the host.
 
 # Make everything ptrace-able.
 echo 0 > /proc/sys/kernel/yama/ptrace_scope
@@ -21,7 +21,7 @@ echo 0 > /proc/sys/kernel/yama/ptrace_scope
 # Do not notify external programs about core dumps.
 echo core >/proc/sys/kernel/core_pattern
 
-## Start docker.
+# Start docker.
 {% if not local_experiment %}
 while ! docker pull {{docker_image_url}}
 do

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -410,7 +410,7 @@ class GoogleCloudDispatcher(BaseDispatcher):
 
     def start(self):
         """Start the experiment on the dispatcher."""
-        with tempfile.NamedTemporaryFile(dir=os.getcwd()) as startup_script:
+        with tempfile.NamedTemporaryFile(dir=os.getcwd(), mode='w') as startup_script:
             self.write_startup_script(startup_script)
             gcloud.create_instance(self.instance_name,
                                    gcloud.InstanceType.DISPATCHER,

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -330,8 +330,7 @@ class LocalDispatcher:
     def start(self):
         """Start the experiment on the dispatcher."""
         container_name = 'dispatcher-container'
-        logs.info(
-            'Started dispatcher with container name: %s', container_name)
+        logs.info('Started dispatcher with container name: %s', container_name)
         experiment_filestore_path = os.path.abspath(
             self.config['experiment_filestore'])
         filesystem.create_directory(experiment_filestore_path)
@@ -407,8 +406,8 @@ class GoogleCloudDispatcher(BaseDispatcher):
 
     def start(self):
         """Start the experiment on the dispatcher."""
-        logs.info(
-            'Started dispatcher with instance name: %s', self.instance_name)
+        logs.info('Started dispatcher with instance name: %s',
+                  self.instance_name)
         with tempfile.NamedTemporaryFile(dir=os.getcwd(),
                                          mode='w') as startup_script:
             self.write_startup_script(startup_script)

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -409,7 +409,8 @@ class GoogleCloudDispatcher(BaseDispatcher):
 
     def start(self):
         """Start the experiment on the dispatcher."""
-        with tempfile.NamedTemporaryFile(dir=os.getcwd(), mode='w') as startup_script:
+        with tempfile.NamedTemporaryFile(dir=os.getcwd(),
+                                         mode='w') as startup_script:
             self.write_startup_script(startup_script)
             gcloud.create_instance(self.instance_name,
                                    gcloud.InstanceType.DISPATCHER,

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -37,7 +37,6 @@ from common import logs
 from common import new_process
 from common import utils
 from common import yaml_utils
-from experiment import stop_experiment
 from src_analysis import experiment_changes
 
 BENCHMARKS_DIR = os.path.join(utils.ROOT_DIR, 'benchmarks')
@@ -522,9 +521,6 @@ def main():
 
     start_experiment(args.experiment_name, args.experiment_config,
                      args.benchmarks, fuzzer_configs)
-    if not os.getenv('MANUAL_EXPERIMENT'):
-        stop_experiment.stop_experiment(args.experiment_name,
-                                        args.experiment_config)
     return 0
 
 

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -329,6 +329,9 @@ class LocalDispatcher:
 
     def start(self):
         """Start the experiment on the dispatcher."""
+        container_name = 'dispatcher-container'
+        logs.info(
+            'Started dispatcher with container name: %s', container_name)
         experiment_filestore_path = os.path.abspath(
             self.config['experiment_filestore'])
         filesystem.create_directory(experiment_filestore_path)
@@ -382,7 +385,7 @@ class LocalDispatcher:
             'LOCAL_EXPERIMENT=True',
             '--cap-add=SYS_PTRACE',
             '--cap-add=SYS_NICE',
-            '--name=dispatcher-container',
+            '--name=%s' % container_name,
             docker_image_url,
             '/bin/bash',
             '-c',
@@ -404,6 +407,8 @@ class GoogleCloudDispatcher(BaseDispatcher):
 
     def start(self):
         """Start the experiment on the dispatcher."""
+        logs.info(
+            'Started dispatcher with instance name: %s', self.instance_name)
         with tempfile.NamedTemporaryFile(dir=os.getcwd(),
                                          mode='w') as startup_script:
             self.write_startup_script(startup_script)

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -63,11 +63,6 @@ CONFIG_DIR = 'config'
 
 RESOURCES_DIR = os.path.join(utils.ROOT_DIR, 'experiment', 'resources')
 
-JINJA_ENV = jinja2.Environment(
-    undefined=jinja2.StrictUndefined,
-    loader=jinja2.FileSystemLoader(RESOURCES_DIR),
-)
-
 
 def read_and_validate_experiment_config(config_filename: str) -> Dict:
     """Reads |config_filename|, validates it, finds as many errors as possible,
@@ -418,7 +413,13 @@ class GoogleCloudDispatcher(BaseDispatcher):
                                    startup_script=startup_script.name)
 
     def _render_startup_script(self):
-        template = JINJA_ENV.get_template(
+        """Renders the startup script template and returns the result as a
+        string."""
+        jinja_env = jinja2.Environment(
+            undefined=jinja2.StrictUndefined,
+            loader=jinja2.FileSystemLoader(RESOURCES_DIR),
+        )
+        template = jinja_env.get_template(
             'dispatcher-startup-script-template.sh')
         cloud_sql_instance_connection_name = (
             self.config['cloud_sql_instance_connection_name'])
@@ -427,9 +428,6 @@ class GoogleCloudDispatcher(BaseDispatcher):
             'instance_name': self.instance_name,
             'postgres_password': os.environ['POSTGRES_PASSWORD'],
             'experiment': self.config['experiment'],
-            # TODO(metzman): Create a function that sets env vars based on
-            # the contents of a dictionary, and use it instead of hardcoding
-            # the configs we use.
             'cloud_project': self.config['cloud_project'],
             'experiment_filestore': self.config['experiment_filestore'],
             'cloud_sql_instance_connection_name':

--- a/experiment/stop_experiment.py
+++ b/experiment/stop_experiment.py
@@ -48,14 +48,14 @@ def stop_experiment(experiment_name, experiment_config_filename):
 
     if not experiment_instances:
         logger.warning('No experiment instances found, no work to do.')
-        return 0
+        return True
 
     if not gcloud.delete_instances(experiment_instances, cloud_compute_zone):
         logger.error('Failed to stop experiment instances.')
-        return 1
+        return False
 
     logger.info('Successfully stopped experiment.')
-    return 0
+    return True
 
 
 def main():
@@ -64,7 +64,7 @@ def main():
         print("Usage {0} <experiment-name> <experiment-config.yaml>")
         return 1
     logs.initialize()
-    return stop_experiment(sys.argv[1], sys.argv[2])
+    return 0 if stop_experiment(sys.argv[1], sys.argv[2]) else 1
 
 
 if __name__ == '__main__':

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -91,7 +91,7 @@ def test_create_trial_instance(benchmark, expected_image, expected_target,
                                experiment_config):
     """Test that create_trial_instance invokes create_instance
     and creates a startup script for the instance, as we expect it to."""
-    expected_startup_script = '''## Start docker.
+    expected_startup_script = '''# Start docker.
 
 while ! docker pull {docker_image_url}
 do
@@ -133,7 +133,7 @@ def test_create_trial_instance_local_experiment(benchmark, expected_image,
     startup script for the instance, as we expect it to when running a
     local_experiment."""
     os.environ['LOCAL_EXPERIMENT'] = str(True)
-    expected_startup_script = '''## Start docker.
+    expected_startup_script = '''# Start docker.
 
 
 docker run \\
@@ -191,7 +191,7 @@ def _test_create_trial_instance(  # pylint: disable=too-many-locals
 
     with open(expected_startup_script_path) as file_handle:
         content = file_handle.read()
-        check_from = '## Start docker.'
+        check_from = '# Start docker.'
         assert check_from in content
         script_for_docker = content[content.find(check_from):]
         assert script_for_docker == expected_startup_script.format(


### PR DESCRIPTION
Using ssh is hacky and error prone. Use a startup script instead.
This will also help with servicification as run_experiment.py will finish immediately after an experiment is started.

Fixes https://github.com/google/fuzzbench/issues/361 and https://github.com/google/fuzzbench/issues/486