### PR TITLE
Add temporary libfuzzer/entropic variants to evaluate the impact of keeping all seed inputs

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -35,7 +35,9 @@ jobs:
           # temporary variants.
           - aflplusplus_havoc
           - libfuzzer_interceptors
+          - libfuzzer_keepseed
           - entropic_interceptors
+          - entropic_keepseed
 
         benchmark_type:
           - oss-fuzz

--- a/fuzzers/entropic_keepseed/builder.Dockerfile
+++ b/fuzzers/entropic_keepseed/builder.Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+COPY patch.diff /
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project && \
+    git checkout b52b2e1c188072e3cbc91500cfd503fb26d50ffc && \
+    patch -p1 < /patch.diff && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /libEntropic.a *.o

--- a/fuzzers/entropic_keepseed/fuzzer.py
+++ b/fuzzers/entropic_keepseed/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+from fuzzers.entropic_interceptors import fuzzer as entropic_fuzzer
+from fuzzers.libfuzzer_interceptors import fuzzer as libfuzzer_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    entropic_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    libfuzzer_fuzzer.run_fuzzer(input_corpus,
+                                output_corpus,
+                                target_binary,
+                                extra_flags=['-entropic=1', '-keep_seed=1'])

--- a/fuzzers/entropic_keepseed/patch.diff
+++ b/fuzzers/entropic_keepseed/patch.diff
@@ -1,0 +1,231 @@
+commit aac9771fa16e3fc00725d4bbd662d71186a09532
+Author: Dokyung Song <dokyungs@google.com>
+Date:   Fri Jul 31 00:07:20 2020 +0000
+
+    [libFuzzer] Optionally keep initial seed inputs regardless of whether they discover new features or not.
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerCorpus.h b/compiler-rt/lib/fuzzer/FuzzerCorpus.h
+index 54d1e09ec6d..80398a9d7ce 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerCorpus.h
++++ b/compiler-rt/lib/fuzzer/FuzzerCorpus.h
+@@ -33,6 +33,7 @@ struct InputInfo {
+   // Stats.
+   size_t NumExecutedMutations = 0;
+   size_t NumSuccessfullMutations = 0;
++  bool SeedInput = false;
+   bool MayDeleteFile = false;
+   bool Reduced = false;
+   bool HasFocusFunction = false;
+@@ -131,9 +132,11 @@ class InputCorpus {
+ 
+   EntropicOptions Entropic;
+ 
++  bool KeepSeed = false;
++
+ public:
+-  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic)
+-      : Entropic(Entropic), OutputCorpus(OutputCorpus) {
++  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic, bool KeepSeed)
++      : Entropic(Entropic), OutputCorpus(OutputCorpus), KeepSeed(KeepSeed) {
+     memset(InputSizesPerFeature, 0, sizeof(InputSizesPerFeature));
+     memset(SmallestElementPerFeature, 0, sizeof(SmallestElementPerFeature));
+   }
+@@ -177,7 +180,7 @@ public:
+   bool empty() const { return Inputs.empty(); }
+   const Unit &operator[] (size_t Idx) const { return Inputs[Idx]->U; }
+   InputInfo *AddToCorpus(const Unit &U, size_t NumFeatures, bool MayDeleteFile,
+-                         bool HasFocusFunction,
++                         bool HasFocusFunction, bool SeedInput,
+                          const Vector<uint32_t> &FeatureSet,
+                          const DataFlowTrace &DFT, const InputInfo *BaseII) {
+     assert(!U.empty());
+@@ -187,6 +190,7 @@ public:
+     InputInfo &II = *Inputs.back();
+     II.U = U;
+     II.NumFeatures = NumFeatures;
++    II.SeedInput = SeedInput;
+     II.MayDeleteFile = MayDeleteFile;
+     II.UniqFeatureSet = FeatureSet;
+     II.HasFocusFunction = HasFocusFunction;
+@@ -471,7 +475,7 @@ private:
+ 
+       for (size_t i = 0; i < N; i++) {
+ 
+-        if (Inputs[i]->NumFeatures == 0) {
++        if (Inputs[i]->NumFeatures == 0 && !(Inputs[i]->SeedInput && KeepSeed)) {
+           // If the seed doesn't represent any features, assign zero energy.
+           Weights[i] = 0.;
+         } else if (Inputs[i]->NumExecutedMutations / kMaxMutationFactor >
+@@ -491,7 +495,7 @@ private:
+ 
+     if (VanillaSchedule) {
+       for (size_t i = 0; i < N; i++)
+-        Weights[i] = Inputs[i]->NumFeatures
++        Weights[i] = (Inputs[i]->NumFeatures || (KeepSeed && Inputs[i]->SeedInput))
+                          ? (i + 1) * (Inputs[i]->HasFocusFunction ? 1000 : 1)
+                          : 0.;
+     }
+diff --git a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+index 00a33a413d2..ef7991c1e27 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+@@ -649,6 +649,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+   Options.Verbosity = Flags.verbosity;
+   Options.MaxLen = Flags.max_len;
+   Options.LenControl = Flags.len_control;
++  Options.KeepSeed = Flags.keep_seed;
+   Options.UnitTimeoutSec = Flags.timeout;
+   Options.ErrorExitCode = Flags.error_exitcode;
+   Options.TimeoutExitCode = Flags.timeout_exitcode;
+@@ -753,7 +754,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+ 
+   Random Rand(Seed);
+   auto *MD = new MutationDispatcher(Rand, Options);
+-  auto *Corpus = new InputCorpus(Options.OutputCorpus, Entropic);
++  auto *Corpus = new InputCorpus(Options.OutputCorpus, Entropic, Options.KeepSeed);
+   auto *F = new Fuzzer(Callback, *Corpus, *MD, Options);
+ 
+   for (auto &U: Dictionary)
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFlags.def b/compiler-rt/lib/fuzzer/FuzzerFlags.def
+index 832224a705d..0dac7e705a3 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFlags.def
++++ b/compiler-rt/lib/fuzzer/FuzzerFlags.def
+@@ -23,6 +23,8 @@ FUZZER_FLAG_INT(len_control, 100, "Try generating small inputs first, "
+ FUZZER_FLAG_STRING(seed_inputs, "A comma-separated list of input files "
+   "to use as an additional seed corpus. Alternatively, an \"@\" followed by "
+   "the name of a file containing the comma-separated list.")
++FUZZER_FLAG_INT(keep_seed, 0, "If 1, keep seed inputs for mutation even if "
++  "they do not produce new coverage.")
+ FUZZER_FLAG_INT(cross_over, 1, "If 1, cross over inputs.")
+ FUZZER_FLAG_INT(mutate_depth, 5,
+             "Apply this number of consecutive mutations to each input.")
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFork.cpp b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+index d9e6b79443e..38fb82fc12d 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFork.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+@@ -309,11 +309,17 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
+   else
+     Env.MainCorpusDir = CorpusDirs[0];
+ 
+-  auto CFPath = DirPlusFile(Env.TempDir, "merge.txt");
+-  CrashResistantMerge(Env.Args, {}, SeedFiles, &Env.Files, {}, &Env.Features,
+-                      {}, &Env.Cov,
+-                      CFPath, false);
+-  RemoveFile(CFPath);
++  if (Options.KeepSeed) {
++    for (auto &File : SeedFiles)
++      Env.Files.push_back(File.File);
++  }
++  else {
++    auto CFPath = DirPlusFile(Env.TempDir, "merge.txt");
++    CrashResistantMerge(Env.Args, {}, SeedFiles, &Env.Files, {}, &Env.Features,
++                        {}, &Env.Cov,
++                        CFPath, false);
++    RemoveFile(CFPath);
++  }
+   Printf("INFO: -fork=%d: %zd seed inputs, starting to fuzz in %s\n", NumJobs,
+          Env.Files.size(), Env.TempDir.c_str());
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerInternal.h b/compiler-rt/lib/fuzzer/FuzzerInternal.h
+index 31096ce804b..e75807209f5 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerInternal.h
++++ b/compiler-rt/lib/fuzzer/FuzzerInternal.h
+@@ -119,6 +119,8 @@ private:
+ 
+   size_t LastCorpusUpdateRun = 0;
+ 
++  bool IsExecutingSeedCorpora = false;
++
+   bool HasMoreMallocsThanFrees = false;
+   size_t NumberOfLeakDetectionAttempts = 0;
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+index 02db6d27b0a..a9af25a3070 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+@@ -487,10 +487,11 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
+     *FoundUniqFeatures = FoundUniqFeaturesOfII;
+   PrintPulseAndReportSlowInput(Data, Size);
+   size_t NumNewFeatures = Corpus.NumFeatureUpdates() - NumUpdatesBefore;
+-  if (NumNewFeatures) {
++  if (NumNewFeatures || (Options.KeepSeed && IsExecutingSeedCorpora)) {
+     TPC.UpdateObservedPCs();
+     auto NewII = Corpus.AddToCorpus({Data, Data + Size}, NumNewFeatures,
+                                     MayDeleteFile, TPC.ObservedFocusFunction(),
++                                    IsExecutingSeedCorpora,
+                                     UniqFeatureSetTmp, DFT, II);
+     WriteFeatureSetToFile(Options.FeaturesDir, Sha1ToString(NewII->Sha1),
+                           NewII->UniqFeatureSet);
+@@ -764,6 +765,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+       assert(CorporaFiles.front().Size <= CorporaFiles.back().Size);
+     }
+ 
++    IsExecutingSeedCorpora = true;
++
+     // Load and execute inputs one by one.
+     for (auto &SF : CorporaFiles) {
+       auto U = FileToVector(SF.File, MaxInputLen, /*ExitOnError=*/false);
+@@ -773,6 +776,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+       TryDetectingAMemoryLeak(U.data(), U.size(),
+                               /*DuringInitialCorpusExecution*/ true);
+     }
++
++    IsExecutingSeedCorpora = false;
+   }
+ 
+   PrintStats("INITED");
+@@ -785,6 +790,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+              Corpus.NumInputsThatTouchFocusFunction());
+   }
+ 
++  Printf("INFO: corpus size = %d\n", Corpus.size());
++
+   if (Corpus.empty() && Options.MaxNumberOfRuns) {
+     Printf("ERROR: no interesting inputs were found. "
+            "Is the code instrumented for coverage? Exiting.\n");
+diff --git a/compiler-rt/lib/fuzzer/FuzzerOptions.h b/compiler-rt/lib/fuzzer/FuzzerOptions.h
+index 9d975bd61fe..ccd0b3dcb56 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerOptions.h
++++ b/compiler-rt/lib/fuzzer/FuzzerOptions.h
+@@ -18,6 +18,7 @@ struct FuzzingOptions {
+   int Verbosity = 1;
+   size_t MaxLen = 0;
+   size_t LenControl = 1000;
++  bool KeepSeed = false;
+   int UnitTimeoutSec = 300;
+   int TimeoutExitCode = 70;
+   int OOMExitCode = 71;
+diff --git a/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp b/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
+index 0e9435ab8fc..dfc642ab6d0 100644
+--- a/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
++++ b/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
+@@ -593,7 +593,8 @@ TEST(Corpus, Distribution) {
+   DataFlowTrace DFT;
+   Random Rand(0);
+   struct EntropicOptions Entropic = {false, 0xFF, 100};
+-  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic));
++  bool KeepSeed = false;
++  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic, KeepSeed));
+   size_t N = 10;
+   size_t TriesPerUnit = 1<<16;
+   for (size_t i = 0; i < N; i++)
+@@ -1057,7 +1058,8 @@ TEST(Entropic, UpdateFrequency) {
+   size_t Index;
+   // Create input corpus with default entropic configuration
+   struct EntropicOptions Entropic = {true, 0xFF, 100};
+-  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic));
++  bool KeepSeed = false;
++  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic, KeepSeed));
+   std::unique_ptr<InputInfo> II(new InputInfo());
+ 
+   C->AddRareFeature(FeatIdx1);
+@@ -1094,7 +1096,8 @@ double SubAndSquare(double X, double Y) {
+ TEST(Entropic, ComputeEnergy) {
+   const double Precision = 0.01;
+   struct EntropicOptions Entropic = {true, 0xFF, 100};
+-  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic));
++  bool KeepSeed = false;
++  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic, KeepSeed));
+   std::unique_ptr<InputInfo> II(new InputInfo());
+   Vector<std::pair<uint32_t, uint16_t>> FeatureFreqs = {{1, 3}, {2, 3}, {3, 3}};
+   II->FeatureFreqs = FeatureFreqs;

