### PR TITLE
Temporarily remove end-to-end queue test for queue from CI.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -38,6 +38,3 @@ jobs:
       run: |
         FUZZBENCH_TEST_INTEGRATION=1 make presubmit
 
-    - name: Run end to end CI test
-      run: |
-        make run-end-to-end-test


### PR DESCRIPTION
Test is flaky. It can be readded when it is not flaky or if it always
returns 0.