### PR TITLE
[libFuzzer] Add -fno-builtin flags to disable optimizing certain libcalls

### DIFF
--- a/fuzzers/libfuzzer/fuzzer.py
+++ b/fuzzers/libfuzzer/fuzzer.py
@@ -25,6 +25,18 @@ def build():
     # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
     # allows us to link against a version of LibFuzzer that we specify.
     cflags = ['-fsanitize=fuzzer-no-link']
+
+    # Can be removed once the patch https://reviews.llvm.org/D83987 lands
+    # and appears in gcr.io/fuzzbench/base-builder
+    cflags += ['-fno-builtin-memcmp']
+    cflags += ['-fno-builtin-strncmp']
+    cflags += ['-fno-builtin-strcmp']
+    cflags += ['-fno-builtin-strncasecmp']
+    cflags += ['-fno-builtin-strcasecmp']
+    cflags += ['-fno-builtin-strstr']
+    cflags += ['-fno-builtin-strcasestr']
+    cflags += ['-fno-builtin-memmem']
+
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -19,6 +19,10 @@
 # are still testing this feature. You should request an experiment by contacting
 # us as you normally do.
 
+- experiment: 2020-07-22
+  fuzzers:
+    - libfuzzer
+
 - experiment: 2020-07-20
   fuzzers:
     - libfuzzer


### PR DESCRIPTION
libFuzzer implements hooks to `memcmp`-like functions to get past data-flow dependent branches more easily.

There is an effort to disable optimizing calls to such functions when `-fsanitize=fuzzer-no-link` is given (see https://reviews.llvm.org/D83987), but getting this patch land and finally appear in the base docker image would take some time.

In the meantime, it would be useful to see if libFuzzer performs differently with this set of `-fno-builtin` flags applied. I will remove these lines once they become redundant.