### PR TITLE
Run test_e2e_run only in the context of an end to end test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ run-experiment:
 # Development.
 
 run-end-to-end-test: export COMPOSE_PROJECT_NAME := e2e-test
-run-end-to-end-test: export COMPOSE_FILE := compose/fuzzbench.yaml:compose/ci.yaml
+run-end-to-end-test: export COMPOSE_FILE := compose/fuzzbench.yaml:compose/e2e-test.yaml
 run-end-to-end-test:
 	docker-compose build
 	docker-compose up --detach queue-server
 	docker-compose up --scale worker=3 run-experiment worker
-	docker-compose run ci-tests; STATUS=$$?; \
+	docker-compose run run-tests; STATUS=$$?; \
 	docker-compose down; exit $$STATUS
 
 include docker/build.mk

--- a/compose/ci.yaml
+++ b/compose/ci.yaml
@@ -6,4 +6,6 @@ services:
     image: fuzzbench
     links:
       - queue-server
+    environment:
+      E2E_INTEGRATION_TEST: 1
     command: python3 -m pytest -vv fuzzbench/test_e2e_run.py

--- a/compose/e2e-test.yaml
+++ b/compose/e2e-test.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
 
-  ci-tests:
+  run-tests:
     image: fuzzbench
     links:
       - queue-server

--- a/fuzzbench/test_e2e_run.py
+++ b/fuzzbench/test_e2e_run.py
@@ -15,22 +15,29 @@
 standalone unit test module, but used as part of our end-to-end integration
 test."""
 
+import os
 
-def test_all_jobs_finished_sucessfully():
-    """Fake test to be implemented later."""
-    assert True
-
-
-def test_measurement_jobs_were_started_before_trial_jobs_finished():
-    """Fake test to be implemented later."""
-    assert True
+import pytest
 
 
-def test_db_contains_experiment_results():
-    """Fake test to be implemented later."""
-    assert True
+# pylint: disable=no-self-use
+@pytest.mark.skipif('E2E_INTEGRATION_TEST' not in os.environ,
+                    reason='Not running end-to-end test.')
+class TestEndToEndRunResults:
+    """Checks the result of a test experiment run."""
 
+    def test_all_jobs_finished_sucessfully(self):
+        """Fake test to be implemented later."""
+        assert True
 
-def test_experiment_report_is_generated():
-    """Fake test to be implemented later."""
-    assert True
+    def test_measurement_jobs_were_started_before_trial_jobs_finished(self):
+        """Fake test to be implemented later."""
+        assert True
+
+    def test_db_contains_experiment_results(self):
+        """Fake test to be implemented later."""
+        assert True
+
+    def test_experiment_report_is_generated(self):
+        """Fake test to be implemented later."""
+        assert True


### PR DESCRIPTION
This test is not a unit test, but is for checking the results of an end-to-end
test. With this change we avoid it running during regular pytest unit test runs.