### PR TITLE
[NFC] help RQ worker reuse this code

### DIFF
--- a/experiment/build/local_build.py
+++ b/experiment/build/local_build.py
@@ -49,7 +49,7 @@ def make_shared_coverage_binaries_dir():
     shared_coverage_binaries_dir = get_shared_coverage_binaries_dir()
     if os.path.exists(shared_coverage_binaries_dir):
         return
-    os.mkdir(shared_coverage_binaries_dir)
+    os.makedirs(shared_coverage_binaries_dir)
 
 
 def build_coverage(benchmark):


### PR DESCRIPTION
This minor change will not affect the current functionality but make initialization easier to setup.
The previous code assumes `experiment_filestore/<experiment_name>` already exists. Since we want to directly use `build/builder.py` in local setting, this assumption may not hold for a RQ worker.
