### PR TITLE
Fix GCB builds

### DIFF
--- a/common/benchmark_utils.py
+++ b/common/benchmark_utils.py
@@ -61,14 +61,6 @@ def get_builder_image_url(benchmark, fuzzer, docker_registry):
         docker_registry=docker_registry, fuzzer=fuzzer, benchmark=benchmark)
 
 
-def get_oss_fuzz_builder_hash(benchmark):
-    """Get the specified hash of the OSS-Fuzz builder for the OSS-Fuzz project
-    used by |benchmark|."""
-    if is_oss_fuzz(benchmark):
-        return oss_fuzz.get_config(benchmark)['oss_fuzz_builder_hash']
-    raise ValueError('Can only get project on OSS-Fuzz benchmarks.')
-
-
 def validate(benchmark):
     """Return True if |benchmark| is a valid fuzzbench fuzzer."""
     if VALID_BENCHMARK_REGEX.match(benchmark) is None:

--- a/common/test_benchmark_utils.py
+++ b/common/test_benchmark_utils.py
@@ -33,18 +33,6 @@ def test_is_oss_fuzz(benchmark, expected_result, oss_fuzz_benchmark):
     assert benchmark_utils.is_oss_fuzz(benchmark) == expected_result
 
 
-def test_get_project_oss_fuzz_benchmark(oss_fuzz_benchmark):
-    """Test that we can get the project of an OSS-Fuzz benchmark."""
-    assert benchmark_utils.get_project(
-        oss_fuzz_benchmark) == conftest.OSS_FUZZ_BENCHMARK_CONFIG['project']
-
-
-def test_get_project_non_oss_fuzz_benchmark():
-    """Test that we can't get the project of a non-OSS-Fuzz benchmark."""
-    with pytest.raises(ValueError):
-        benchmark_utils.get_project(OTHER_BENCHMARK)
-
-
 @pytest.mark.parametrize('benchmark,expected_fuzz_target',
                          [(conftest.OSS_FUZZ_BENCHMARK_NAME,
                            conftest.OSS_FUZZ_BENCHMARK_CONFIG['fuzz_target']),
@@ -64,18 +52,3 @@ def test_get_runner_image_url(benchmark, expected_url, oss_fuzz_benchmark):
     assert benchmark_utils.get_runner_image_url('experiment', benchmark,
                                                 'fuzzer',
                                                 DOCKER_REGISTRY) == expected_url
-
-
-def test_get_builder_hash_oss_fuzz_benchmark(oss_fuzz_benchmark):
-    """Test that we can get the oss_fuzz_builder_hash of an OSS-Fuzz
-    benchmark."""
-    assert benchmark_utils.get_oss_fuzz_builder_hash(
-        oss_fuzz_benchmark
-    ) == conftest.OSS_FUZZ_BENCHMARK_CONFIG['oss_fuzz_builder_hash']
-
-
-def test_get_builder_hash_non_oss_fuzz_benchmark():
-    """Test that we can't get the oss_fuzz_builder_hash of a non-OSS-Fuzz
-    benchmark."""
-    with pytest.raises(ValueError):
-        benchmark_utils.get_oss_fuzz_builder_hash(OTHER_BENCHMARK)

--- a/docker/build.mk
+++ b/docker/build.mk
@@ -70,9 +70,9 @@ $(1)-commit := $(shell cat benchmarks/$(1)/oss-fuzz.yaml | \
 
 .$(1)-project-builder:
 	docker build \
-    --tag $(BASE_TAG)/builders/oss-fuzz/$(1) \
+    --tag $(BASE_TAG)/builders/oss-fuzz-project/$(1) \
     --file benchmarks/$(1)/Dockerfile \
-    $(call cache_from,${BASE_TAG}/builders/oss-fuzz/$(1)) \
+    $(call cache_from,${BASE_TAG}/builders/oss-fuzz-project/$(1)) \
     benchmarks/$(1)
 
 endef

--- a/docker/gcb/base-images.yaml
+++ b/docker/gcb/base-images.yaml
@@ -42,7 +42,7 @@ steps:
     # Use two tags so that the image builds properly and we can push it to the
     # correct location.
     '--tag',
-    'gcr.io/fuzzbench/base-image:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/base-image',
 
     '--tag',
     '${_REPO}/base-image:${_EXPERIMENT}',
@@ -69,7 +69,7 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/base-builder:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/base-builder',
 
     '--tag',
     '${_REPO}/base-builder:${_EXPERIMENT}',
@@ -96,7 +96,7 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/base-builder:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/base-builder',
 
     '--tag',
     '${_REPO}/base-runner:${_EXPERIMENT}',

--- a/docker/gcb/coverage.yaml
+++ b/docker/gcb/coverage.yaml
@@ -31,7 +31,7 @@ steps:
     # Use two tags so that the image builds properly and we can push it to the
     # correct location.
     '--tag',
-    'gcr.io/fuzzbench/builders/coverage:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/builders/coverage',
 
     '--tag',
     '${_REPO}/builders/coverage:${_EXPERIMENT}',
@@ -60,7 +60,7 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/builders/coverage/${_BENCHMARK}:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/builders/coverage/${_BENCHMARK}',
 
     '--tag',
     '${_REPO}/builders/coverage/${_BENCHMARK}:${_EXPERIMENT}',

--- a/docker/gcb/fuzzer.yaml
+++ b/docker/gcb/fuzzer.yaml
@@ -31,7 +31,7 @@ steps:
     # Use two tags so that the image builds properly and we can push it to the
     # correct location.
     '--tag',
-    'gcr.io/fuzzbench/builders/${_FUZZER}:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/builders/${_FUZZER}',
 
     '--tag',
     '${_REPO}/builders/${_FUZZER}:${_EXPERIMENT}',
@@ -61,7 +61,7 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/builders/${_FUZZER}/${_BENCHMARK}:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/builders/${_FUZZER}/${_BENCHMARK}',
 
     '--tag',
     '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}:${_EXPERIMENT}',
@@ -97,7 +97,7 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/runners/${_FUZZER}/${_BENCHMARK}-intermediate:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/runners/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     '--tag',
     '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}-intermediate:${_EXPERIMENT}',
@@ -127,7 +127,7 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/runners/${_FUZZER}/${_BENCHMARK}:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/runners/${_FUZZER}/${_BENCHMARK}',
 
     '--tag',
     '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}:${_EXPERIMENT}',

--- a/docker/gcb/oss-fuzz-coverage.yaml
+++ b/docker/gcb/oss-fuzz-coverage.yaml
@@ -28,7 +28,7 @@ steps:
     # Use two tags so that the image builds properly and we can push it to the
     # correct location.
     '--tag',
-    'gcr.io/fuzzbench/builders/coverage/${_BENCHMARK}-intermediate:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/builders/coverage/${_BENCHMARK}-intermediate',
 
     '--tag',
     '${_REPO}/builders/coverage/${_BENCHMARK}-intermediate:${_EXPERIMENT}',
@@ -61,7 +61,7 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/builders/coverage/${_BENCHMARK}:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/builders/coverage/${_BENCHMARK}',
 
     '--tag',
     '${_REPO}/builders/coverage/${_BENCHMARK}:${_EXPERIMENT}',

--- a/docker/gcb/oss-fuzz-coverage.yaml
+++ b/docker/gcb/oss-fuzz-coverage.yaml
@@ -68,8 +68,6 @@ steps:
     '--cache-from',
     '${_REPO}/builders/coverage/${_BENCHMARK}-intermediate',
 
-    # Use a hardcoded repo because the parent image is pinned by SHA. Users
-    # won't have it.
     '--build-arg',
     'parent_image=gcr.io/fuzzbench/builders/oss-fuzz-project/${_BENCHMARK}',
 

--- a/docker/gcb/oss-fuzz-coverage.yaml
+++ b/docker/gcb/oss-fuzz-coverage.yaml
@@ -19,7 +19,37 @@ steps:
   args:
     - '-c'
     - |
+      docker pull ${_REPO}/builders/oss-fuzz-project/${_BENCHMARK} || exit 0
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: [
+    'build',
+
+    # Use two tags so that the image builds properly and we can push it to the
+    # correct location.
+    '--tag',
+    'gcr.io/fuzzbench/builders/oss-fuzz-project/${_BENCHMARK}',
+
+    '--tag',
+    '${_REPO}/builders/oss-fuzz-project/${_BENCHMARK}:${_EXPERIMENT}',
+
+    '--file=benchmarks/${_BENCHMARK}/Dockerfile',
+
+    '--cache-from',
+    '${_REPO}/builders/oss-fuzz-project/${_BENCHMARK}:${_EXPERIMENT}',
+
+    'benchmarks/${_BENCHMARK}',
+  ]
+  id: 'build-project-builder'
+
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
       docker pull ${_REPO}/builders/coverage/${_BENCHMARK}-intermediate || exit 0
+  id: 'pull-coverage-benchmark-builder-intermediate'
+  wait_for: ['-']
 
 - name: 'gcr.io/cloud-builders/docker'
   args: [
@@ -41,11 +71,12 @@ steps:
     # Use a hardcoded repo because the parent image is pinned by SHA. Users
     # won't have it.
     '--build-arg',
-    'parent_image=gcr.io/fuzzbench/oss-fuzz/${_OSS_FUZZ_PROJECT}@sha256:${_OSS_FUZZ_BUILDER_HASH}',
+    'parent_image=gcr.io/fuzzbench/builders/oss-fuzz-project/${_BENCHMARK}',
 
     'fuzzers/coverage',
   ]
   id: 'build-coverage-benchmark-builder-intermediate'
+  wait_for: ['build-project-builder', 'pull-coverage-benchmark-builder-intermediate']
 
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
@@ -104,5 +135,6 @@ steps:
   ]
 
 images:
+  - '${_REPO}/builders/oss-fuzz-project/${_BENCHMARK}:${_EXPERIMENT}'
   - '${_REPO}/builders/coverage/${_BENCHMARK}-intermediate:${_EXPERIMENT}'
   - '${_REPO}/builders/coverage/${_BENCHMARK}:${_EXPERIMENT}'

--- a/docker/gcb/oss-fuzz-fuzzer.yaml
+++ b/docker/gcb/oss-fuzz-fuzzer.yaml
@@ -26,7 +26,7 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/builders/${_FUZZER}/${_BENCHMARK}-intermediate:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     '--tag',
     '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate:${_EXPERIMENT}',
@@ -59,7 +59,7 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/builders/${_FUZZER}/${_BENCHMARK}:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/builders/${_FUZZER}/${_BENCHMARK}',
 
     '--tag',
     '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}:${_EXPERIMENT}',
@@ -97,7 +97,7 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/runners/${_FUZZER}/${_BENCHMARK}-intermediate:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/runners/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     '--tag',
     '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}-intermediate:${_EXPERIMENT}',
@@ -128,7 +128,7 @@ steps:
     'build',
 
     '--tag',
-    'gcr.io/fuzzbench/runners/${_FUZZER}/${_BENCHMARK}:${_EXPERIMENT}',
+    'gcr.io/fuzzbench/runners/${_FUZZER}/${_BENCHMARK}',
 
     '--tag',
     '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}:${_EXPERIMENT}',

--- a/docker/gcb/oss-fuzz-fuzzer.yaml
+++ b/docker/gcb/oss-fuzz-fuzzer.yaml
@@ -14,12 +14,43 @@
 
 steps:
 
+
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
+      docker pull ${_REPO}/builders/oss-fuzz-project/${_BENCHMARK} || exit 0
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: [
+    'build',
+
+    # Use two tags so that the image builds properly and we can push it to the
+    # correct location.
+    '--tag',
+    'gcr.io/fuzzbench/builders/oss-fuzz-project/${_BENCHMARK}',
+
+    '--tag',
+    '${_REPO}/builders/oss-fuzz-project/${_BENCHMARK}:${_EXPERIMENT}',
+
+    '--file=benchmarks/${_BENCHMARK}/Dockerfile',
+
+    '--cache-from',
+    '${_REPO}/builders/oss-fuzz-project/${_BENCHMARK}:${_EXPERIMENT}',
+
+    'benchmarks/${_BENCHMARK}',
+  ]
+  id: 'build-project-builder'
+
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
   args:
     - '-c'
     - |
       docker pull ${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate || exit 0
+  id: 'pull-fuzzer-benchmark-builder-intermediate'
+  wait_for: ['-']
 
 - name: 'gcr.io/cloud-builders/docker'
   args: [
@@ -39,11 +70,12 @@ steps:
     # Use a hardcoded repo because the parent image is pinned by SHA. Users
     # won't have it.
     '--build-arg',
-    'parent_image=gcr.io/fuzzbench/oss-fuzz/${_OSS_FUZZ_PROJECT}@sha256:${_OSS_FUZZ_BUILDER_HASH}',
+    'parent_image=gcr.io/fuzzbench/builders/oss-fuzz-project/${_BENCHMARK}',
 
     'fuzzers/${_FUZZER}',
   ]
   id: 'build-fuzzer-benchmark-builder-intermediate'
+  wait_for: ['pull-fuzzer-benchmark-builder-intermediate', 'build-project-builder']
 
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
@@ -150,6 +182,7 @@ steps:
   wait_for: ['pull-fuzzer-benchmark-runner', 'build-fuzzer-benchmark-runner-intermediate']
 
 images:
+  - '${_REPO}/builders/oss-fuzz-project/${_BENCHMARK}:${_EXPERIMENT}'
   - '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate:${_EXPERIMENT}'
   - '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}:${_EXPERIMENT}'
   - '${_REPO}/runners/${_FUZZER}/${_BENCHMARK}-intermediate:${_EXPERIMENT}'

--- a/docker/generate_makefile.py
+++ b/docker/generate_makefile.py
@@ -176,7 +176,7 @@ OSS_FUZZER_BENCHMARK_TEMPLATE = """
 	docker build \\
     --tag {base_tag}/builders/{fuzzer}/{benchmark}-intermediate \\
     --file=fuzzers/{fuzzer}/builder.Dockerfile \\
-    --build-arg parent_image=gcr.io/fuzzbench/builders/oss-fuzz/{benchmark} \\
+    --build-arg parent_image=gcr.io/fuzzbench/builders/oss-fuzz-project/{benchmark} \\
     $(call cache_from,{base_tag}/builders/{fuzzer}/{benchmark}-intermediate) \\
     fuzzers/{fuzzer}
 

--- a/experiment/build/gcb_build.py
+++ b/experiment/build/gcb_build.py
@@ -69,14 +69,13 @@ def _build_benchmark_coverage(benchmark: str) -> Tuple[int, str]:
 def _build_oss_fuzz_project_fuzzer(benchmark: str,
                                    fuzzer: str) -> Tuple[int, str]:
     """Build a |benchmark|, |fuzzer| runner image on GCB."""
-    project = benchmark_utils.get_project(benchmark)
     substitutions = {
         '_BENCHMARK': benchmark,
         '_FUZZER': fuzzer,
     }
     config_file = get_build_config_file('oss-fuzz-fuzzer.yaml')
-    config_name = 'oss-fuzz-{project}-fuzzer-{fuzzer}'.format(
-        project=project, fuzzer=fuzzer)
+    config_name = 'oss-fuzz-{benchmark}-fuzzer-{fuzzer}'.format(
+        benchmark=benchmark, fuzzer=fuzzer)
 
     return _build(config_file, config_name, substitutions)
 

--- a/experiment/build/gcb_build.py
+++ b/experiment/build/gcb_build.py
@@ -70,16 +70,13 @@ def _build_oss_fuzz_project_fuzzer(benchmark: str,
                                    fuzzer: str) -> Tuple[int, str]:
     """Build a |benchmark|, |fuzzer| runner image on GCB."""
     project = benchmark_utils.get_project(benchmark)
-    oss_fuzz_builder_hash = benchmark_utils.get_oss_fuzz_builder_hash(benchmark)
     substitutions = {
-        '_OSS_FUZZ_PROJECT': project,
         '_BENCHMARK': benchmark,
         '_FUZZER': fuzzer,
-        '_OSS_FUZZ_BUILDER_HASH': oss_fuzz_builder_hash,
     }
     config_file = get_build_config_file('oss-fuzz-fuzzer.yaml')
-    config_name = 'oss-fuzz-{project}-fuzzer-{fuzzer}-hash-{hash}'.format(
-        project=project, fuzzer=fuzzer, hash=oss_fuzz_builder_hash)
+    config_name = 'oss-fuzz-{project}-fuzzer-{fuzzer}'.format(
+        project=project, fuzzer=fuzzer)
 
     return _build(config_file, config_name, substitutions)
 
@@ -100,19 +97,14 @@ def _build_benchmark_fuzzer(benchmark: str, fuzzer: str) -> Tuple[int, str]:
 
 def _build_oss_fuzz_project_coverage(benchmark: str) -> Tuple[int, str]:
     """Build a coverage build of OSS-Fuzz-based benchmark |benchmark| on GCB."""
-    project = benchmark_utils.get_project(benchmark)
-    oss_fuzz_builder_hash = benchmark_utils.get_oss_fuzz_builder_hash(benchmark)
     coverage_binaries_dir = exp_path.filestore(
         build_utils.get_coverage_binaries_dir())
     substitutions = {
         '_GCS_COVERAGE_BINARIES_DIR': coverage_binaries_dir,
         '_BENCHMARK': benchmark,
-        '_OSS_FUZZ_PROJECT': project,
-        '_OSS_FUZZ_BUILDER_HASH': oss_fuzz_builder_hash,
     }
     config_file = get_build_config_file('oss-fuzz-coverage.yaml')
-    config_name = 'oss-fuzz-{project}-coverage-hash-{hash}'.format(
-        project=project, hash=oss_fuzz_builder_hash)
+    config_name = 'oss-fuzz-{benchmark}-coverage'.format(benchmark=benchmark)
     return _build(config_file, config_name, substitutions)
 
 


### PR DESCRIPTION
1. Experiment based tagging is broken. Previously the experiment tag was added to the tag argument that used ${_REPO} and the one that used gcr.io/fuzzbench, but this was a mistake. It should have only been done to ${_REPO} because we only want to do this before pushing.
2. GCB builds for OSS-Fuzz benchmarks did not take into account the new build system for oss-fuzz benchmarks until now.