### PR TITLE
Initial prototype of build logic consolidation

### DIFF
--- a/docker/image_types.yaml
+++ b/docker/image_types.yaml
@@ -1,0 +1,67 @@
+# Defines the different types of docker images that FuzzBench uses and their
+# dependency graph.
+
+'base-image':
+  tag: 'base-image'
+  context: 'docker/base-image'
+
+'base-builder':
+  tag: 'base-builder'
+  context: 'docker/base-builder'
+  depends_on:
+    - 'base-image'
+
+'base-runner':
+  tag: 'base-runner'
+  context: 'docker/base-runner'
+  depends_on:
+    - 'base-image'
+
+'coverage-builder':
+  tag: 'builders/coverage'
+  context: 'fuzzers/coverage'
+  dockerfile: 'fuzzers/coverage/builder.Dockerfile'
+  depends_on:
+    - 'base-builder'
+
+'coverage-{benchmark}-builder':
+  tag: 'builders/coverage/{benchmark}'
+  context: '.'
+  dockerfile: 'docker/benchmark-builder/Dockerfile'
+  depends_on:
+    - 'coverage-builder'
+
+'{fuzzer}-builder':
+  tag: 'builders/{fuzzer}'
+  context: 'fuzzers/{fuzzer}'
+  dockerfile: 'fuzzers/{fuzzer}/builder.Dockerfile'
+  depends_on:
+    - 'base-builder'
+
+'{fuzzer}-{benchmark}-builder':
+  tag: 'builders/{fuzzer}/{benchmark}'
+  context: '.'
+  dockerfile: 'docker/benchmark-builder/Dockerfile'
+  build_arg:
+    - 'fuzzer={fuzzer}'
+    - 'benchmark={benchmark}'
+  depends_on:
+    - '{fuzzer}-builder'
+
+'{fuzzer}-{benchmark}-intermediate-runner':
+  tag: 'runners/{fuzzer}/{benchmark}-intermediate'
+  context: 'fuzzers/{fuzzer}'
+  dockerfile: 'fuzzers/{fuzzer}/runner.Dockerfile'
+  depends_on:
+    - 'base-runner'
+
+'{fuzzer}-{benchmark}-runner':
+  tag: 'runners/{fuzzer}/{benchmark}'
+  context: '.'
+  dockerfile: 'docker/benchmark-runner/Dockerfile'
+  build_arg:
+    - 'fuzzer={fuzzer}'
+    - 'benchmark={benchmark}'
+  depends_on:
+    - '{fuzzer}-{benchmark}-builder'
+    - '{fuzzer}-{benchmark}-intermediate-runner'

