### PR TITLE
Don't stop experiment in automatic_run_experiment

### DIFF
--- a/service/automatic_run_experiment.py
+++ b/service/automatic_run_experiment.py
@@ -29,7 +29,6 @@ from common import yaml_utils
 from database import models
 from database import utils as db_utils
 from experiment import run_experiment
-from experiment import stop_experiment
 
 logger = logs.Logger('automatic_run_experiment')  # pylint: disable=invalid-name
 

--- a/service/automatic_run_experiment.py
+++ b/service/automatic_run_experiment.py
@@ -215,7 +215,6 @@ def _run_experiment(experiment_name, fuzzer_configs, dry_run=False):
         return
     run_experiment.start_experiment(experiment_name, EXPERIMENT_CONFIG_FILE,
                                     BENCHMARKS, fuzzer_configs)
-    stop_experiment.stop_experiment(experiment_name, EXPERIMENT_CONFIG_FILE)
 
 
 def main():

--- a/service/test_automatic_run_experiment.py
+++ b/service/test_automatic_run_experiment.py
@@ -57,10 +57,8 @@ def test_run_requested_experiment_pause_service(
 
 
 @mock.patch('experiment.run_experiment.start_experiment')
-@mock.patch('experiment.stop_experiment.stop_experiment')
 @mock.patch('service.automatic_run_experiment._get_requested_experiments')
 def test_run_requested_experiment(mocked_get_requested_experiments,
-                                  mocked_stop_experiment,
                                   mocked_start_experiment, db):
     """Tests that run_requested_experiment starts and stops the experiment
     properly."""
@@ -113,9 +111,6 @@ def test_run_requested_experiment(mocked_get_requested_experiments,
     # what we expected.
     start_experiment_call_args[0][0][3].sort(key=sort_key)
     assert start_experiment_call_args == expected_calls
-
-    mocked_stop_experiment.assert_called_with(expected_experiment_name,
-                                              expected_config_file)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
run_experiment will exit after starting the dispatcher, not after
the experiment terminates. Stopping the experiment immediately after
starting the experiment isn't what we want.
We don't need to do this because we now call stop_experiment
at the end of dispatcher.py