### PR TITLE
[libFuzzer] Add (libfuzzer|entropic)_fixcrossover variants

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -46,8 +46,10 @@ jobs:
           - aflplusplus_seek
           - libfuzzer_interceptors
           - libfuzzer_keepseed
+          - libfuzzer_fixcrossover
           - entropic_interceptors
           - entropic_keepseed
+          - entropic_fixcrossover
 
         benchmark_type:
           - oss-fuzz

--- a/fuzzers/entropic_fixcrossover/builder.Dockerfile
+++ b/fuzzers/entropic_fixcrossover/builder.Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+COPY patch.diff /
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project && \
+    git checkout b52b2e1c188072e3cbc91500cfd503fb26d50ffc && \
+    patch -p1 < /patch.diff && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /libEntropic.a *.o

--- a/fuzzers/entropic_fixcrossover/fuzzer.py
+++ b/fuzzers/entropic_fixcrossover/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+from fuzzers.entropic_interceptors import fuzzer as entropic_fuzzer
+from fuzzers.libfuzzer_interceptors import fuzzer as libfuzzer_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    entropic_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    libfuzzer_fuzzer.run_fuzzer(input_corpus,
+                                output_corpus,
+                                target_binary,
+                                extra_flags=['-entropic=1'])

--- a/fuzzers/entropic_fixcrossover/patch.diff
+++ b/fuzzers/entropic_fixcrossover/patch.diff
@@ -1,0 +1,207 @@
+commit df6a841a7c8b1c540f0e3c31c3697a11b2a00f51
+Author: Dokyung Song <dokyungs@google.com>
+Date:   Wed Aug 5 23:12:19 2020 +0000
+
+    [libFuzzer] Fix arguments of InsertPartOf/CopyPartOf calls in CrossOver mutator.
+    
+    The CrossOver mutator is meant to cross over two given buffers
+    (referred to as the first/second buffer below). Previously
+    InsertPartOf/CopyPartOf calls used in the CrossOver mutator
+    incorrectly inserted/copied part of the second buffer into a "scratch
+    buffer" (MutateInPlaceHere of the size CurrentMaxMutationLen), rather
+    than the first buffer. This is not intended behavior, because the
+    scratch buffer does not always (i) contain the content of the first
+    buffer, and (ii) have the same size as the first buffer;
+    CurrentMaxMutationLen is typically a lot larger than the size of the
+    first buffer. This patch fixes the issue by using the first buffer
+    instead of the scratch buffer in InsertPartOf/CopyPartOf calls.
+    
+    This patch also adds two new tests, namely "cross_over_insert" and
+    "cross_over_copy", which specifically target InsertPartOf and
+    CopyPartOf, respectively.
+    
+    - cross_over_insert.test checks if the fuzzer can use InsertPartOf to
+      trigger the crash.
+    
+    - cross_over_copy.test checks if the fuzzer can use CopyPartOf to
+      trigger the crash.
+    
+    These newly added tests were designed to pass with the current patch,
+    but not without the it (with b216c80cc2496b87bf827260ce7e24dc62247d71
+    these tests do no pass). To achieve this, -max_len was intentionally
+    given a high value. Without this patch, InsertPartOf/CopyPartOf will
+    generate larger inputs, possibly with unpredictable data in it,
+    thereby failing to trigger the crash.
+    
+    The test pass condition for these new tests is narrowed down by (i)
+    limiting mutation depth to 1 (i.e., a single CrossOver mutation should
+    be able to trigger the crash) and (ii) checking whether the mutation
+    sequence of "CrossOver-" leads to the crash.
+    
+    Also note that these newly added tests and an existing test
+    (cross_over.test) all use "-reduce_inputs=0" flags to prevent reducing
+    inputs; it's easier to force the fuzzer to keep original input string
+    this way than tweaking cov-instrumented basic blocks in the source
+    code of the fuzzer executable.
+    
+    Differential Revision: https://reviews.llvm.org/D85554
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerMutate.cpp b/compiler-rt/lib/fuzzer/FuzzerMutate.cpp
+index 29541eac5dc..df9ada45bb0 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerMutate.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerMutate.cpp
+@@ -425,26 +425,26 @@ size_t MutationDispatcher::Mutate_CrossOver(uint8_t *Data, size_t Size,
+   if (!CrossOverWith) return 0;
+   const Unit &O = *CrossOverWith;
+   if (O.empty()) return 0;
+-  MutateInPlaceHere.resize(MaxSize);
+-  auto &U = MutateInPlaceHere;
+   size_t NewSize = 0;
+   switch(Rand(3)) {
+     case 0:
+-      NewSize = CrossOver(Data, Size, O.data(), O.size(), U.data(), U.size());
++      MutateInPlaceHere.resize(MaxSize);
++      NewSize = CrossOver(Data, Size, O.data(), O.size(),
++                          MutateInPlaceHere.data(), MaxSize);
++      memcpy(Data, MutateInPlaceHere.data(), NewSize);
+       break;
+     case 1:
+-      NewSize = InsertPartOf(O.data(), O.size(), U.data(), U.size(), MaxSize);
++      NewSize = InsertPartOf(O.data(), O.size(), Data, Size, MaxSize);
+       if (!NewSize)
+-        NewSize = CopyPartOf(O.data(), O.size(), U.data(), U.size());
++        NewSize = CopyPartOf(O.data(), O.size(), Data, Size);
+       break;
+     case 2:
+-      NewSize = CopyPartOf(O.data(), O.size(), U.data(), U.size());
++      NewSize = CopyPartOf(O.data(), O.size(), Data, Size);
+       break;
+     default: assert(0);
+   }
+   assert(NewSize > 0 && "CrossOver returned empty unit");
+   assert(NewSize <= MaxSize && "CrossOver returned overisized unit");
+-  memcpy(Data, U.data(), NewSize);
+   return NewSize;
+ }
+ 
+diff --git a/compiler-rt/test/fuzzer/CrossOverTest.cpp b/compiler-rt/test/fuzzer/CrossOverTest.cpp
+index a7643570a92..3ca53a8a851 100644
+--- a/compiler-rt/test/fuzzer/CrossOverTest.cpp
++++ b/compiler-rt/test/fuzzer/CrossOverTest.cpp
+@@ -4,10 +4,10 @@
+ 
+ // Test for a fuzzer. The fuzzer must find the string
+ // ABCDEFGHIJ
+-// We use it as a test for CrossOver functionality
+-// by passing two inputs to it:
+-// ABCDE00000
+-// ZZZZZFGHIJ
++// We use it as a test for each of CrossOver functionalities
++// by passing the following sets of two inputs to it:
++// {ABCDEHIJ, ZFG} to test InsertPartOf
++// {ABCDE00HIJ, ZFG} to test CopyPartOf
+ //
+ #include <assert.h>
+ #include <cstddef>
+@@ -16,6 +16,17 @@
+ #include <iostream>
+ #include <ostream>
+ 
++#ifndef INPUT_A
++#define INPUT_A "ABCDE00000"
++#endif
++
++#ifndef INPUT_B
++#define INPUT_B "ZZZZZFGHIJ"
++#endif
++
++const char *InputA = INPUT_A;
++const char *InputB = INPUT_B;
++
+ static volatile int Sink;
+ static volatile int *NullPtr;
+ 
+@@ -42,13 +53,11 @@ static const uint32_t ExpectedHash = 0xe1677acb;
+ 
+ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+   // fprintf(stderr, "ExpectedHash: %x\n", ExpectedHash);
+-  if (Size != 10) return 0;
+-  if (*Data == 'A')
++  if (Size == 10 && ExpectedHash == simple_hash(Data, Size))
++    *NullPtr = 0;
++  if (*Data == InputA[0])
+     Sink++;
+-  if (*Data == 'Z')
++  if (*Data == InputB[0])
+     Sink--;
+-  if (ExpectedHash == simple_hash(Data, Size))
+-    *NullPtr = 0;
+   return 0;
+ }
+-
+diff --git a/compiler-rt/test/fuzzer/cross_over.test b/compiler-rt/test/fuzzer/cross_over.test
+index 058b5eb2c85..64e06e8cd36 100644
+--- a/compiler-rt/test/fuzzer/cross_over.test
++++ b/compiler-rt/test/fuzzer/cross_over.test
+@@ -12,7 +12,7 @@ RUN: echo -n ABCDE00000 > %t-corpus/A
+ RUN: echo -n ZZZZZFGHIJ > %t-corpus/B
+ 
+ 
+-RUN: not %run %t-CrossOverTest -max_len=10 -seed=1 -runs=10000000 %t-corpus
++RUN: not %run %t-CrossOverTest -max_len=10 -reduce_inputs=0 -seed=1 -runs=10000000 %t-corpus
+ 
+ # Test the same thing but using -seed_inputs instead of passing the corpus dir.
+-RUN: not %run %t-CrossOverTest -max_len=10 -seed=1 -runs=10000000 -seed_inputs=%t-corpus/A,%t-corpus/B
++RUN: not %run %t-CrossOverTest -max_len=10 -reduce_inputs=0 -seed=1 -runs=10000000 -seed_inputs=%t-corpus/A,%t-corpus/B
+diff --git a/compiler-rt/test/fuzzer/cross_over_copy.test b/compiler-rt/test/fuzzer/cross_over_copy.test
+new file mode 100644
+index 00000000000..f8f45c974e2
+--- /dev/null
++++ b/compiler-rt/test/fuzzer/cross_over_copy.test
+@@ -0,0 +1,20 @@
++# Tests CrossOver CopyPartOf.
++# We want to make sure that the test can find the input
++# ABCDEFGHIJ when given two other inputs in the seed corpus:
++#    ABCDE00HIJ and
++# (Z)     FG
++#
++RUN: %cpp_compiler -DINPUT_A='"ABCDE00HIJ"' -DINPUT_B='"ZFG"' %S/CrossOverTest.cpp -o %t-CrossOverTest
++
++RUN: rm -rf %t-corpus
++RUN: mkdir %t-corpus
++RUN: echo -n ABCDE00HIJ > %t-corpus/A
++RUN: echo -n ZFG > %t-corpus/B
++
++
++RUN: not %run %t-CrossOverTest -mutate_depth=1 -max_len=1024 -reduce_inputs=0 -seed=1 -runs=10000000 %t-corpus 2>&1 | FileCheck %s
++
++# Test the same thing but using -seed_inputs instead of passing the corpus dir.
++RUN: not %run %t-CrossOverTest -mutate_depth=1 -max_len=1024 -reduce_inputs=0 -seed=1 -runs=10000000 -seed_inputs=%t-corpus/A,%t-corpus/B 2>&1 | FileCheck %s
++
++CHECK: MS: 1 CrossOver-
+diff --git a/compiler-rt/test/fuzzer/cross_over_insert.test b/compiler-rt/test/fuzzer/cross_over_insert.test
+new file mode 100644
+index 00000000000..5ad2ff0a633
+--- /dev/null
++++ b/compiler-rt/test/fuzzer/cross_over_insert.test
+@@ -0,0 +1,20 @@
++# Tests CrossOver InsertPartOf.
++# We want to make sure that the test can find the input
++# ABCDEFGHIJ when given two other inputs in the seed corpus:
++#    ABCDE  HIJ and
++# (Z)     FG
++#
++RUN: %cpp_compiler -DINPUT_A='"ABCDEHIJ"' -DINPUT_B='"ZFG"' %S/CrossOverTest.cpp -o %t-CrossOverTest
++    
++RUN: rm -rf %t-corpus
++RUN: mkdir %t-corpus
++RUN: echo -n ABCDEHIJ > %t-corpus/A
++RUN: echo -n ZFG > %t-corpus/B
++
++
++RUN: not %run %t-CrossOverTest -mutate_depth=1 -max_len=1024 -reduce_inputs=0 -seed=1 -runs=10000000 %t-corpus 2>&1 | FileCheck %s
++
++# Test the same thing but using -seed_inputs instead of passing the corpus dir.
++RUN: not %run %t-CrossOverTest -mutate_depth=1 -max_len=1024 -reduce_inputs=0 -seed=1 -runs=10000000 -seed_inputs=%t-corpus/A,%t-corpus/B 2>&1 | FileCheck %s
++
++CHECK: MS: 1 CrossOver-

