### PR TITLE
Set up new queue-based architecture development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Running experiments locally.
+
+run-experiment: export COMPOSE_PROJECT_NAME := fuzzbench
+run-experiment: export COMPOSE_FILE := compose/fuzzbench.yaml
+run-experiment:
+	docker-compose up --build --scale worker=2 --detach
+	docker-compose logs --follow run-experiment
+	docker-compose down
+
+# Development.
+
 include docker/build.mk
 include docker/generated.mk
 

--- a/compose/fuzzbench.yaml
+++ b/compose/fuzzbench.yaml
@@ -1,0 +1,24 @@
+version: "3"
+
+services:
+
+  run-experiment:
+    image: fuzzbench
+    build:
+      context: ../
+      dockerfile: docker/fuzzbench/Dockerfile
+    links:
+      - queue-server
+
+  worker:
+    image: fuzzbench
+    environment:
+      RQ_REDIS_URL: redis://queue-server
+    command: rq worker --burst
+    links:
+      - queue-server
+    depends_on:
+      - run-experiment
+
+  queue-server:
+    image: redis

--- a/docker/fuzzbench/Dockerfile
+++ b/docker/fuzzbench/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.8
+
+WORKDIR /fuzzbench
+
+ADD requirements.txt /fuzzbench/requirements.txt
+RUN pip3 install -r requirements.txt
+
+ADD fuzzbench/*.py /fuzzbench/
+
+CMD python3 -u run_experiment.py

--- a/docker/fuzzbench/Dockerfile
+++ b/docker/fuzzbench/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.8
+FROM python:3.7
 
 WORKDIR /fuzzbench
 

--- a/fuzzbench/fake_jobs.py
+++ b/fuzzbench/fake_jobs.py
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fake jobs."""
+
+import time
+
+
+def build_image(name):
+    """Build a Docker image."""
+    print('Building', name)
+    time.sleep(3)
+    return True
+
+
+def run_trial():
+    """Run a trial."""
+    return True
+
+
+def measure_corpus_snapshot():
+    """Measure a corpus snapshot."""
+    return True

--- a/fuzzbench/run_experiment.py
+++ b/fuzzbench/run_experiment.py
@@ -1,0 +1,50 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Runs a FuzzBench experiment."""
+
+import time
+
+import redis
+import rq
+
+import fake_jobs
+
+
+def run_experiment():
+    """Main experiment logic."""
+    print('Initializing the job queue.')
+    queue = rq.Queue()
+    jobs = []
+    for i in range(6):
+        jobs.append(queue.enqueue(fake_jobs.build_image, 'something-%d' % i))
+
+    while True:
+        print('Current status of jobs:')
+        for job in jobs:
+            print('  %s%s : %s' % (job.func_name, job.args, job.get_status()))
+        if all([job.result is not None for job in jobs]):
+            break
+        time.sleep(3)
+    print('All done!')
+
+
+def main():
+    """Set up Redis connection and start the experiment."""
+    redis_connection = redis.Redis(host="queue-server")
+    with rq.Connection(redis_connection):
+        return run_experiment()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ pytest==5.3.5
 python-dateutil==2.8.1
 pytz==2019.3
 PyYAML==5.3
+redis==3.5.3
+rq==1.4.3
 scikit-posthocs==0.6.2
 scipy==1.4.1
 seaborn==0.10.0


### PR DESCRIPTION
We are implementing a new architecture for FuzzBench, which will be more scalable and completely platform independent. While the [current architecture](https://google.github.io/fuzzbench/reference/how-it-works/) heavily relies on Google Compute Engine (e.g., it directly creates and manages GCE instances), the new architecture is a task-queue based system that can be run on any platform or environment. This includes a local machine, a small lab cluster, or the cloud. Here's a high level overview:
![image](https://user-images.githubusercontent.com/1070168/87357044-374bb800-c531-11ea-8fef-653822f5fc56.png)

The current architecture's main modules (such as the Builder, Dispatcher, Scheduler, and Measurer) will be replaced by the new `run_experiment` and `worker` containers. In the new architecture, deployment (i.e., infrastructure management and container orchestration) will be fully separated from the application logic (e.g., in the local machine use case we will use Docker Compose for orchestration). Our goal is to enable the incremental development of the new architecture's modules, while keeping the old ones working. When the new modules are fully functional, the old ones can be removed. This PR sets up an initial infrastructure for the development of this new architecture, in particular: 
- Add "skeleton" code for the main `run_experiment` module and "fake jobs" code for the `worker`. 
- Add Dockefile for the fuzzbench container image (used by `run_experiment` and `worker`).
- Add docker-compose file to define the local setup for a fuzzbench experiment.
- Add Makefile target for running a local experiment.
- Add redis and rq as dependencies.

To run the experiment skeleton locally, simply run:
```shell
$ make run-experiment
```
The [next PR](https://github.com/google/fuzzbench/pull/522) adds the skeleton of an end-to-end integration test for the new architecture, that will be used to validate each step of the development. 
