### PR TITLE
Support running experiments without seeds or dictionaries.

### DIFF
--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -36,6 +36,8 @@ docker run \
 -e EXPERIMENT={{experiment}} \
 -e TRIAL_ID={{trial_id}} \
 -e MAX_TOTAL_TIME={{max_total_time}} \
+-e NO_SEEDS={{no_seeds}} \
+-e NO_DICTIONARIES={{no_dictionaries}} \
 -e DOCKER_REGISTRY={{docker_registry}} {% if not local_experiment %}-e CLOUD_PROJECT={{cloud_project}} -e CLOUD_COMPUTE_ZONE={{cloud_compute_zone}} {% endif %}\
 -e EXPERIMENT_FILESTORE={{experiment_filestore}} {% if local_experiment %}-v {{experiment_filestore}}:{{experiment_filestore}} {% endif %}\
 -e REPORT_FILESTORE={{report_filestore}} {% if local_experiment %}-v {{report_filestore}}:{{report_filestore}} {% endif %}\

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -37,7 +37,6 @@ from common import logs
 from common import new_process
 from common import utils
 from common import yaml_utils
-from src_analysis import experiment_changes
 
 BENCHMARKS_DIR = os.path.join(utils.ROOT_DIR, 'benchmarks')
 FUZZERS_DIR = os.path.join(utils.ROOT_DIR, 'fuzzers')
@@ -199,9 +198,13 @@ def get_git_hash():
     return output.strip().decode('utf-8')
 
 
-def start_experiment(experiment_name: str, config_filename: str,
-                     benchmarks: List[str], fuzzers: List[str],
-                     no_seeds=False, no_dictionaries=False):
+def start_experiment(  # pylint: disable=too-many-arguments
+        experiment_name: str,
+        config_filename: str,
+        benchmarks: List[str],
+        fuzzers: List[str],
+        no_seeds=False,
+        no_dictionaries=False):
     """Start a fuzzer benchmarking experiment."""
     check_no_local_changes()
 
@@ -451,26 +454,30 @@ def main():
                                required=False,
                                default=None,
                                choices=all_fuzzers)
-    fuzzers_group.add_argument('-s',
-                               '--no-seeds',
-                               help='Should trials be conducted without seed corpora.',
-                               required=False,
-                               default=False,
-                               action='store_true')
-    fuzzers_group.add_argument('-d',
-                               '--no-dictionaries',
-                               help='Should trials be conducted without dictionaries.',
-                               required=False,
-                               default=False,
-                               action='store_true')
+    fuzzers_group.add_argument(
+        '-s',
+        '--no-seeds',
+        help='Should trials be conducted without seed corpora.',
+        required=False,
+        default=False,
+        action='store_true')
+    fuzzers_group.add_argument(
+        '-d',
+        '--no-dictionaries',
+        help='Should trials be conducted without dictionaries.',
+        required=False,
+        default=False,
+        action='store_true')
 
     args = parser.parse_args()
     fuzzers = args.fuzzers or all_fuzzers
 
-    start_experiment(args.experiment_name, args.experiment_config,
-                     args.benchmarks, fuzzers,
+    start_experiment(args.experiment_name,
+                     args.experiment_config,
+                     args.benchmarks,
+                     fuzzers,
                      no_seeds=args.no_seeds,
-                     no_dictionary=args.no_dictionaries)
+                     no_dictionaries=args.no_dictionaries)
     return 0
 
 

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -453,20 +453,18 @@ def main():
                         required=False,
                         default=None,
                         choices=all_fuzzers)
-    parser.add_argument(
-        '-ns',
-        '--no-seeds',
-        help='Should trials be conducted without seed corpora.',
-        required=False,
-        default=False,
-        action='store_true')
-    parser.add_argument(
-        '-nd',
-        '--no-dictionaries',
-        help='Should trials be conducted without dictionaries.',
-        required=False,
-        default=False,
-        action='store_true')
+    parser.add_argument('-ns',
+                        '--no-seeds',
+                        help='Should trials be conducted without seed corpora.',
+                        required=False,
+                        default=False,
+                        action='store_true')
+    parser.add_argument('-nd',
+                        '--no-dictionaries',
+                        help='Should trials be conducted without dictionaries.',
+                        required=False,
+                        default=False,
+                        action='store_true')
 
     args = parser.parse_args()
     fuzzers = args.fuzzers or all_fuzzers

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -446,22 +446,21 @@ def main():
                         '--experiment-name',
                         help='Experiment name.',
                         required=True)