--- a/fuzzers/entropic_keepseed/runner.Dockerfile
+++ b/fuzzers/entropic_keepseed/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-runner

--- a/fuzzers/libfuzzer_keepseed/builder.Dockerfile
+++ b/fuzzers/libfuzzer_keepseed/builder.Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+COPY patch.diff /
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/ && \
+    git checkout b52b2e1c188072e3cbc91500cfd503fb26d50ffc && \
+    patch -p1 < /patch.diff && \
+    cd compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_keepseed/fuzzer.py
+++ b/fuzzers/libfuzzer_keepseed/fuzzer.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+from fuzzers.libfuzzer_interceptors import fuzzer as libfuzzer_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    libfuzzer_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    libfuzzer_fuzzer.run_fuzzer(input_corpus,
+                                output_corpus,
+                                target_binary,
+                                extra_flags=['-keep_seed=1'])

--- a/fuzzers/libfuzzer_keepseed/patch.diff
+++ b/fuzzers/libfuzzer_keepseed/patch.diff
@@ -1,0 +1,231 @@
+commit aac9771fa16e3fc00725d4bbd662d71186a09532
+Author: Dokyung Song <dokyungs@google.com>
+Date:   Fri Jul 31 00:07:20 2020 +0000
+
+    [libFuzzer] Optionally keep initial seed inputs regardless of whether they discover new features or not.
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerCorpus.h b/compiler-rt/lib/fuzzer/FuzzerCorpus.h
+index 54d1e09ec6d..80398a9d7ce 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerCorpus.h
++++ b/compiler-rt/lib/fuzzer/FuzzerCorpus.h
+@@ -33,6 +33,7 @@ struct InputInfo {
+   // Stats.
+   size_t NumExecutedMutations = 0;
+   size_t NumSuccessfullMutations = 0;
++  bool SeedInput = false;
+   bool MayDeleteFile = false;
+   bool Reduced = false;
+   bool HasFocusFunction = false;
+@@ -131,9 +132,11 @@ class InputCorpus {
+ 
+   EntropicOptions Entropic;
+ 
++  bool KeepSeed = false;
++
+ public:
+-  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic)
+-      : Entropic(Entropic), OutputCorpus(OutputCorpus) {
++  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic, bool KeepSeed)
++      : Entropic(Entropic), OutputCorpus(OutputCorpus), KeepSeed(KeepSeed) {
+     memset(InputSizesPerFeature, 0, sizeof(InputSizesPerFeature));
+     memset(SmallestElementPerFeature, 0, sizeof(SmallestElementPerFeature));
+   }
+@@ -177,7 +180,7 @@ public:
+   bool empty() const { return Inputs.empty(); }
+   const Unit &operator[] (size_t Idx) const { return Inputs[Idx]->U; }
+   InputInfo *AddToCorpus(const Unit &U, size_t NumFeatures, bool MayDeleteFile,
+-                         bool HasFocusFunction,
++                         bool HasFocusFunction, bool SeedInput,
+                          const Vector<uint32_t> &FeatureSet,
+                          const DataFlowTrace &DFT, const InputInfo *BaseII) {
+     assert(!U.empty());
+@@ -187,6 +190,7 @@ public:
+     InputInfo &II = *Inputs.back();
+     II.U = U;
+     II.NumFeatures = NumFeatures;
++    II.SeedInput = SeedInput;
+     II.MayDeleteFile = MayDeleteFile;
+     II.UniqFeatureSet = FeatureSet;
+     II.HasFocusFunction = HasFocusFunction;
+@@ -471,7 +475,7 @@ private:
+ 
+       for (size_t i = 0; i < N; i++) {
+ 
+-        if (Inputs[i]->NumFeatures == 0) {
++        if (Inputs[i]->NumFeatures == 0 && !(Inputs[i]->SeedInput && KeepSeed)) {
+           // If the seed doesn't represent any features, assign zero energy.
+           Weights[i] = 0.;
+         } else if (Inputs[i]->NumExecutedMutations / kMaxMutationFactor >
+@@ -491,7 +495,7 @@ private:
+ 
+     if (VanillaSchedule) {
+       for (size_t i = 0; i < N; i++)
+-        Weights[i] = Inputs[i]->NumFeatures
++        Weights[i] = (Inputs[i]->NumFeatures || (KeepSeed && Inputs[i]->SeedInput))
+                          ? (i + 1) * (Inputs[i]->HasFocusFunction ? 1000 : 1)
+                          : 0.;
+     }
+diff --git a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+index 00a33a413d2..ef7991c1e27 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+@@ -649,6 +649,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+   Options.Verbosity = Flags.verbosity;
+   Options.MaxLen = Flags.max_len;
+   Options.LenControl = Flags.len_control;
++  Options.KeepSeed = Flags.keep_seed;
+   Options.UnitTimeoutSec = Flags.timeout;
+   Options.ErrorExitCode = Flags.error_exitcode;
+   Options.TimeoutExitCode = Flags.timeout_exitcode;
+@@ -753,7 +754,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+ 
+   Random Rand(Seed);
+   auto *MD = new MutationDispatcher(Rand, Options);
+-  auto *Corpus = new InputCorpus(Options.OutputCorpus, Entropic);
++  auto *Corpus = new InputCorpus(Options.OutputCorpus, Entropic, Options.KeepSeed);
+   auto *F = new Fuzzer(Callback, *Corpus, *MD, Options);
+ 
+   for (auto &U: Dictionary)
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFlags.def b/compiler-rt/lib/fuzzer/FuzzerFlags.def
+index 832224a705d..0dac7e705a3 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFlags.def
++++ b/compiler-rt/lib/fuzzer/FuzzerFlags.def
+@@ -23,6 +23,8 @@ FUZZER_FLAG_INT(len_control, 100, "Try generating small inputs first, "
+ FUZZER_FLAG_STRING(seed_inputs, "A comma-separated list of input files "
+   "to use as an additional seed corpus. Alternatively, an \"@\" followed by "
+   "the name of a file containing the comma-separated list.")
++FUZZER_FLAG_INT(keep_seed, 0, "If 1, keep seed inputs for mutation even if "
++  "they do not produce new coverage.")
+ FUZZER_FLAG_INT(cross_over, 1, "If 1, cross over inputs.")
+ FUZZER_FLAG_INT(mutate_depth, 5,
+             "Apply this number of consecutive mutations to each input.")
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFork.cpp b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+index d9e6b79443e..38fb82fc12d 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFork.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+@@ -309,11 +309,17 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
+   else
+     Env.MainCorpusDir = CorpusDirs[0];
+ 
+-  auto CFPath = DirPlusFile(Env.TempDir, "merge.txt");
+-  CrashResistantMerge(Env.Args, {}, SeedFiles, &Env.Files, {}, &Env.Features,
+-                      {}, &Env.Cov,
+-                      CFPath, false);
+-  RemoveFile(CFPath);
++  if (Options.KeepSeed) {
++    for (auto &File : SeedFiles)
++      Env.Files.push_back(File.File);
++  }
++  else {
++    auto CFPath = DirPlusFile(Env.TempDir, "merge.txt");
++    CrashResistantMerge(Env.Args, {}, SeedFiles, &Env.Files, {}, &Env.Features,
++                        {}, &Env.Cov,
++                        CFPath, false);
++    RemoveFile(CFPath);
++  }
+   Printf("INFO: -fork=%d: %zd seed inputs, starting to fuzz in %s\n", NumJobs,
+          Env.Files.size(), Env.TempDir.c_str());
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerInternal.h b/compiler-rt/lib/fuzzer/FuzzerInternal.h
+index 31096ce804b..e75807209f5 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerInternal.h
++++ b/compiler-rt/lib/fuzzer/FuzzerInternal.h
+@@ -119,6 +119,8 @@ private:
+ 
+   size_t LastCorpusUpdateRun = 0;
+ 
++  bool IsExecutingSeedCorpora = false;
++
+   bool HasMoreMallocsThanFrees = false;
+   size_t NumberOfLeakDetectionAttempts = 0;
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+index 02db6d27b0a..a9af25a3070 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+@@ -487,10 +487,11 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
+     *FoundUniqFeatures = FoundUniqFeaturesOfII;
+   PrintPulseAndReportSlowInput(Data, Size);
+   size_t NumNewFeatures = Corpus.NumFeatureUpdates() - NumUpdatesBefore;
+-  if (NumNewFeatures) {
++  if (NumNewFeatures || (Options.KeepSeed && IsExecutingSeedCorpora)) {
+     TPC.UpdateObservedPCs();
+     auto NewII = Corpus.AddToCorpus({Data, Data + Size}, NumNewFeatures,
+                                     MayDeleteFile, TPC.ObservedFocusFunction(),
++                                    IsExecutingSeedCorpora,
+                                     UniqFeatureSetTmp, DFT, II);
+     WriteFeatureSetToFile(Options.FeaturesDir, Sha1ToString(NewII->Sha1),
+                           NewII->UniqFeatureSet);
+@@ -764,6 +765,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+       assert(CorporaFiles.front().Size <= CorporaFiles.back().Size);
+     }
+ 
++    IsExecutingSeedCorpora = true;
++
+     // Load and execute inputs one by one.
+     for (auto &SF : CorporaFiles) {
+       auto U = FileToVector(SF.File, MaxInputLen, /*ExitOnError=*/false);
+@@ -773,6 +776,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+       TryDetectingAMemoryLeak(U.data(), U.size(),
+                               /*DuringInitialCorpusExecution*/ true);
+     }
++
++    IsExecutingSeedCorpora = false;
+   }
+ 
+   PrintStats("INITED");
+@@ -785,6 +790,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+              Corpus.NumInputsThatTouchFocusFunction());
+   }
+ 
++  Printf("INFO: corpus size = %d\n", Corpus.size());
++
+   if (Corpus.empty() && Options.MaxNumberOfRuns) {
+     Printf("ERROR: no interesting inputs were found. "
+            "Is the code instrumented for coverage? Exiting.\n");
+diff --git a/compiler-rt/lib/fuzzer/FuzzerOptions.h b/compiler-rt/lib/fuzzer/FuzzerOptions.h
+index 9d975bd61fe..ccd0b3dcb56 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerOptions.h
++++ b/compiler-rt/lib/fuzzer/FuzzerOptions.h
+@@ -18,6 +18,7 @@ struct FuzzingOptions {
+   int Verbosity = 1;
+   size_t MaxLen = 0;
+   size_t LenControl = 1000;
++  bool KeepSeed = false;
+   int UnitTimeoutSec = 300;
+   int TimeoutExitCode = 70;
+   int OOMExitCode = 71;
+diff --git a/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp b/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
+index 0e9435ab8fc..dfc642ab6d0 100644
+--- a/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
++++ b/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
+@@ -593,7 +593,8 @@ TEST(Corpus, Distribution) {
+   DataFlowTrace DFT;
+   Random Rand(0);
+   struct EntropicOptions Entropic = {false, 0xFF, 100};
+-  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic));
++  bool KeepSeed = false;
++  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic, KeepSeed));
+   size_t N = 10;
+   size_t TriesPerUnit = 1<<16;
+   for (size_t i = 0; i < N; i++)
+@@ -1057,7 +1058,8 @@ TEST(Entropic, UpdateFrequency) {
+   size_t Index;
+   // Create input corpus with default entropic configuration
+   struct EntropicOptions Entropic = {true, 0xFF, 100};
+-  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic));
++  bool KeepSeed = false;
++  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic, KeepSeed));
+   std::unique_ptr<InputInfo> II(new InputInfo());
+ 
+   C->AddRareFeature(FeatIdx1);
+@@ -1094,7 +1096,8 @@ double SubAndSquare(double X, double Y) {
+ TEST(Entropic, ComputeEnergy) {
+   const double Precision = 0.01;
+   struct EntropicOptions Entropic = {true, 0xFF, 100};
+-  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic));
++  bool KeepSeed = false;
++  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic, KeepSeed));
+   std::unique_ptr<InputInfo> II(new InputInfo());
+   Vector<std::pair<uint32_t, uint16_t>> FeatureFreqs = {{1, 3}, {2, 3}, {3, 3}};
+   II->FeatureFreqs = FeatureFreqs;

