### PR TITLE
Add end-to-end integration test skeleton for new architecture.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,15 @@ run-experiment:
 
 # Development.
 
+run-end-to-end-test: export COMPOSE_PROJECT_NAME := e2e-test
+run-end-to-end-test: export COMPOSE_FILE := compose/fuzzbench.yaml:compose/ci.yaml
+run-end-to-end-test:
+	docker-compose build
+	docker-compose up --detach queue-server
+	docker-compose up --scale worker=3 run-experiment worker
+	docker-compose run ci-tests; STATUS=$$?; \
+	docker-compose down; exit $$STATUS
+
 include docker/build.mk
 include docker/generated.mk
 

--- a/compose/ci.yaml
+++ b/compose/ci.yaml
@@ -1,0 +1,9 @@
+version: "3"
+
+services:
+
+  ci-tests:
+    image: fuzzbench
+    links:
+      - queue-server
+    command: python3 -m pytest -vv -k test_e2e_run

--- a/fuzzbench/test_e2e_run.py
+++ b/fuzzbench/test_e2e_run.py
@@ -1,0 +1,36 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checks the result of a test experiment run. Note that this is not a
+standalone unit test module, but used as part of our end-to-end integration
+test."""
+
+
+def test_all_jobs_finished_sucessfully():
+    """Fake test to be implemented later."""
+    assert True
+
+
+def test_measurement_jobs_were_started_before_trial_jobs_finished():
+    """Fake test to be implemented later."""
+    assert True
+
+
+def test_db_contains_experiment_results():
+    """Fake test to be implemented later."""
+    assert True
+
+
+def test_experiment_report_is_generated():
+    """Fake test to be implemented later."""
+    assert True


### PR DESCRIPTION
The PR sets up the infrastructure for the continuous integration testing of the new architecture we're developing.
 
- Add a skeleton of tests/checks that will run after a test experiment run, as part of the integration test.
- Add Docker Compose specification for the end to end integration test. The spec extends the main docker compose specification with a container that runs the test script mentioned above.
- Add Makefile target for running the e2e integration test.

The [next PR](https://github.com/google/fuzzbench/pull/523) will set this up as a CI test at prepsubmit (with GH actions), so we can validate each step of development of the new architecture. See the output of the test at https://github.com/google/fuzzbench/pull/523/checks?check_run_id=867126894, under presumbit / Run end to end CI test.