-    fuzzers_group = parser.add_mutually_exclusive_group()
-    fuzzers_group.add_argument('-f',
-                               '--fuzzers',
-                               help='Fuzzers to use.',
-                               nargs='+',
-                               required=False,
-                               default=None,
-                               choices=all_fuzzers)
-    fuzzers_group.add_argument(
+    parser.add_argument('-f',
+                        '--fuzzers',
+                        help='Fuzzers to use.',
+                        nargs='+',
+                        required=False,
+                        default=None,
+                        choices=all_fuzzers)
+    parser.add_argument(
         '-s',
         '--no-seeds',
         help='Should trials be conducted without seed corpora.',
         required=False,
         default=False,
         action='store_true')
-    fuzzers_group.add_argument(
+    parser.add_argument(
         '-d',
         '--no-dictionaries',
         help='Should trials be conducted without dictionaries.',

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -454,14 +454,14 @@ def main():
                         default=None,
                         choices=all_fuzzers)
     parser.add_argument(
-        '-s',
+        '-ns',
         '--no-seeds',
         help='Should trials be conducted without seed corpora.',
         required=False,
         default=False,
         action='store_true')
     parser.add_argument(
-        '-d',
+        '-nd',
         '--no-dictionaries',
         help='Should trials be conducted without dictionaries.',
         required=False,

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -70,6 +70,9 @@ def _clean_seed_corpus(seed_corpus_dir):
     from sub-directories into the corpus directory root. Also, deletes any files
     that exceed the 1 MB limit. If the NO_SEEDS env var is specified than the
     seed corpus files are deleted."""
+    if not os.path.exists(seed_corpus_dir):
+        return
+
     if environment.get('NO_SEEDS'):
         logs.info('NO_SEEDS specified, deleting seed corpus files.')
         shutil.rmtree(seed_corpus_dir)

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -65,9 +65,15 @@ fuzzer_errored_out = False  # pylint:disable=invalid-name
 
 
 def _clean_seed_corpus(seed_corpus_dir):
-    """Moves seed corpus files from sub-directories into the corpus directory
-    root. Also, deletes any files that exceed the 1 MB limit."""
-    if not os.path.exists(seed_corpus_dir):
+    """Prepares |seed_corpus_dir| for the trial. This ensures that it can be
+    used by AFL which is picky about the seed corpus. Moves seed corpus files
+    from sub-directories into the corpus directory root. Also, deletes any files
+    that exceed the 1 MB limit. If the NO_SEEDS env var is specified than the
+    seed corpus files are deleted."""
+    if environment.get('NO_SEEDS'):
+        logs.info('NO_SEEDS specified, deleting seed corpus files.')
+        shutil.rmtree(seed_corpus_dir)
+        os.mkdir(seed_corpus_dir)
         return
 
     failed_to_move_files = []

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -733,7 +733,9 @@ def render_startup_script_template(instance_name: str, fuzzer: str,
         'fuzz_target': fuzz_target,
         'docker_image_url': docker_image_url,
         'docker_registry': experiment_config['docker_registry'],
-        'local_experiment': local_experiment
+        'local_experiment': local_experiment,
+        'no_seeds': experiment_config['no_seeds'],
+        'no_dictionaries': experiment_config['no_dictionaries'],
     }
 
     if not local_experiment:

--- a/experiment/test_data/experiment-config.yaml
+++ b/experiment/test_data/experiment-config.yaml
@@ -24,3 +24,5 @@ cloud_sql_instance_connection_name: "fuzzbench:us-central1:experiment-db=tcp:543
 benchmarks: "benchmark-1,benchmark-2"
 fuzzers: "fuzzer-a,fuzzer-b"
 git_hash: "git-hash"
+no_seeds: false
+no_dictionaries: false

--- a/experiment/test_runner.py
+++ b/experiment/test_runner.py
@@ -297,6 +297,18 @@ class TestIntegrationRunner:
         mocked_error.assert_not_called()
 
 
+def test_clean_seed_corpus_no_seeds(fs):
+    """Test that seed corpus files are deleted if NO_SEEDS is set in the
+    environment to 'True'."""
+    seed_corpus_dir = '/seeds'
+    fs.create_dir(seed_corpus_dir)
+    seed_file = os.path.join(seed_corpus_dir, 'a')
+    fs.create_file(seed_file, contents='abc')
+    runner._clean_seed_corpus(seed_corpus_dir)  # pylint: disable=protected-access
+    assert not os.path.exists(seed_file)
+    assert os.path.exists(seed_corpus_dir)
+
+
 def test_clean_seed_corpus(fs):
     """Test that seed corpus files are moved to root directory and deletes files
     exceeding 1 MB limit."""

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -108,6 +108,8 @@ docker run \\
 -e EXPERIMENT=test-experiment \\
 -e TRIAL_ID=9 \\
 -e MAX_TOTAL_TIME=86400 \\
+-e NO_SEEDS=False \\
+-e NO_DICTIONARIES=False \\
 -e DOCKER_REGISTRY=gcr.io/fuzzbench -e CLOUD_PROJECT=fuzzbench -e CLOUD_COMPUTE_ZONE=us-central1-a \\
 -e EXPERIMENT_FILESTORE=gs://experiment-data \\
 -e REPORT_FILESTORE=gs://web-reports \\

--- a/fuzzers/test_utils.py
+++ b/fuzzers/test_utils.py
@@ -62,9 +62,9 @@ def test_dictionary_options_file_with_dict(fs):
     assert utils.get_dictionary_path('/fuzz-target') == '/fuzz.dict'
 
 
-def test_dictionary_skip(fs, environ):
-    """Test that None is return when SKIP_DICT is set."""
-    os.environ['SKIP_DICT'] = '1'
+def test_dictionary_no_dictionaries(fs, environ):
+    """Test that None is return when NO_DICTIONARIES is set."""
+    os.environ['NO_DICTIONARIES'] = '1'
     fs.create_file('/fuzz-target.dict', contents='A')
     assert utils.get_dictionary_path('/fuzz-target') is None
 

--- a/fuzzers/utils.py
+++ b/fuzzers/utils.py
@@ -117,7 +117,8 @@ def restore_directory(directory):
 
 def get_dictionary_path(target_binary):
     """Return dictionary path for a target binary."""
-    if os.getenv('SKIP_DICT'):
+    if os.getenv('NO_DICTIONARIES'):
+        # Don't use dictionaries if experiment specifies not to.
         return None
 
     dictionary_path = target_binary + '.dict'


### PR DESCRIPTION
This adds two new flags to run_experiment: --no-seeds and --no-dictionaries.
When passed, they cause trials run as part of the experiment not to use seed corpus files or dictionaries (respectively) even if they are provided by the benchmark.

Fixes #127