### PR TITLE
[DO NOT MERGE] Proof-of-concept report generation webapp

### DIFF
--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -72,6 +72,27 @@ def clobber_experiments_data(df, experiments):
     return result
 
 
+def drop_private(experiment_df):
+    """Drop all snapshots from private experiments."""
+    return experiment_df[~experiment_df['private']]
+
+
+def filter_fuzzers_from_experiments(experiment_df, fuzzers_from_experiments):
+    """Drop snapshots whose fuzzer and experiment combination are not in
+    |fuzzers_from_experiments| from experiment_df and returns the result.
+    fuzzers_from_experiments is a list of tuples containing a fuzzer and an
+    experiment."""
+    fuzzers_from_experiments = set(fuzzers_from_experiments)
+
+    def make_fuzzer_experiment_tuple(row):
+        return (row['fuzzer'], row['experiment'])
+
+    fuzzer_and_benchmark = experiment_df.apply(
+        make_fuzzer_experiment_tuple, axis=1)
+
+    return experiment_df[fuzzer_and_benchmark.isin(fuzzers_from_experiments)]
+
+
 def filter_fuzzers(experiment_df, included_fuzzers):
     """Returns table with only rows where fuzzer is in |included_fuzzers|."""
     return experiment_df[experiment_df['fuzzer'].isin(included_fuzzers)]

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -87,8 +87,8 @@ def filter_fuzzers_from_experiments(experiment_df, fuzzers_from_experiments):
     def make_fuzzer_experiment_tuple(row):
         return (row['fuzzer'], row['experiment'])
 
