### PR TITLE
Fix checkout_commit not working in production.

### DIFF
--- a/docker/benchmark-builder/Dockerfile
+++ b/docker/benchmark-builder/Dockerfile
@@ -21,7 +21,6 @@ FROM $parent_image
 
 ARG fuzzer
 ARG benchmark
-ARG checkout_commit
 
 ENV FUZZER $fuzzer
 ENV BENCHMARK $benchmark
@@ -47,9 +46,10 @@ RUN touch $SRC/__init__.py
 # and is not needed during build process.
 ENV ASAN_OPTIONS="detect_leaks=0"
 
-ENV CHECKOUT_COMMIT $checkout_commit
 RUN mkdir /opt/fuzzbench/
 COPY docker/benchmark-builder/checkout_commit.py /opt/fuzzbench/
-RUN python3 /opt/fuzzbench/checkout_commit.py $checkout_commit $SRC
+COPY benchmarks/$benchmark/benchmark.yaml /
+RUN export CHECKOUT_COMMIT=$(cat /benchmark.yaml | tr -d ' ' | grep 'commit:' | cut -d ':' -f2) && \
+    python3 -u /opt/fuzzbench/checkout_commit.py $CHECKOUT_COMMIT $SRC
 
 RUN PYTHONPATH=$SRC python3 -u -c "from fuzzers import utils; utils.initialize_flags(); import fuzzer; fuzzer.build()"

--- a/docker/benchmark-builder/checkout_commit.py
+++ b/docker/benchmark-builder/checkout_commit.py
@@ -49,11 +49,15 @@ def main():
     if len(sys.argv) != 3:
         print("Usage: %s <commit> <src_dir>" % sys.argv[0])
         return 1
+
     commit = sys.argv[1]
     src_dir = sys.argv[2]
     if not commit:
-        print('Not checking out commit.')
+        print('No commit provided, skip.')
         return 0
+
+    print('Checking out commit', commit)
+
     # Infer the project repo directory in the oss-fuzz builder image by
     # iteratively checking out the commit (provided by integrator) in src_dir.
     for _, directories, _ in os.walk(src_dir):

--- a/docker/build.mk
+++ b/docker/build.mk
@@ -63,8 +63,6 @@ dispatcher-image: base-image
 define benchmark_template
 $(1)-fuzz-target  := $(shell cat benchmarks/$(1)/benchmark.yaml | \
                              grep fuzz_target | cut -d ':' -f2 | tr -d ' ')
-$(1)-commit := $(shell cat benchmarks/$(1)/benchmark.yaml | \
-                           grep commit: | cut -d ':' -f2 | tr -d ' ')
 
 # TODO: It would be better to call this benchmark builder. But that would be
 # confusing because this doesn't involve benchmark-builder/Dockerfile. Rename

--- a/docker/generate_makefile.py
+++ b/docker/generate_makefile.py
@@ -102,7 +102,6 @@ FUZZER_BENCHMARK_TEMPLATE = """
     --build-arg parent_image={base_tag}/builders/{fuzzer}/{benchmark}-intermediate \\
     --build-arg fuzzer={fuzzer} \\
     --build-arg benchmark={benchmark} \\
-    --build-arg checkout_commit=$({benchmark}-commit) \\
     $(call cache_from,{base_tag}/builders/{fuzzer}/{benchmark}) \\
     .
 


### PR DESCRIPTION
This only worked in local make, while was not developed to work
in production and broke coverage builds on jsoncpp and libpcap
To avoid more hacks in build yamls, directly parse this info
from benchmark.yaml making it work in both local and production.