--- a/experiment/build/docker_images.py
+++ b/experiment/build/docker_images.py
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Provides the set of buildable images and their dependencies."""
+
+import yaml
+
+
+def subst(template, fuzzer, benchmark):
+    """Replaces {fuzzer} or {benchmark} with |fuzzer| or |benchmark| in
+    |template| string."""
+    return template.format(fuzzer=fuzzer, benchmark=benchmark)
+
+
+def instantiate_image_obj(name_template, obj_template, fuzzer, benchmark):
+    """Instantiates an image object from a template for a |fuzzer| - |benchmark|
+    pair."""
+    name = subst(name_template, fuzzer, benchmark)
+    obj = obj_template.copy()
+    for key in obj:
+        if key in ('build_arg', 'depends_on'):
+            obj[key] = [subst(item, fuzzer, benchmark) for item in obj[key]]
+        else:
+            obj[key] = subst(obj[key], fuzzer, benchmark)
+    return name, obj
+
+
+def get_image_type_templates():
+    """Loads the image types config that contains "templates" describing how to
+    build them and their dependencies."""
+    with open('docker/image_types.yaml') as config_file:
+        templates = yaml.load(config_file, yaml.SafeLoader)
+        return templates
+
+
+def get_images_to_build(fuzzers, benchmarks):
+    """Returns the set of buildable images."""
+    images = {}
+    templates = get_image_type_templates()
+    for fuzzer in fuzzers:
+        for benchmark in benchmarks:
+            for name_templ, obj_templ in templates.items():
+                name, obj = instantiate_image_obj(name_templ, obj_templ, fuzzer,
+                                                  benchmark)
+                images[name] = obj
+    return images

--- a/experiment/build/docker_images.py
+++ b/experiment/build/docker_images.py
@@ -16,7 +16,7 @@
 from common import yaml_utils
 
 
-def _subst(template, fuzzer, benchmark):
+def _substitute(template, fuzzer, benchmark):
     """Replaces {fuzzer} or {benchmark} with |fuzzer| or |benchmark| in
     |template| string."""
     return template.format(fuzzer=fuzzer, benchmark=benchmark)
@@ -25,13 +25,15 @@ def _subst(template, fuzzer, benchmark):
 def _instantiate_image_obj(name_template, obj_template, fuzzer, benchmark):
     """Instantiates an image object from a template for a |fuzzer| - |benchmark|
     pair."""
-    name = _subst(name_template, fuzzer, benchmark)
+    name = _substitute(name_template, fuzzer, benchmark)
     obj = obj_template.copy()
     for key in obj:
         if key in ('build_arg', 'depends_on'):
-            obj[key] = [_subst(item, fuzzer, benchmark) for item in obj[key]]
+            obj[key] = [
+                _substitute(item, fuzzer, benchmark) for item in obj[key]
+            ]
         else:
-            obj[key] = _subst(obj[key], fuzzer, benchmark)
+            obj[key] = _substitute(obj[key], fuzzer, benchmark)
     return name, obj
 
 

--- a/experiment/build/generate_cloudbuild.py
+++ b/experiment/build/generate_cloudbuild.py
@@ -1,0 +1,66 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generates Cloud Build specification"""
+
+import json
+import yaml
+
+from experiment.build import docker_images
+
+
+def create_cloud_build_spec(buildable_images):
+    """Returns Cloud Build specificatiion."""
+
+    cloud_build_spec = {}
+    cloud_build_spec['steps'] = []
+    cloud_build_spec['images'] = []
+
+    for name, image in buildable_images.items():
+        step = {}
+        step['id'] = name
+        step['name'] = 'gcr.io/cloud-builders/docker'
+        step['args'] = []
+        step['args'] += ['--tag', image['tag']]
+        step['args'] += ['--cache-from', 'gcr.io/fuzzbench/' + image['tag']]
+        step['args'] += ['--build-arg', 'BUILDKIT_INLINE_CACHE=1']
+        if 'build_arg' in image:
+            for build_arg in image['build_arg']:
+                step['args'] += ['--build-arg', build_arg]
+        if 'dockerfile' in image:
+            step['args'] += ['--file', image['dockerfile']]
+        step['args'] += [image['context']]
+        if 'depends_on' in image:
+            step['wait_for'] = []
+            for dep in image['depends_on']:
+                step['wait_for'] += [dep]
+        cloud_build_spec['images'].append(name)
+        cloud_build_spec['steps'].append(step)
+
+    return cloud_build_spec
+
+
+def main():
+    """Main."""
+    fuzzers = ['afl', 'libfuzzer']
+    benchmarks = ['libxml', 'libpng']
+    buildable_images = docker_images.get_images_to_build(fuzzers, benchmarks)
+    cloud_build_spec = create_cloud_build_spec(buildable_images)
+    # Build spec can be yaml or json, use whichever:
+    # https://cloud.google.com/cloud-build/docs/configuring-builds/create-basic-configuration
+    print(yaml.dump(cloud_build_spec))
+    print(json.dumps(cloud_build_spec))
+
+
+if __name__ == '__main__':
+    main()

--- a/experiment/build/generate_cloudbuild.py
+++ b/experiment/build/generate_cloudbuild.py
@@ -20,7 +20,7 @@ import yaml
 from experiment.build import docker_images
 
 
-# TODO: Add unit test for this.
+# TODO(Tanq16): Add unit test for this.
 def create_cloud_build_spec(buildable_images, docker_registry):
     """Returns Cloud Build specificatiion."""
 
@@ -61,7 +61,7 @@ def main():
                         help='Docker registry to use.')
     args = parser.parse_args()
 
