### PR TITLE
Upgrade curl, bloaty benchmarks for clang source code coverage.

### DIFF
--- a/benchmarks/bloaty_fuzz_target/Dockerfile
+++ b/benchmarks/bloaty_fuzz_target/Dockerfile
@@ -15,7 +15,6 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder@sha256:12125f1ecb9e4905a19c35700a3402c1eba43c82ea2d227f01c28833d75e3574
-MAINTAINER jhaberman@gmail.com
 RUN apt-get update && apt-get install -y cmake ninja-build g++
 RUN git clone --depth 1 https://github.com/google/bloaty.git bloaty
 WORKDIR bloaty

--- a/benchmarks/bloaty_fuzz_target/Dockerfile
+++ b/benchmarks/bloaty_fuzz_target/Dockerfile
@@ -14,7 +14,8 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:dc0a0e4327c53b000c63837c5ea8d5e8f18fb0fb2a38abd4249dedca39ed0a1f
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:12125f1ecb9e4905a19c35700a3402c1eba43c82ea2d227f01c28833d75e3574
+MAINTAINER jhaberman@gmail.com
 RUN apt-get update && apt-get install -y cmake ninja-build g++
 RUN git clone --depth 1 https://github.com/google/bloaty.git bloaty
 WORKDIR bloaty

--- a/benchmarks/bloaty_fuzz_target/oss-fuzz.yaml
+++ b/benchmarks/bloaty_fuzz_target/oss-fuzz.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 commit: 3cf5c3feca15ab88730d6526b2f06302597926b5
 commit_date: 2020-05-25 18:51:34+00:00
 fuzz_target: fuzz_target

--- a/benchmarks/bloaty_fuzz_target/oss-fuzz.yaml
+++ b/benchmarks/bloaty_fuzz_target/oss-fuzz.yaml
@@ -1,18 +1,4 @@
-# Copyright 2020 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-commit: 08f59b2ae229c75b01c50bfcb52e74984c8019fb
-commit_date: 2019-11-18 16:52:25+00:00
+commit: 3cf5c3feca15ab88730d6526b2f06302597926b5
+commit_date: 2020-05-25 18:51:34+00:00
 fuzz_target: fuzz_target
 project: bloaty

--- a/benchmarks/curl_curl_fuzzer_http/Dockerfile
+++ b/benchmarks/curl_curl_fuzzer_http/Dockerfile
@@ -14,12 +14,11 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:dc0a0e4327c53b000c63837c5ea8d5e8f18fb0fb2a38abd4249dedca39ed0a1f
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:aea783f76a46298085620e73d9943fad84c912e38b8a1a482177ae84360152ec
 
-# Curl will be checked out to the commit hash specified in oss-fuzz.yaml.
 RUN git clone --depth 1 https://github.com/curl/curl.git /src/curl
 RUN git clone https://github.com/curl/curl-fuzzer.git /src/curl_fuzzer
-RUN git -C /src/curl_fuzzer checkout -f 82eb95b410cc84579b8f9d663f2a7e38f3bdb41f
+RUN git -C /src/curl_fuzzer checkout -f 9a48d437484b5ad5f2a97c0cab0d8bcbb5d058de
 
 # Use curl-fuzzer's scripts to get latest dependencies.
 RUN $SRC/curl_fuzzer/scripts/ossfuzzdeps.sh

--- a/benchmarks/curl_curl_fuzzer_http/oss-fuzz.yaml
+++ b/benchmarks/curl_curl_fuzzer_http/oss-fuzz.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commit: e0363a47de4972c7d23d87b8f75a683cf0c4271b
-commit_date: 2019-11-18 15:40:08+00:00
+commit: 376d5bb323c03c0fc4af266c03abac8f067fbd0e
+commit_date: 2020-07-26 21:48:36+00:00
 fuzz_target: curl_fuzzer_http
 project: curl


### PR DESCRIPTION
Fixes https://github.com/google/fuzzbench/issues/590