### PR TITLE
[CI] Cache Python packages

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -66,7 +66,6 @@ jobs:
       with:
         python-version: 3.7
 
-    # test
     # Copied from:
     # https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions
     - name: Cache pip

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -71,10 +71,10 @@ jobs:
     - name: Cache pip
       uses: actions/cache@v2
       with:
-        # This path is specific to Ubuntu
+        # This path is specific to Ubuntu.
         path: ~/.cache/pip
         # Look to see if there is a cache hit for the corresponding requirements
-        # file
+        # file.
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -66,6 +66,20 @@ jobs:
       with:
         python-version: 3.7
 
+    # Copied from:
+    # https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        # This path is specific to Ubuntu
+        path: ~/.cache/pip
+        # Look to see if there is a cache hit for the corresponding requirements
+        # file
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
+
     - name: Install dependencies
       run: |
         make install-dependencies

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -66,6 +66,7 @@ jobs:
       with:
         python-version: 3.7
 
+    # test
     # Copied from:
     # https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions
     - name: Cache pip

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -21,10 +21,10 @@ jobs:
     - name: Cache pip
       uses: actions/cache@v2
       with:
-        # This path is specific to Ubuntu
+        # This path is specific to Ubuntu.
         path: ~/.cache/pip
         # Look to see if there is a cache hit for the corresponding requirements
-        # file
+        # file.
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -16,6 +16,20 @@ jobs:
       with:
         python-version: 3.7
 
+    # Copied from:
+    # https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        # This path is specific to Ubuntu
+        path: ~/.cache/pip
+        # Look to see if there is a cache hit for the corresponding requirements
+        # file
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
+
     - name: Install dependencies
       run: |
         make install-dependencies


### PR DESCRIPTION
Transient pip install errors are a large source of spurious CI
failures. Pip install also takes > 1 minute, around half the time
it takes for presubmit job to run on CI so speeding it up will
be a nice improvement.