### PR TITLE
Fix merged experiment use the right report name.

### DIFF
--- a/experiment/reporter.py
+++ b/experiment/reporter.py
@@ -52,6 +52,7 @@ def output_report(experiment_config: dict, in_progress=False):
         generate_report.generate_report(
             [experiment_name],
             str(reports_dir),
+            report_name=experiment_name,
             in_progress=in_progress,
             merge_with_clobber_nonprivate=merge_with_nonprivate)
         filestore_utils.rsync(str(reports_dir),

--- a/experiment/test_reporter.py
+++ b/experiment/test_reporter.py
@@ -45,8 +45,10 @@ def test_output_report_filestore(fs, experiment):
                 'rsync', '-d', '-r', reports_dir,
                 'gs://web-reports/test-experiment'
             ]]
+            experiment_name = os.environ['EXPERIMENT']
             mocked_generate_report.assert_called_with(
-                [os.environ['EXPERIMENT']],
+                [experiment_name],
                 reports_dir,
+                report_name=experiment_name,
                 in_progress=False,
                 merge_with_clobber_nonprivate=False)


### PR DESCRIPTION
Do not use experiment[0] from
add_nonprivate_experiments_for_merge_with_clobber to decide
report name, it should just experiment name when called
from dispatcher.