### PR TITLE
[libFuzzer] Update libFuzzer.a version

### DIFF
--- a/fuzzers/libfuzzer/builder.Dockerfile
+++ b/fuzzers/libfuzzer/builder.Dockerfile
@@ -17,7 +17,7 @@ FROM $parent_image
 
 RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
     cd /llvm-project/ && \
-    git checkout 12d1124c49beec0fb79d36944960e5bf0f236d4c && \
+    git checkout b52b2e1c188072e3cbc91500cfd503fb26d50ffc && \
     cd compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
       clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \

--- a/fuzzers/libfuzzer/fuzzer.py
+++ b/fuzzers/libfuzzer/fuzzer.py
@@ -26,8 +26,9 @@ def build():
     # allows us to link against a version of LibFuzzer that we specify.
     cflags = ['-fsanitize=fuzzer-no-link']
 
-    # Can be removed once the patch https://reviews.llvm.org/D83987 lands
-    # and appears in gcr.io/fuzzbench/base-builder
+    # Can be removed once the patch https://reviews.llvm.org/D83987
+    # appears in gcr.io/fuzzbench/base-builder
+    cflags += ['-fno-builtin-bcmp']
     cflags += ['-fno-builtin-memcmp']
     cflags += ['-fno-builtin-strncmp']
     cflags += ['-fno-builtin-strcmp']


### PR DESCRIPTION
Use latest libFuzzer.a which provides a more robust version of interceptors.