--- a/fuzzers/entropic_fixcrossover/runner.Dockerfile
+++ b/fuzzers/entropic_fixcrossover/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-runner

--- a/fuzzers/libfuzzer_fixcrossover/builder.Dockerfile
+++ b/fuzzers/libfuzzer_fixcrossover/builder.Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+COPY patch.diff /
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/ && \
+    git checkout b52b2e1c188072e3cbc91500cfd503fb26d50ffc && \
+    patch -p1 < /patch.diff && \
+    cd compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_fixcrossover/fuzzer.py
+++ b/fuzzers/libfuzzer_fixcrossover/fuzzer.py
@@ -1,0 +1,26 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+from fuzzers.libfuzzer_interceptors import fuzzer as libfuzzer_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    libfuzzer_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    libfuzzer_fuzzer.run_fuzzer(input_corpus, output_corpus, target_binary)

--- a/fuzzers/libfuzzer_fixcrossover/patch.diff
+++ b/fuzzers/libfuzzer_fixcrossover/patch.diff
@@ -1,0 +1,207 @@
+commit df6a841a7c8b1c540f0e3c31c3697a11b2a00f51
+Author: Dokyung Song <dokyungs@google.com>
+Date:   Wed Aug 5 23:12:19 2020 +0000
+
+    [libFuzzer] Fix arguments of InsertPartOf/CopyPartOf calls in CrossOver mutator.
+    
+    The CrossOver mutator is meant to cross over two given buffers
+    (referred to as the first/second buffer below). Previously
+    InsertPartOf/CopyPartOf calls used in the CrossOver mutator
+    incorrectly inserted/copied part of the second buffer into a "scratch
+    buffer" (MutateInPlaceHere of the size CurrentMaxMutationLen), rather
+    than the first buffer. This is not intended behavior, because the
+    scratch buffer does not always (i) contain the content of the first
+    buffer, and (ii) have the same size as the first buffer;
+    CurrentMaxMutationLen is typically a lot larger than the size of the
+    first buffer. This patch fixes the issue by using the first buffer
+    instead of the scratch buffer in InsertPartOf/CopyPartOf calls.
+    
+    This patch also adds two new tests, namely "cross_over_insert" and
+    "cross_over_copy", which specifically target InsertPartOf and
+    CopyPartOf, respectively.
+    
+    - cross_over_insert.test checks if the fuzzer can use InsertPartOf to
+      trigger the crash.
+    
+    - cross_over_copy.test checks if the fuzzer can use CopyPartOf to
+      trigger the crash.
+    
+    These newly added tests were designed to pass with the current patch,
+    but not without the it (with b216c80cc2496b87bf827260ce7e24dc62247d71
+    these tests do no pass). To achieve this, -max_len was intentionally
+    given a high value. Without this patch, InsertPartOf/CopyPartOf will
+    generate larger inputs, possibly with unpredictable data in it,
+    thereby failing to trigger the crash.
+    
+    The test pass condition for these new tests is narrowed down by (i)
+    limiting mutation depth to 1 (i.e., a single CrossOver mutation should
+    be able to trigger the crash) and (ii) checking whether the mutation
+    sequence of "CrossOver-" leads to the crash.
+    
+    Also note that these newly added tests and an existing test
+    (cross_over.test) all use "-reduce_inputs=0" flags to prevent reducing
+    inputs; it's easier to force the fuzzer to keep original input string
+    this way than tweaking cov-instrumented basic blocks in the source
+    code of the fuzzer executable.
+    
+    Differential Revision: https://reviews.llvm.org/D85554
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerMutate.cpp b/compiler-rt/lib/fuzzer/FuzzerMutate.cpp
+index 29541eac5dc..df9ada45bb0 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerMutate.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerMutate.cpp
+@@ -425,26 +425,26 @@ size_t MutationDispatcher::Mutate_CrossOver(uint8_t *Data, size_t Size,
+   if (!CrossOverWith) return 0;
+   const Unit &O = *CrossOverWith;
+   if (O.empty()) return 0;
+-  MutateInPlaceHere.resize(MaxSize);
+-  auto &U = MutateInPlaceHere;
+   size_t NewSize = 0;
+   switch(Rand(3)) {
+     case 0:
+-      NewSize = CrossOver(Data, Size, O.data(), O.size(), U.data(), U.size());
++      MutateInPlaceHere.resize(MaxSize);
++      NewSize = CrossOver(Data, Size, O.data(), O.size(),
++                          MutateInPlaceHere.data(), MaxSize);
++      memcpy(Data, MutateInPlaceHere.data(), NewSize);
+       break;
+     case 1:
+-      NewSize = InsertPartOf(O.data(), O.size(), U.data(), U.size(), MaxSize);
++      NewSize = InsertPartOf(O.data(), O.size(), Data, Size, MaxSize);
+       if (!NewSize)
+-        NewSize = CopyPartOf(O.data(), O.size(), U.data(), U.size());
++        NewSize = CopyPartOf(O.data(), O.size(), Data, Size);
+       break;
+     case 2:
+-      NewSize = CopyPartOf(O.data(), O.size(), U.data(), U.size());
++      NewSize = CopyPartOf(O.data(), O.size(), Data, Size);
+       break;
+     default: assert(0);
+   }
+   assert(NewSize > 0 && "CrossOver returned empty unit");
+   assert(NewSize <= MaxSize && "CrossOver returned overisized unit");
+-  memcpy(Data, U.data(), NewSize);
+   return NewSize;
+ }
+ 
+diff --git a/compiler-rt/test/fuzzer/CrossOverTest.cpp b/compiler-rt/test/fuzzer/CrossOverTest.cpp
+index a7643570a92..3ca53a8a851 100644
+--- a/compiler-rt/test/fuzzer/CrossOverTest.cpp
++++ b/compiler-rt/test/fuzzer/CrossOverTest.cpp
+@@ -4,10 +4,10 @@
+ 
+ // Test for a fuzzer. The fuzzer must find the string
+ // ABCDEFGHIJ
+-// We use it as a test for CrossOver functionality
+-// by passing two inputs to it:
+-// ABCDE00000
+-// ZZZZZFGHIJ
++// We use it as a test for each of CrossOver functionalities
++// by passing the following sets of two inputs to it:
++// {ABCDEHIJ, ZFG} to test InsertPartOf
++// {ABCDE00HIJ, ZFG} to test CopyPartOf
+ //
+ #include <assert.h>
+ #include <cstddef>
+@@ -16,6 +16,17 @@
+ #include <iostream>
+ #include <ostream>
+ 
++#ifndef INPUT_A
++#define INPUT_A "ABCDE00000"
++#endif
++
++#ifndef INPUT_B
++#define INPUT_B "ZZZZZFGHIJ"
++#endif
++
++const char *InputA = INPUT_A;
++const char *InputB = INPUT_B;
++
+ static volatile int Sink;
+ static volatile int *NullPtr;
+ 
+@@ -42,13 +53,11 @@ static const uint32_t ExpectedHash = 0xe1677acb;
+ 
+ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+   // fprintf(stderr, "ExpectedHash: %x\n", ExpectedHash);
+-  if (Size != 10) return 0;
+-  if (*Data == 'A')
++  if (Size == 10 && ExpectedHash == simple_hash(Data, Size))
++    *NullPtr = 0;
++  if (*Data == InputA[0])
+     Sink++;
+-  if (*Data == 'Z')
++  if (*Data == InputB[0])
+     Sink--;
+-  if (ExpectedHash == simple_hash(Data, Size))
+-    *NullPtr = 0;
+   return 0;
+ }
+-
+diff --git a/compiler-rt/test/fuzzer/cross_over.test b/compiler-rt/test/fuzzer/cross_over.test
+index 058b5eb2c85..64e06e8cd36 100644
+--- a/compiler-rt/test/fuzzer/cross_over.test
++++ b/compiler-rt/test/fuzzer/cross_over.test
+@@ -12,7 +12,7 @@ RUN: echo -n ABCDE00000 > %t-corpus/A
+ RUN: echo -n ZZZZZFGHIJ > %t-corpus/B
+ 
+ 
+-RUN: not %run %t-CrossOverTest -max_len=10 -seed=1 -runs=10000000 %t-corpus
++RUN: not %run %t-CrossOverTest -max_len=10 -reduce_inputs=0 -seed=1 -runs=10000000 %t-corpus
+ 
+ # Test the same thing but using -seed_inputs instead of passing the corpus dir.
+-RUN: not %run %t-CrossOverTest -max_len=10 -seed=1 -runs=10000000 -seed_inputs=%t-corpus/A,%t-corpus/B
++RUN: not %run %t-CrossOverTest -max_len=10 -reduce_inputs=0 -seed=1 -runs=10000000 -seed_inputs=%t-corpus/A,%t-corpus/B
+diff --git a/compiler-rt/test/fuzzer/cross_over_copy.test b/compiler-rt/test/fuzzer/cross_over_copy.test
+new file mode 100644
+index 00000000000..f8f45c974e2
+--- /dev/null
++++ b/compiler-rt/test/fuzzer/cross_over_copy.test
+@@ -0,0 +1,20 @@
++# Tests CrossOver CopyPartOf.
++# We want to make sure that the test can find the input
++# ABCDEFGHIJ when given two other inputs in the seed corpus:
++#    ABCDE00HIJ and
++# (Z)     FG
++#
++RUN: %cpp_compiler -DINPUT_A='"ABCDE00HIJ"' -DINPUT_B='"ZFG"' %S/CrossOverTest.cpp -o %t-CrossOverTest
++
++RUN: rm -rf %t-corpus
++RUN: mkdir %t-corpus
++RUN: echo -n ABCDE00HIJ > %t-corpus/A
++RUN: echo -n ZFG > %t-corpus/B
++
++
++RUN: not %run %t-CrossOverTest -mutate_depth=1 -max_len=1024 -reduce_inputs=0 -seed=1 -runs=10000000 %t-corpus 2>&1 | FileCheck %s
++
++# Test the same thing but using -seed_inputs instead of passing the corpus dir.
++RUN: not %run %t-CrossOverTest -mutate_depth=1 -max_len=1024 -reduce_inputs=0 -seed=1 -runs=10000000 -seed_inputs=%t-corpus/A,%t-corpus/B 2>&1 | FileCheck %s
++
++CHECK: MS: 1 CrossOver-
+diff --git a/compiler-rt/test/fuzzer/cross_over_insert.test b/compiler-rt/test/fuzzer/cross_over_insert.test
+new file mode 100644
+index 00000000000..5ad2ff0a633
+--- /dev/null
++++ b/compiler-rt/test/fuzzer/cross_over_insert.test
+@@ -0,0 +1,20 @@
++# Tests CrossOver InsertPartOf.
++# We want to make sure that the test can find the input
++# ABCDEFGHIJ when given two other inputs in the seed corpus:
++#    ABCDE  HIJ and
++# (Z)     FG
++#
++RUN: %cpp_compiler -DINPUT_A='"ABCDEHIJ"' -DINPUT_B='"ZFG"' %S/CrossOverTest.cpp -o %t-CrossOverTest
++    
++RUN: rm -rf %t-corpus
++RUN: mkdir %t-corpus
++RUN: echo -n ABCDEHIJ > %t-corpus/A
++RUN: echo -n ZFG > %t-corpus/B
++
++
++RUN: not %run %t-CrossOverTest -mutate_depth=1 -max_len=1024 -reduce_inputs=0 -seed=1 -runs=10000000 %t-corpus 2>&1 | FileCheck %s
++
++# Test the same thing but using -seed_inputs instead of passing the corpus dir.
++RUN: not %run %t-CrossOverTest -mutate_depth=1 -max_len=1024 -reduce_inputs=0 -seed=1 -runs=10000000 -seed_inputs=%t-corpus/A,%t-corpus/B 2>&1 | FileCheck %s
++
++CHECK: MS: 1 CrossOver-

--- a/fuzzers/libfuzzer_fixcrossover/runner.Dockerfile
+++ b/fuzzers/libfuzzer_fixcrossover/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-runner

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -19,6 +19,11 @@
 # are still testing this feature. You should request an experiment by contacting
 # us as you normally do.
 
+- experiment: 2020-08-08
+  fuzzers:
+    - libfuzzer_fixcrossover
+    - entropic_fixcrossover
+
 - experiment: 2020-08-07
   fuzzers:
     - aflplusplus_datalenrand


### PR DESCRIPTION
This patch adds new variants to  to test whether fixing the CrossOver mutator gives an average input size decrease (and perhaps a throughput increase).

An experiment for these newly added variants is requested with this patch.