### PR TITLE
Fix issue formatting in logs.error.

### DIFF
--- a/common/logs.py
+++ b/common/logs.py
@@ -197,8 +197,7 @@ def error(message, *args, extras=None, logger=None):
     # I can't figure out how to include both the message and the exception
     # other than this having the exception message preceed the log message
     # (without using private APIs).
-    _report_error_with_retries(traceback.format_exc() + '\nMessage: ' +
-                               message)
+    _report_error_with_retries(traceback.format_exc() + '\nMessage: ' + message)
     extras = {} if extras is None else extras
     extras['traceback'] = traceback.format_exc()
     log(logger, logging.ERROR, message, *args, extras=extras)

--- a/common/logs.py
+++ b/common/logs.py
@@ -187,15 +187,18 @@ def error(message, *args, extras=None, logger=None):
             return
         _error_reporting_client.report(message)
 
+    if args:
+        message = message % args
+
     if not any(sys.exc_info()):
-        _report_error_with_retries(message % args)
+        _report_error_with_retries(message)
         log(logger, logging.ERROR, message, *args, extras=extras)
         return
     # I can't figure out how to include both the message and the exception
     # other than this having the exception message preceed the log message
     # (without using private APIs).
     _report_error_with_retries(traceback.format_exc() + '\nMessage: ' +
-                               message % args)
+                               message)
     extras = {} if extras is None else extras
     extras['traceback'] = traceback.format_exc()
     log(logger, logging.ERROR, message, *args, extras=extras)


### PR DESCRIPTION
There is an issue with our logging module, it doesn't properly handle
messages containing % signs, since it assumes those are formatting
directives (e.g. "%s").

Make it OK to pass unescaped messages to logs.error as long as
there are no actual formatting args by only doing formatting
if formatting args are supplied. We did this previously for other
log messages so this commit does it for error messages.

The particular issue that brought this to light was a git
command from oss_fuzz_benchmark_integration.py. This command
contains a percent sign.