-    # TODO: Create fuzzer/benchmark list dynamically.
+    # TODO(Tanq16): Create fuzzer/benchmark list dynamically.
     fuzzers = ['afl', 'libfuzzer']
     benchmarks = ['libxml', 'libpng']
     buildable_images = docker_images.get_images_to_build(fuzzers, benchmarks)

--- a/experiment/build/generate_makefile.py
+++ b/experiment/build/generate_makefile.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 """Generates Makefile containing docker image targets."""
 
+import argparse
+
 from experiment.build import docker_images
 
 
-def print_makefile(buildable_images):
+# TODO: Add unit test for this.
+def print_makefile(buildable_images, docker_registry):
     """Prints the generated makefile to stdout."""
     print('export DOCKER_BUILDKIT := 1')
 
@@ -28,7 +31,7 @@ def print_makefile(buildable_images):
         print()
         print('\tdocker build \\')
         print('    --tag ' + image['tag'] + ' \\')
-        print('    --cache-from gcr.io/fuzzbench/' + image['tag'] + ' \\')
+        print('    --cache-from ' + docker_registry + image['tag'] + ' \\')
         if 'build_arg' in image:
             for arg in image['build_arg']:
                 print('    --build-arg ' + arg + ' \\')
@@ -39,11 +42,19 @@ def print_makefile(buildable_images):
 
 
 def main():
-    """Main."""
+    """Generates Makefile with docker image build rules."""
+    parser = argparse.ArgumentParser(description='GCB spec generator.')
+    parser.add_argument('-r',
+                        '--docker-registry',
+                        default='gcr.io/fuzzbench/',
+                        help='Docker registry to use as cache.')
+    args = parser.parse_args()
+
+    # TODO: Create fuzzer/benchmark list dynamically.
     fuzzers = ['afl', 'libfuzzer']
     benchmarks = ['libxml', 'libpng']
     buildable_images = docker_images.get_images_to_build(fuzzers, benchmarks)
-    print_makefile(buildable_images)
+    print_makefile(buildable_images, args.docker_registry)
 
 
 if __name__ == '__main__':

--- a/experiment/build/generate_makefile.py
+++ b/experiment/build/generate_makefile.py
@@ -18,7 +18,7 @@ import argparse
 from experiment.build import docker_images
 
 
-# TODO: Add unit test for this.
+# TODO(Tanq16): Add unit test for this.
 def print_makefile(buildable_images, docker_registry):
     """Prints the generated makefile to stdout."""
     print('export DOCKER_BUILDKIT := 1')
@@ -43,14 +43,15 @@ def print_makefile(buildable_images, docker_registry):
 
 def main():
     """Generates Makefile with docker image build rules."""
-    parser = argparse.ArgumentParser(description='GCB spec generator.')
+    parser = argparse.ArgumentParser(
+        description='Makefile build rule generator.')
     parser.add_argument('-r',
                         '--docker-registry',
                         default='gcr.io/fuzzbench/',
                         help='Docker registry to use as cache.')
     args = parser.parse_args()
 
-    # TODO: Create fuzzer/benchmark list dynamically.
+    # TODO(Tanq16): Create fuzzer/benchmark list dynamically.
     fuzzers = ['afl', 'libfuzzer']
     benchmarks = ['libxml', 'libpng']
     buildable_images = docker_images.get_images_to_build(fuzzers, benchmarks)

