### PR TITLE
Fix for dispatcher oooming out.

### DIFF
--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -21,7 +21,7 @@ from common import experiment_utils
 from common import new_process
 
 # Constants for dispatcher specs.
-DISPATCHER_MACHINE_TYPE = 'n1-standard-96'
+DISPATCHER_MACHINE_TYPE = 'n1-highmem-96'
 DISPATCHER_BOOT_DISK_SIZE = '4TB'
 DISPATCHER_BOOT_DISK_TYPE = 'pd-ssd'
 

--- a/common/test_gcloud.py
+++ b/common/test_gcloud.py
@@ -39,7 +39,7 @@ def test_create_instance():
             '--image-project=cos-cloud',
             '--zone=zone-a',
             '--scopes=cloud-platform',
-            '--machine-type=n1-standard-96',
+            '--machine-type=n1-highmem-96',
             '--boot-disk-size=4TB',
             '--boot-disk-type=pd-ssd',
         ]]

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -19,7 +19,7 @@
 # are still testing this feature. You should request an experiment by contacting
 # us as you normally do.
 
-- experiment: 2020-08-01
+- experiment: 2020-08-02
   fuzzers:
     - afl
     - aflfast
@@ -40,6 +40,8 @@
     - mopt
     - libfuzzer_keepseed
     - entropic_keepseed
+    - libfuzzer_interceptors
+    - entropic_interceptors
 
 - experiment: 2020-07-30
   fuzzers:


### PR DESCRIPTION
Dispatcher docker oomed out on 2020-07-30, and some coverage
timeouts are also noticed on 2020-08-01. Trying n1-highmem-96
till we break measurer.