### PR TITLE
[GCB] Fix parent_image outside of FuzzBench cloud project

### DIFF
--- a/docker/gcb/coverage.yaml
+++ b/docker/gcb/coverage.yaml
@@ -101,7 +101,7 @@ steps:
     '${_REPO}/builders/coverage/${_BENCHMARK}',
 
     '--build-arg',
-    'parent_image=${_REPO}/builders/coverage/${_BENCHMARK}-intermediate',
+    'parent_image=gcr.io/fuzzbench/builders/coverage/${_BENCHMARK}-intermediate',
 
     '--build-arg',
     'fuzzer=coverage',

--- a/docker/gcb/fuzzer.yaml
+++ b/docker/gcb/fuzzer.yaml
@@ -102,7 +102,7 @@ steps:
     '${_REPO}/builders/${_FUZZER}/${_BENCHMARK}',
 
     '--build-arg',
-    'parent_image=${_REPO}/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
+    'parent_image=gcr.io/fuzzbench/builders/${_FUZZER}/${_BENCHMARK}-intermediate',
 
     '--build-arg',
     'fuzzer=${_FUZZER}',


### PR DESCRIPTION
GCB was broken on non-FuzzBench cloud projects because experiment
tagging meant that certain images were no longer tagged the way
they were passed as parent_image.