-    fuzzer_and_benchmark = experiment_df.apply(
-        make_fuzzer_experiment_tuple, axis=1)
+    fuzzer_and_benchmark = experiment_df.apply(make_fuzzer_experiment_tuple,
+                                               axis=1)
 
     return experiment_df[fuzzer_and_benchmark.isin(fuzzers_from_experiments)]
 

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -130,7 +130,9 @@ def generate_report(experiment_names,
                     in_progress=False,
                     end_time=None,
                     merge_with_clobber=False,
-                    merge_with_clobber_nonprivate=False):
+                    merge_with_clobber_nonprivate=False,
+                    fuzzers_from_experiments=None,
+                    drop_private=False):
     """Generate report helper."""
     if merge_with_clobber_nonprivate:
         experiment_names = (
@@ -147,6 +149,8 @@ def generate_report(experiment_names,
     else:
         experiment_df = queries.get_experiment_data(experiment_names)
         # Save the raw data along with the report.
+        if drop_private:
+            experiment_df = data_utils.drop_private(experiment_df)
         experiment_df.to_csv(data_path)
 
     data_utils.validate_data(experiment_df)
@@ -166,6 +170,11 @@ def generate_report(experiment_names,
     if merge_with_clobber:
         experiment_df = data_utils.clobber_experiments_data(
             experiment_df, experiment_names)
+
+    if fuzzers_from_experiments is not None:
+        assert not fuzzers
+        experiment_df = data_utils.filter_fuzzers_from_experiments(
+            experiment_df, fuzzers_from_experiments)
 
     fuzzer_names = experiment_df.fuzzer.unique()
     plotter = plotting.Plotter(fuzzer_names, quick, log_scale)

--- a/analysis/queries.py
+++ b/analysis/queries.py
@@ -24,6 +24,7 @@ def get_experiment_data(experiment_names):
 
     snapshots_query = db_utils.query(
         Experiment.git_hash,\
+        Experiment.private,\
         Trial.experiment, Trial.fuzzer, Trial.benchmark,\
         Trial.time_started, Trial.time_ended,\
         Snapshot.trial_id, Snapshot.time, Snapshot.edges_covered)\
@@ -49,3 +50,15 @@ def add_nonprivate_experiments_for_merge_with_clobber(experiment_names):
     ]
 
     return nonprivate_experiment_names + experiment_names
+
+# !!! MOVE
+def get_fuzzers_and_experiments(nonprivate=True):
+    trials_query = db_utils.query(
+        Trial.fuzzer,\
+        Trial.experiment)\
+        .select_from(Experiment)\
+        .join(Trial)\
+        .filter(Trial.preempted.is_(False))
+    if nonprivate:
+        trials_query = trials_query.filter(Experiment.private.is_(False))
+    return trials_query.distinct()

--- a/analysis/queries.py
+++ b/analysis/queries.py
@@ -51,7 +51,7 @@ def add_nonprivate_experiments_for_merge_with_clobber(experiment_names):
 
     return nonprivate_experiment_names + experiment_names
 
-# !!! MOVE
+
 def get_fuzzers_and_experiments(nonprivate=True):
     trials_query = db_utils.query(
         Trial.fuzzer,\

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,6 @@ sqlalchemy==1.3.13
 pylint==2.4.4
 pytype==2019.11.27
 yapf==0.28.0
+
+# Webapp
+Flask==1.1.2

--- a/web/reports.py
+++ b/web/reports.py
@@ -9,7 +9,6 @@ from analysis import queries
 from analysis import generate_report
 from common import utils
 
-
 app = flask.Flask(__name__)
 
 TEMPLATES_DIR = os.path.join(utils.ROOT_DIR, 'web', 'templates')
@@ -24,19 +23,28 @@ def index():
     template_name = 'generate_reports.html'
     template = JINJA_ENV.get_template(template_name)
     fuzzers_and_experiments = queries.get_fuzzers_and_experiments()
-    fuzzers = sorted(set(fuzzer_and_experiment[0] for fuzzer_and_experiment in fuzzers_and_experiments))
-    experiments = sorted(set(fuzzer_and_experiment[1] for fuzzer_and_experiment in fuzzers_and_experiments))
+    fuzzers = sorted(
+        set(fuzzer_and_experiment[0]
+            for fuzzer_and_experiment in fuzzers_and_experiments))
+    experiments = sorted(
+        set(fuzzer_and_experiment[1]
+            for fuzzer_and_experiment in fuzzers_and_experiments))
     return template.render(fuzzers=fuzzers, experiments=experiments)
 
 
 @app.route('/generate', methods=['POST'])
 def generate():
-    temp_directory = '/tmp/tmpdir' # tempfile.TemporaryDirectory()
+    temp_directory = '/tmp/tmpdir'  # tempfile.TemporaryDirectory()
     fuzzers_from_experiments = [
-        tuple(k.split(',')) for k in request.form.keys()]
-    experiments = [fuzzer_from_experiment[1] for fuzzer_from_experiment in fuzzers_from_experiments]
+        tuple(k.split(',')) for k in request.form.keys()
+    ]
+    experiments = [
+        fuzzer_from_experiment[1]
+        for fuzzer_from_experiment in fuzzers_from_experiments
+    ]
     generate_report.generate_report(
-        experiments, report_directory=temp_directory,
+        experiments,
+        report_directory=temp_directory,
         fuzzers_from_experiments=fuzzers_from_experiments,
         quick=True,
         report_name='custom',

--- a/web/reports.py
+++ b/web/reports.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+
+import flask
+from flask import request
+import jinja2
+
+from analysis import queries
+from analysis import generate_report
+from common import utils
+
+
+app = flask.Flask(__name__)
+
+TEMPLATES_DIR = os.path.join(utils.ROOT_DIR, 'web', 'templates')
+JINJA_ENV = jinja2.Environment(
+    undefined=jinja2.StrictUndefined,
+    loader=jinja2.FileSystemLoader(TEMPLATES_DIR),
+)
+
+
+@app.route('/')
+def index():
+    template_name = 'generate_reports.html'
+    template = JINJA_ENV.get_template(template_name)
+    fuzzers_and_experiments = queries.get_fuzzers_and_experiments()
+    fuzzers = sorted(set(fuzzer_and_experiment[0] for fuzzer_and_experiment in fuzzers_and_experiments))
+    experiments = sorted(set(fuzzer_and_experiment[1] for fuzzer_and_experiment in fuzzers_and_experiments))
+    return template.render(fuzzers=fuzzers, experiments=experiments)
+
+
+@app.route('/generate', methods=['POST'])
+def generate():
+    temp_directory = '/tmp/tmpdir' # tempfile.TemporaryDirectory()
+    fuzzers_from_experiments = [
+        tuple(k.split(',')) for k in request.form.keys()]
+    experiments = [fuzzer_from_experiment[1] for fuzzer_from_experiment in fuzzers_from_experiments]
+    generate_report.generate_report(
+        experiments, report_directory=temp_directory,
+        fuzzers_from_experiments=fuzzers_from_experiments,
+        quick=True,
+        report_name='custom',
+        drop_private=True)
+    return 'done'

--- a/web/templates/generate_reports.html
+++ b/web/templates/generate_reports.html
@@ -1,0 +1,29 @@
+<style>
+table, th, td {
+  border: 1px solid black;
+  border-collapse: collapse;
+}
+th, td {
+  padding: 15px;
+}
+</style>
+<form action="/generate" method="post">
+<table style="width:100%">
+  <tr>
+    <th>fuzzer/experiment</th>
+    {% for experiment in experiments %}
+    <th>{{ experiment }}</th>
+    {% endfor %}
+  </tr>  
+  {% for fuzzer in fuzzers %}
+  <tr>
+  <td>{{ fuzzer }}</td>
+  {% for experiment in experiments %}
+  <th><input type="checkbox" name="{{fuzzer}},{{experiment}}" value="{{fuzzer}},{{experiment}}"/></th>
+  
+  {% endfor %}
+  </tr>
+  {% endfor %}  
+</table>
+<input type="submit" value="Submit">
+</form>


### PR DESCRIPTION
This is a webapp that allows users to specify fuzzers from specific experiments and will generate reports based on the selection.
![webapp-demo](https://user-images.githubusercontent.com/31354670/89088652-698d5000-d34e-11ea-98e0-5d399d084d60.png)

If I add boxes to select all fuzzers in an experiment I think this is close to the ideal interface for generating reports for users (only downside is some slowness in waiting for reports to generate).

Some not so ideal things that could prevent us from deploying this:
1. Do we want to deal with auth or should we allow any rando on the internet to use this? Maybe limiting to people with gmail accounts is sufficient to prevent abuse?
2. Writing will be hard. Appengine doesn't allow writing to disk but graph generation assumes writing to disk. We could just deploy this on a single server and periodically delete generated reports, but this feels fragile and not really up to best standards for webapps. We could also teach generate_report to write directly to GCS and use appengine. Or we could not use appengine and just copy the report to GCS after generation. I'm tempted to go with this solution.

I think the interface for selecting experiment-fuzzer pairs is ideal in this solution. But as an alternative we could tell people to run this webapp themselves and have the webapp download a public archive of the DB.

In any case, I think this is a good starting point for a discussion. I don't like the current solution and I don't love the proposed improvements. They seem more cumbersome and error prone than this interface (where if someone makes a mistake they can just regenerate the report). This solution also has the advantage of not changing reports. Thus the reports we publish on fuzzbench.com/reports/ will always contain just what was run in the experiment.