### PR TITLE
Dump the coverage report even if it times out.

### DIFF
--- a/fuzzers/coverage/builder.Dockerfile
+++ b/fuzzers/coverage/builder.Dockerfile
@@ -15,6 +15,7 @@
 ARG parent_image=gcr.io/fuzzbench/base-builder
 FROM $parent_image
 
+# The patch adds hook to dump clang coverage data when timeout.
 COPY patch.diff /
 
 # Use a libFuzzer version that supports clang source-based coverage.

--- a/fuzzers/coverage/builder.Dockerfile
+++ b/fuzzers/coverage/builder.Dockerfile
@@ -15,12 +15,13 @@
 ARG parent_image=gcr.io/fuzzbench/base-builder
 FROM $parent_image
 
+COPY patch.diff /
+
 # Use a libFuzzer version that supports clang source-based coverage.
 RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout d8981ce5b9f8caa567613b2bf5aa3095e0156130 && \
-    cd compiler-rt/lib/fuzzer && \
-    (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
-    done && wait) && \
-    ar r /usr/lib/libFuzzer.a *.o
+    cd /llvm-project && \
+    git checkout 0b5e6b11c358e704384520dc036eddb5da1c68bf && \
+    patch -p1 < /patch.diff && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
+    bash build.sh && \
+    cp libFuzzer.a /usr/lib

--- a/fuzzers/coverage/patch.diff
+++ b/fuzzers/coverage/patch.diff
@@ -1,0 +1,55 @@
+diff --git a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+index 306e644277c..26db440ecd7 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+@@ -737,6 +737,8 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+       F->SetMaxInputLen(kDefaultMaxMergeLen);
+     assert(Flags.merge_control_file);
+     F->CrashResistantMergeInternalStep(Flags.merge_control_file);
++    if (Options.DumpCoverage)
++      TPC.DumpCoverage();
+     exit(0);
+   }
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerExtFunctions.def b/compiler-rt/lib/fuzzer/FuzzerExtFunctions.def
+index bb15d68e0de..154b6239d53 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerExtFunctions.def
++++ b/compiler-rt/lib/fuzzer/FuzzerExtFunctions.def
+@@ -48,3 +48,6 @@ EXT_FUNC(__sanitizer_dump_coverage, void, (const uintptr_t *, uintptr_t),
+ EXT_FUNC(__msan_scoped_disable_interceptor_checks, void, (), false);
+ EXT_FUNC(__msan_scoped_enable_interceptor_checks, void, (), false);
+ EXT_FUNC(__msan_unpoison, void, (const volatile void *, size_t size), false);
++
++//Clang source-based coverage functions
++EXT_FUNC(__llvm_profile_dump, int, (), false);
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+index b6b11f08579..52309df4696 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+@@ -323,11 +323,8 @@ void TracePC::PrintCoverage() {
+ }
+ 
+ void TracePC::DumpCoverage() {
+-  if (EF->__sanitizer_dump_coverage) {
+-    Vector<uintptr_t> PCsCopy(GetNumPCs());
+-    for (size_t i = 0; i < GetNumPCs(); i++)
+-      PCsCopy[i] = PCs()[i] ? GetPreviousInstructionPc(PCs()[i]) : 0;
+-    EF->__sanitizer_dump_coverage(PCsCopy.data(), PCsCopy.size());
++  if (EF->__llvm_profile_dump) {
++    EF->__llvm_profile_dump();
+   }
+ }
+ 
+diff --git a/compiler-rt/lib/fuzzer/build.sh b/compiler-rt/lib/fuzzer/build.sh
+index 504e54e3a81..78191272c68 100755
+--- a/compiler-rt/lib/fuzzer/build.sh
++++ b/compiler-rt/lib/fuzzer/build.sh
+@@ -2,7 +2,7 @@
+ LIBFUZZER_SRC_DIR=$(dirname $0)
+ CXX="${CXX:-clang}"
+ for f in $LIBFUZZER_SRC_DIR/*.cpp; do
+-  $CXX -g -O2 -fno-omit-frame-pointer -std=c++11 $f -c &
++  $CXX -stdlib=libc++ -g -O2 -fno-omit-frame-pointer -std=c++11 $f -fPIC -c &
+ done
+ wait
+ rm -f libFuzzer.a

--- a/fuzzers/coverage/patch.diff
+++ b/fuzzers/coverage/patch.diff
@@ -20,7 +20,7 @@ index bb15d68e0de..154b6239d53 100644
  EXT_FUNC(__msan_scoped_enable_interceptor_checks, void, (), false);
  EXT_FUNC(__msan_unpoison, void, (const volatile void *, size_t size), false);
 +
-+//Clang source-based coverage functions
++// Clang source-based coverage functions.
 +EXT_FUNC(__llvm_profile_dump, int, (), false);
 diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
 index b6b11f08579..52309df4696 100644


### PR DESCRIPTION
The current case is that clang source-based coverage measurer will dump an empty .profraw file if the measuring times out.
This patch will fix it.
Related to #547 