### PR TITLE
Use -summary-only flag for coverage measuring

### DIFF
--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -545,7 +545,7 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
             '-instr-profile=%s' % self.profdata_file
         ]
 
-        if summary:
+        if summary_only:
             command.append('-summary-only')
 
         with open(self.cov_summary_file, 'w') as output_file:

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -163,7 +163,7 @@ def get_covered_region(experiment: str, fuzzer: str, benchmark: str,
                                       })
         snapshot_measurer = SnapshotMeasurer(fuzzer, benchmark, trial_id,
                                              snapshot_logger)
-        snapshot_measurer.generate_summary(0, summary=False)
+        snapshot_measurer.generate_summary(0, summary_only=False)
         new_covered_regions = snapshot_measurer.get_current_covered_regions()
         covered_regions[key] = covered_regions[key].union(new_covered_regions)
     q.put(covered_regions)
@@ -537,7 +537,7 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
             self.logger.error(
                 'Coverage profdata generation failed for cycle: %d.', cycle)
 
-    def generate_summary(self, cycle: int, summary=True):
+    def generate_summary(self, cycle: int, summary_only=True):
         """Transform the .profdata file into json form."""
         coverage_binary = get_coverage_binary(self.benchmark)
         command = [
@@ -545,7 +545,6 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
             '-instr-profile=%s' % self.profdata_file
         ]
 
-        # Add summary-only flag to reduce memory use.
         if summary:
             command.append('-summary-only')
 

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -163,6 +163,7 @@ def get_covered_region(experiment: str, fuzzer: str, benchmark: str,
                                       })
         snapshot_measurer = SnapshotMeasurer(fuzzer, benchmark, trial_id,
                                              snapshot_logger)
+        snapshot_measurer.generate_summary(0, summary=False)
         new_covered_regions = snapshot_measurer.get_current_covered_regions()
         covered_regions[key] = covered_regions[key].union(new_covered_regions)
     q.put(covered_regions)
@@ -536,21 +537,30 @@ class SnapshotMeasurer:  # pylint: disable=too-many-instance-attributes
             self.logger.error(
                 'Coverage profdata generation failed for cycle: %d.', cycle)
 
-    def generate_summary(self, cycle: int):
+    def generate_summary(self, cycle: int, summary=True):
         """Transform the .profdata file into json form."""
         coverage_binary = get_coverage_binary(self.benchmark)
         command = [
             'llvm-cov', 'export', '-format=text', coverage_binary,
             '-instr-profile=%s' % self.profdata_file
         ]
+
+        # Add summary-only flag to reduce memory use.
+        if summary:
+            command.append('-summary-only')
+
         with open(self.cov_summary_file, 'w') as output_file:
             result = new_process.execute(command,
                                          output_file=output_file,
                                          expect_zero=False)
         if result.retcode != 0:
-            self.logger.error(
-                'Coverage summary json file generation failed for \
-                    cycle: %d.', cycle)
+            if cycle != 0:
+                self.logger.error(
+                    'Coverage summary json file generation failed for \
+                        cycle: %d.', cycle)
+            else:
+                self.logger.error(
+                    'Coverage summary json file generation failed in the end.')
 
     def generate_coverage_information(self, cycle: int):
         """Generate the .profdata file and then transform it into

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -163,7 +163,7 @@ def test_generate_summary(mocked_get_coverage_binary, mocked_execute,
     expected = [
         'llvm-cov', 'export', '-format=text',
         '/work/coverage-binaries/benchmark-a/fuzz-target',
-        '-instr-profile=/reports/data.profdata'
+        '-instr-profile=/reports/data.profdata', '-summary-only'
     ]
 
     assert (len(mocked_execute.call_args_list)) == 1


### PR DESCRIPTION
This patch will use `-summary-only` flag for the measuring process.