### PR TITLE
Make experiments private by default.

### DIFF
--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -59,7 +59,7 @@ def _initialize_experiment_in_db(experiment_config: dict,
         db_utils.get_or_create(models.Experiment,
                                name=experiment_config['experiment'],
                                git_hash=experiment_config['git_hash'],
-                               private=experiment_config.get('private', False))
+                               private=experiment_config.get('private', True))
     ])
 
     # TODO(metzman): Consider doing this without sqlalchemy. This can get


### PR DESCRIPTION
For the most part all nonprivate experiments are run by the service
which explicitly makes them nonprivate. So private should be the
default since most other experiments are not ones I want to
be merged into other experiments.