--- a/fuzzers/libfuzzer_keepseed/runner.Dockerfile
+++ b/fuzzers/libfuzzer_keepseed/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-runner

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -19,6 +19,28 @@
 # are still testing this feature. You should request an experiment by contacting
 # us as you normally do.
 
+- experiment: 2020-08-01
+  fuzzers:
+    - afl
+    - aflfast
+    - aflplusplus
+    - aflplusplus_optimal
+    - aflplusplus_qemu
+    - afl_qemu
+    - aflsmart
+    - eclipser
+    - entropic
+    - fairfuzz
+    - fastcgs_lm
+    - honggfuzz
+    - honggfuzz_qemu
+    - lafintel
+    - libfuzzer
+    - manul
+    - mopt
+    - libfuzzer_keepseed
+    - entropic_keepseed
+
 - experiment: 2020-07-30
   fuzzers:
     - libfuzzer


### PR DESCRIPTION
This patch adds temporary `libfuzzer` and `entropic` variants, namely `libfuzzer_keepseed` and `entropic_keepseed`, to evaluate the impact of keeping all seed inputs regardless of whether they find new coverage or not.

This MAY help SQLITE3 benchmarks where the seed inputs are not sound w.r.t. the input language that the fuzzer executable expects. Such seed inputs are likely discarded by libFuzzer as ill-formed inputs are rejected earlier by the fuzzer executable, not finding new coverage. However, they may still contain useful fragments, and thus be worth mutating or spliced with others.

The downside of this is that the corpus size (and likely individual input size too) grows, which may negatively impact the performance. A quick 30-min local testing says that fuzzing unfortunately does get slowed down, but the coverage may increase with Entropic schedule (but not with libFuzzer's vanilla schedule). I would like to see, with this patch and experiment request, how keeping all seed inputs affects libfuzzer and entropic's performance on a larger scale and with statistic significance both on SQLITE3 and other benchmarks.