--- a/experiment/build/generate_makefile.py
+++ b/experiment/build/generate_makefile.py
@@ -1,0 +1,50 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generates Makefile containing docker image targets."""
+
+from experiment.build import docker_images
+
+
+def print_makefile(buildable_images):
+    """Prints the generated makefile to stdout."""
+    print('export DOCKER_BUILDKIT := 1')
+
+    for name, image in buildable_images.items():
+        print(name + ':', end='')
+        if 'depends_on' in image:
+            for dep in image['depends_on']:
+                print(' ' + dep, end='')
+        print()
+        print('\tdocker build \\')
+        print('    --tag ' + image['tag'] + ' \\')
+        print('    --cache-from gcr.io/fuzzbench/' + image['tag'] + ' \\')
+        if 'build_arg' in image:
+            for arg in image['build_arg']:
+                print('    --build-arg ' + arg + ' \\')
+        if 'dockerfile' in image:
+            print('    --file ' + image['dockerfile'] + ' \\')
+        print('    ' + image['context'])
+        print()
+
+
+def main():
+    """Main."""
+    fuzzers = ['afl', 'libfuzzer']
+    benchmarks = ['libxml', 'libpng']
+    buildable_images = docker_images.get_images_to_build(fuzzers, benchmarks)
+    print_makefile(buildable_images)
+
+
+if __name__ == '__main__':
+    main()

--- a/experiment/build/test_docker_images.py
+++ b/experiment/build/test_docker_images.py
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Docker images tests."""
+
+from experiment.build import docker_images
+
+
+def test_dependencies_exist():
+    """Tests that if an image has a dependency, then the dependency exist among
+    the images."""
+    fuzzers = ['afl', 'libfuzzer']
+    benchmarks = ['libxml', 'libpng']
+    all_images = docker_images.get_images_to_build(fuzzers, benchmarks)
+    for image in all_images.values():
+        if 'depends_on' in image:
+            for dep in image['depends_on']:
+                assert dep in all_images

--- a/experiment/build/test_docker_images.py
+++ b/experiment/build/test_docker_images.py
@@ -16,12 +16,32 @@
 from experiment.build import docker_images
 
 
+def test_images_to_build_list():
+    """Tests that the expected set of images is returned by
+    images_to_build()."""
+    fuzzers = ['afl', 'libfuzzer']
+    benchmarks = ['libxml', 'libpng']
+    all_images = docker_images.get_images_to_build(fuzzers, benchmarks)
+    assert set(all_images.keys()) == set([
+        'base-image', 'base-builder', 'base-runner', 'coverage-builder',
+        'coverage-libxml-builder', 'coverage-libpng-builder', 'afl-builder',
+        'afl-libxml-builder', 'afl-libxml-intermediate-runner',
+        'afl-libxml-runner', 'afl-libpng-builder',
+        'afl-libpng-intermediate-runner', 'afl-libpng-runner',
+        'libfuzzer-builder', 'libfuzzer-libxml-builder',
+        'libfuzzer-libxml-intermediate-runner', 'libfuzzer-libxml-runner',
+        'libfuzzer-libpng-builder', 'libfuzzer-libpng-intermediate-runner',
+        'libfuzzer-libpng-runner'
+    ])
+
+
 def test_dependencies_exist():
     """Tests that if an image has a dependency, then the dependency exist among
     the images."""
     fuzzers = ['afl', 'libfuzzer']
     benchmarks = ['libxml', 'libpng']
     all_images = docker_images.get_images_to_build(fuzzers, benchmarks)
+
     for image in all_images.values():
         if 'depends_on' in image:
             for dep in image['depends_on']:


### PR DESCRIPTION
Running a FuzzBench experiment involves building hundreds of docker images for all the different fuzzer-benchmark pairs. Currently, we build these images using Google Cloud Build in prod, and using Makefiles locally. The logic of building the images and the dependencies between them is currently encoded in two places, ie., in docker/gcb/*.yaml and docker/generate_makefile.py. This is difficult to maintain and [very error prone](https://github.com/google/fuzzbench/issues/336). To complicate things further, we are also implementing distributed builds as part of a new queue-based architecture (https://github.com/google/fuzzbench/pull/521).

To eliminate the above described redundancy and make the FuzzBench build system simple and easy to maintain, we introduce a `get_images_to_build(fuzzers, benchmarks)` function that returns the set of buildable images with their properties describing how to build them, as well as their dependencies (as python objects). This can be used to simply generate the input for different build tools, ie. the 1) GCB build spec, 2) the Makefile, and 3) the (rq) jobs to enqueue in the new architecture.

The PR includes the initial prototype of:
- the `get_images_to_build` function, which relies on
- an easy to read/modify config file describing the image types and their dependencies
- generator for Cloud Build spec
- generator for Makefile rules