### PR TITLE
[NFC] update current jobs status reporting info

### DIFF
--- a/fuzzbench/run_experiment.py
+++ b/fuzzbench/run_experiment.py
@@ -25,6 +25,8 @@ def run_experiment():
     """Main experiment logic."""
     print('Initializing the job queue.')
     queue = rq.Queue()
+    # Initialization.
+    queue.empty()
     jobs_list = []
     jobs_list.append(
         queue.enqueue(jobs.build_image,
@@ -46,6 +48,7 @@ def run_experiment():
 
     while True:
         print('Current status of jobs:')
+        print('\tqueued:\t%d' % len(queue))
         print('\tstarted:\t%d' % queue.started_job_registry.count)
         print('\tdeferred:\t%d' % queue.deferred_job_registry.count)
         print('\tfinished:\t%d' % queue.finished_job_registry.count)

--- a/fuzzbench/run_experiment.py
+++ b/fuzzbench/run_experiment.py
@@ -46,8 +46,14 @@ def run_experiment():
 
     while True:
         print('Current status of jobs:')
+        print('\tstarted:\t%d' % queue.started_job_registry.count)
+        print('\tdeferred:\t%d' % queue.deferred_job_registry.count)
+        print('\tfinished:\t%d' % queue.finished_job_registry.count)
+        print('\tscheduled:\t%d' % queue.scheduled_job_registry.count)
+        print('\tfailed:\t%d' % queue.failed_job_registry.count)
         for job in jobs_list:
-            print('  %s%s : %s' % (job.func_name, job.args, job.get_status()))
+            print('  %s : %s\t(%s)' % (job.func_name, job.get_status(), job.id))
+
         if all([job.result is not None for job in jobs_list]):
             break
         time.sleep(3)

--- a/fuzzbench/run_experiment.py
+++ b/fuzzbench/run_experiment.py
@@ -25,8 +25,6 @@ def run_experiment():
     """Main experiment logic."""
     print('Initializing the job queue.')
     queue = rq.Queue()
-    # Initialization.
-    queue.empty()
     jobs_list = []
     jobs_list.append(
         queue.enqueue(jobs.build_image,

--- a/fuzzbench/run_experiment.py
+++ b/fuzzbench/run_experiment.py
@@ -46,11 +46,10 @@ def run_experiment():
 
     while True:
         print('Current status of jobs:')
-        print('\tqueued:\t%d' % len(queue))
+        print('\tqueued:\t%d' % queue.count)
         print('\tstarted:\t%d' % queue.started_job_registry.count)
         print('\tdeferred:\t%d' % queue.deferred_job_registry.count)
         print('\tfinished:\t%d' % queue.finished_job_registry.count)
-        print('\tscheduled:\t%d' % queue.scheduled_job_registry.count)
         print('\tfailed:\t%d' % queue.failed_job_registry.count)
         for job in jobs_list:
             print('  %s : %s\t(%s)' % (job.func_name, job.get_status(), job.id))


### PR DESCRIPTION
Use queue's job registries to reflect the actual status of that queue. This will help to have a glance at what is going on now.
Minor format changing makes it look neat and aligned.

Reference: https://python-rq.org/docs/job_registries/

The final result will look like this:
```
...
Attaching to e2e-test_run-experiment_1, e2e-test_worker_2, e2e-test_worker_1, e2e-test_worker_3
run-experiment_1  | Initializing the job queue.
run-experiment_1  | Current status of jobs:
run-experiment_1  | 	started:	1
run-experiment_1  | 	deferred:	15
run-experiment_1  | 	finished:	0
run-experiment_1  | 	scheduled:	0
run-experiment_1  | 	failed:	0
run-experiment_1  |   fuzzbench.jobs.build_image : started	(base-image)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(base-builder)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(base-runner)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(coverage-builder)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(coverage-freetype2-2017-builder)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(afl-builder)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(afl-freetype2-2017-builder)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(afl-freetype2-2017-intermediate-runner)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(coverage-libpng-1.2.56-builder)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(afl-libpng-1.2.56-builder)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(afl-libpng-1.2.56-intermediate-runner)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(libfuzzer-builder)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(libfuzzer-freetype2-2017-builder)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(libfuzzer-freetype2-2017-intermediate-runner)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(libfuzzer-libpng-1.2.56-builder)
run-experiment_1  |   fuzzbench.jobs.build_image : deferred	(libfuzzer-libpng-1.2.56-intermediate-runner)
...