### PR TITLE
Modify the patch for the libfuzzer/entropic's keepseed variants

### DIFF
--- a/fuzzers/entropic_keepseed/fuzzer.py
+++ b/fuzzers/entropic_keepseed/fuzzer.py
@@ -27,4 +27,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
     libfuzzer_fuzzer.run_fuzzer(input_corpus,
                                 output_corpus,
                                 target_binary,
-                                extra_flags=['-entropic=1', '-keep_seed=1'])
+                                extra_flags=[
+                                    '-entropic=1', '-keep_seed=1',
+                                    '-cross_over_uniformdist=1'
+                                ])

--- a/fuzzers/entropic_keepseed/patch.diff
+++ b/fuzzers/entropic_keepseed/patch.diff
@@ -1,11 +1,11 @@
-commit aac9771fa16e3fc00725d4bbd662d71186a09532
+commit 72e16fc7160185305eee536c257a478ae84f7082
 Author: Dokyung Song <dokyungs@google.com>
 Date:   Fri Jul 31 00:07:20 2020 +0000
 
     [libFuzzer] Optionally keep initial seed inputs regardless of whether they discover new features or not.
 
 diff --git a/compiler-rt/lib/fuzzer/FuzzerCorpus.h b/compiler-rt/lib/fuzzer/FuzzerCorpus.h
-index 54d1e09ec6d..80398a9d7ce 100644
+index 54d1e09ec6d..5c687013c59 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerCorpus.h
 +++ b/compiler-rt/lib/fuzzer/FuzzerCorpus.h
 @@ -33,6 +33,7 @@ struct InputInfo {
@@ -16,7 +16,7 @@ index 54d1e09ec6d..80398a9d7ce 100644
    bool MayDeleteFile = false;
    bool Reduced = false;
    bool HasFocusFunction = false;
-@@ -131,9 +132,11 @@ class InputCorpus {
+@@ -131,9 +132,12 @@ class InputCorpus {
  
    EntropicOptions Entropic;
  
@@ -25,12 +25,13 @@ index 54d1e09ec6d..80398a9d7ce 100644
  public:
 -  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic)
 -      : Entropic(Entropic), OutputCorpus(OutputCorpus) {
-+  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic, bool KeepSeed)
++  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic,
++              bool KeepSeed)
 +      : Entropic(Entropic), OutputCorpus(OutputCorpus), KeepSeed(KeepSeed) {
      memset(InputSizesPerFeature, 0, sizeof(InputSizesPerFeature));
      memset(SmallestElementPerFeature, 0, sizeof(SmallestElementPerFeature));
    }
-@@ -177,7 +180,7 @@ public:
+@@ -177,7 +181,7 @@ public:
    bool empty() const { return Inputs.empty(); }
    const Unit &operator[] (size_t Idx) const { return Inputs[Idx]->U; }
    InputInfo *AddToCorpus(const Unit &U, size_t NumFeatures, bool MayDeleteFile,
@@ -39,7 +40,7 @@ index 54d1e09ec6d..80398a9d7ce 100644
                           const Vector<uint32_t> &FeatureSet,
                           const DataFlowTrace &DFT, const InputInfo *BaseII) {
      assert(!U.empty());
-@@ -187,6 +190,7 @@ public:
+@@ -187,6 +191,7 @@ public:
      InputInfo &II = *Inputs.back();
      II.U = U;
      II.NumFeatures = NumFeatures;
@@ -47,26 +48,20 @@ index 54d1e09ec6d..80398a9d7ce 100644
      II.MayDeleteFile = MayDeleteFile;
      II.UniqFeatureSet = FeatureSet;
      II.HasFocusFunction = HasFocusFunction;
-@@ -471,7 +475,7 @@ private:
+@@ -276,6 +281,11 @@ public:
+     return Idx;
+   }
  
-       for (size_t i = 0; i < N; i++) {
- 
--        if (Inputs[i]->NumFeatures == 0) {
-+        if (Inputs[i]->NumFeatures == 0 && !(Inputs[i]->SeedInput && KeepSeed)) {
-           // If the seed doesn't represent any features, assign zero energy.
-           Weights[i] = 0.;
-         } else if (Inputs[i]->NumExecutedMutations / kMaxMutationFactor >
-@@ -491,7 +495,7 @@ private:
- 
-     if (VanillaSchedule) {
-       for (size_t i = 0; i < N; i++)
--        Weights[i] = Inputs[i]->NumFeatures
-+        Weights[i] = (Inputs[i]->NumFeatures || (KeepSeed && Inputs[i]->SeedInput))
-                          ? (i + 1) * (Inputs[i]->HasFocusFunction ? 1000 : 1)
-                          : 0.;
-     }
++  InputInfo &ChooseUnitToCrossOverWith(Random &Rand) {
++    InputInfo &II = *Inputs[Rand(Inputs.size())];
++    return II;
++  }
++
+   void PrintStats() {
+     for (size_t i = 0; i < Inputs.size(); i++) {
+       const auto &II = *Inputs[i];
 diff --git a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
-index 00a33a413d2..ef7991c1e27 100644
+index 8339697396c..0933af56804 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
 +++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
 @@ -649,6 +649,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
@@ -77,33 +72,49 @@ index 00a33a413d2..ef7991c1e27 100644
    Options.UnitTimeoutSec = Flags.timeout;
    Options.ErrorExitCode = Flags.error_exitcode;
    Options.TimeoutExitCode = Flags.timeout_exitcode;
-@@ -753,7 +754,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+@@ -657,6 +658,8 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+   Options.IgnoreCrashes = Flags.ignore_crashes;
+   Options.MaxTotalTimeSec = Flags.max_total_time;
+   Options.DoCrossOver = Flags.cross_over;
++  Options.CrossOverUniformDist = Flags.cross_over_uniformdist;
++  Options.TraceSeedInput = Flags.trace_seed_input;
+   Options.MutateDepth = Flags.mutate_depth;
+   Options.ReduceDepth = Flags.reduce_depth;
+   Options.UseCounters = Flags.use_counters;
+@@ -753,7 +756,8 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
  
    Random Rand(Seed);
    auto *MD = new MutationDispatcher(Rand, Options);
 -  auto *Corpus = new InputCorpus(Options.OutputCorpus, Entropic);
-+  auto *Corpus = new InputCorpus(Options.OutputCorpus, Entropic, Options.KeepSeed);
++  auto *Corpus =
++      new InputCorpus(Options.OutputCorpus, Entropic, Options.KeepSeed);
    auto *F = new Fuzzer(Callback, *Corpus, *MD, Options);
  
    for (auto &U: Dictionary)
 diff --git a/compiler-rt/lib/fuzzer/FuzzerFlags.def b/compiler-rt/lib/fuzzer/FuzzerFlags.def
-index 832224a705d..0dac7e705a3 100644
+index 832224a705d..10b1f5f539a 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerFlags.def
 +++ b/compiler-rt/lib/fuzzer/FuzzerFlags.def
-@@ -23,6 +23,8 @@ FUZZER_FLAG_INT(len_control, 100, "Try generating small inputs first, "
+@@ -23,7 +23,14 @@ FUZZER_FLAG_INT(len_control, 100, "Try generating small inputs first, "
  FUZZER_FLAG_STRING(seed_inputs, "A comma-separated list of input files "
    "to use as an additional seed corpus. Alternatively, an \"@\" followed by "
    "the name of a file containing the comma-separated list.")
-+FUZZER_FLAG_INT(keep_seed, 0, "If 1, keep seed inputs for mutation even if "
-+  "they do not produce new coverage.")
++FUZZER_FLAG_INT(keep_seed, 0, "If 1, keep all seed inputs in the corpus even if "
++  "they do not produce new coverage. This also invalidates -reduce_inputs for "
++  "seed input mutations.")
  FUZZER_FLAG_INT(cross_over, 1, "If 1, cross over inputs.")
++FUZZER_FLAG_INT(cross_over_uniformdist, 0, "Experimental. If 1, use a uniform "
++  "probability distribution when choosing inputs to cross over with.")
++FUZZER_FLAG_INT(trace_seed_input, 0, "Internal. Print all seed inputs picked "
++  "up by the fuzzer.")
  FUZZER_FLAG_INT(mutate_depth, 5,
              "Apply this number of consecutive mutations to each input.")
+ FUZZER_FLAG_INT(reduce_depth, 0, "Experimental/internal. "
 diff --git a/compiler-rt/lib/fuzzer/FuzzerFork.cpp b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
-index d9e6b79443e..38fb82fc12d 100644
+index d9e6b79443e..97e91cbe869 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerFork.cpp
 +++ b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
-@@ -309,11 +309,17 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
+@@ -309,11 +309,20 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
    else
      Env.MainCorpusDir = CorpusDirs[0];
  
@@ -115,13 +126,16 @@ index d9e6b79443e..38fb82fc12d 100644
 +  if (Options.KeepSeed) {
 +    for (auto &File : SeedFiles)
 +      Env.Files.push_back(File.File);
-+  }
-+  else {
++  } else {
 +    auto CFPath = DirPlusFile(Env.TempDir, "merge.txt");
 +    CrashResistantMerge(Env.Args, {}, SeedFiles, &Env.Files, {}, &Env.Features,
-+                        {}, &Env.Cov,
-+                        CFPath, false);
++                        {}, &Env.Cov, CFPath, false);
 +    RemoveFile(CFPath);
++  }
++  if (Options.TraceSeedInput) {
++    for (auto &File : Env.Files) {
++      Printf("INFO: seed - %s\n", File.c_str());
++    }
 +  }
    Printf("INFO: -fork=%d: %zd seed inputs, starting to fuzz in %s\n", NumJobs,
           Env.Files.size(), Env.TempDir.c_str());
@@ -140,23 +154,53 @@ index 31096ce804b..e75807209f5 100644
    size_t NumberOfLeakDetectionAttempts = 0;
  
 diff --git a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
-index 02db6d27b0a..a9af25a3070 100644
+index 02db6d27b0a..28d5f32c0d6 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
 +++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
-@@ -487,10 +487,11 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
+@@ -478,7 +478,7 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
+       UniqFeatureSetTmp.push_back(Feature);
+     if (Options.Entropic)
+       Corpus.UpdateFeatureFrequency(II, Feature);
+-    if (Options.ReduceInputs && II)
++    if (Options.ReduceInputs && II && !(Options.KeepSeed && II->SeedInput))
+       if (std::binary_search(II->UniqFeatureSet.begin(),
+                              II->UniqFeatureSet.end(), Feature))
+         FoundUniqFeaturesOfII++;
+@@ -487,11 +487,12 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
      *FoundUniqFeatures = FoundUniqFeaturesOfII;
    PrintPulseAndReportSlowInput(Data, Size);
    size_t NumNewFeatures = Corpus.NumFeatureUpdates() - NumUpdatesBefore;
 -  if (NumNewFeatures) {
 +  if (NumNewFeatures || (Options.KeepSeed && IsExecutingSeedCorpora)) {
      TPC.UpdateObservedPCs();
-     auto NewII = Corpus.AddToCorpus({Data, Data + Size}, NumNewFeatures,
-                                     MayDeleteFile, TPC.ObservedFocusFunction(),
-+                                    IsExecutingSeedCorpora,
-                                     UniqFeatureSetTmp, DFT, II);
+-    auto NewII = Corpus.AddToCorpus({Data, Data + Size}, NumNewFeatures,
+-                                    MayDeleteFile, TPC.ObservedFocusFunction(),
+-                                    UniqFeatureSetTmp, DFT, II);
++    auto NewII =
++        Corpus.AddToCorpus({Data, Data + Size}, NumNewFeatures, MayDeleteFile,
++                           TPC.ObservedFocusFunction(),
++                           IsExecutingSeedCorpora, UniqFeatureSetTmp, DFT, II);
      WriteFeatureSetToFile(Options.FeaturesDir, Sha1ToString(NewII->Sha1),
                            NewII->UniqFeatureSet);
-@@ -764,6 +765,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+     return true;
+@@ -664,8 +665,14 @@ void Fuzzer::MutateAndTestOne() {
+   MD.StartMutationSequence();
+ 
+   auto &II = Corpus.ChooseUnitToMutate(MD.GetRand());
+-  if (Options.DoCrossOver)
+-    MD.SetCrossOverWith(&Corpus.ChooseUnitToMutate(MD.GetRand()).U);
++  if (Options.DoCrossOver) {
++    if (Options.CrossOverUniformDist) {
++      MD.SetCrossOverWith(&Corpus.ChooseUnitToCrossOverWith(MD.GetRand()).U);
++    }
++    else {
++      MD.SetCrossOverWith(&Corpus.ChooseUnitToMutate(MD.GetRand()).U);
++    }
++  }
+   const auto &U = II.U;
+   memcpy(BaseSha1, II.Sha1, sizeof(BaseSha1));
+   assert(CurrentUnitData);
+@@ -764,6 +771,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
        assert(CorporaFiles.front().Size <= CorporaFiles.back().Size);
      }
  
@@ -165,7 +209,7 @@ index 02db6d27b0a..a9af25a3070 100644
      // Load and execute inputs one by one.
      for (auto &SF : CorporaFiles) {
        auto U = FileToVector(SF.File, MaxInputLen, /*ExitOnError=*/false);
-@@ -773,6 +776,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+@@ -773,6 +782,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
        TryDetectingAMemoryLeak(U.data(), U.size(),
                                /*DuringInitialCorpusExecution*/ true);
      }
@@ -174,7 +218,7 @@ index 02db6d27b0a..a9af25a3070 100644
    }
  
    PrintStats("INITED");
-@@ -785,6 +790,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+@@ -785,6 +796,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
               Corpus.NumInputsThatTouchFocusFunction());
    }
  
@@ -184,7 +228,7 @@ index 02db6d27b0a..a9af25a3070 100644
      Printf("ERROR: no interesting inputs were found. "
             "Is the code instrumented for coverage? Exiting.\n");
 diff --git a/compiler-rt/lib/fuzzer/FuzzerOptions.h b/compiler-rt/lib/fuzzer/FuzzerOptions.h
-index 9d975bd61fe..ccd0b3dcb56 100644
+index 9d975bd61fe..bb2c14be47b 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerOptions.h
 +++ b/compiler-rt/lib/fuzzer/FuzzerOptions.h
 @@ -18,6 +18,7 @@ struct FuzzingOptions {
@@ -195,6 +239,15 @@ index 9d975bd61fe..ccd0b3dcb56 100644
    int UnitTimeoutSec = 300;
    int TimeoutExitCode = 70;
    int OOMExitCode = 71;
+@@ -30,6 +31,8 @@ struct FuzzingOptions {
+   int RssLimitMb = 0;
+   int MallocLimitMb = 0;
+   bool DoCrossOver = true;
++  bool CrossOverUniformDist = false;
++  bool TraceSeedInput = false;
+   int MutateDepth = 5;
+   bool ReduceDepth = false;
+   bool UseCounters = false;
 diff --git a/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp b/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
 index 0e9435ab8fc..dfc642ab6d0 100644
 --- a/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp

--- a/fuzzers/libfuzzer_keepseed/fuzzer.py
+++ b/fuzzers/libfuzzer_keepseed/fuzzer.py
@@ -23,7 +23,8 @@ def build():
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
-    libfuzzer_fuzzer.run_fuzzer(input_corpus,
-                                output_corpus,
-                                target_binary,
-                                extra_flags=['-keep_seed=1'])
+    libfuzzer_fuzzer.run_fuzzer(
+        input_corpus,
+        output_corpus,
+        target_binary,
+        extra_flags=['-keep_seed=1', '-cross_over_uniformdist=1'])

--- a/fuzzers/libfuzzer_keepseed/patch.diff
+++ b/fuzzers/libfuzzer_keepseed/patch.diff
@@ -1,11 +1,11 @@
-commit aac9771fa16e3fc00725d4bbd662d71186a09532
+commit 72e16fc7160185305eee536c257a478ae84f7082
 Author: Dokyung Song <dokyungs@google.com>
 Date:   Fri Jul 31 00:07:20 2020 +0000
 
     [libFuzzer] Optionally keep initial seed inputs regardless of whether they discover new features or not.
 
 diff --git a/compiler-rt/lib/fuzzer/FuzzerCorpus.h b/compiler-rt/lib/fuzzer/FuzzerCorpus.h
-index 54d1e09ec6d..80398a9d7ce 100644
+index 54d1e09ec6d..5c687013c59 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerCorpus.h
 +++ b/compiler-rt/lib/fuzzer/FuzzerCorpus.h
 @@ -33,6 +33,7 @@ struct InputInfo {
@@ -16,7 +16,7 @@ index 54d1e09ec6d..80398a9d7ce 100644
    bool MayDeleteFile = false;
    bool Reduced = false;
    bool HasFocusFunction = false;
-@@ -131,9 +132,11 @@ class InputCorpus {
+@@ -131,9 +132,12 @@ class InputCorpus {
  
    EntropicOptions Entropic;
  
@@ -25,12 +25,13 @@ index 54d1e09ec6d..80398a9d7ce 100644
  public:
 -  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic)
 -      : Entropic(Entropic), OutputCorpus(OutputCorpus) {
-+  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic, bool KeepSeed)
++  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic,
++              bool KeepSeed)
 +      : Entropic(Entropic), OutputCorpus(OutputCorpus), KeepSeed(KeepSeed) {
      memset(InputSizesPerFeature, 0, sizeof(InputSizesPerFeature));
      memset(SmallestElementPerFeature, 0, sizeof(SmallestElementPerFeature));
    }
-@@ -177,7 +180,7 @@ public:
+@@ -177,7 +181,7 @@ public:
    bool empty() const { return Inputs.empty(); }
    const Unit &operator[] (size_t Idx) const { return Inputs[Idx]->U; }
    InputInfo *AddToCorpus(const Unit &U, size_t NumFeatures, bool MayDeleteFile,
@@ -39,7 +40,7 @@ index 54d1e09ec6d..80398a9d7ce 100644
                           const Vector<uint32_t> &FeatureSet,
                           const DataFlowTrace &DFT, const InputInfo *BaseII) {
      assert(!U.empty());
-@@ -187,6 +190,7 @@ public:
+@@ -187,6 +191,7 @@ public:
      InputInfo &II = *Inputs.back();
      II.U = U;
      II.NumFeatures = NumFeatures;
@@ -47,26 +48,20 @@ index 54d1e09ec6d..80398a9d7ce 100644
      II.MayDeleteFile = MayDeleteFile;
      II.UniqFeatureSet = FeatureSet;
      II.HasFocusFunction = HasFocusFunction;
-@@ -471,7 +475,7 @@ private:
+@@ -276,6 +281,11 @@ public:
+     return Idx;
+   }
  
-       for (size_t i = 0; i < N; i++) {
- 
--        if (Inputs[i]->NumFeatures == 0) {
-+        if (Inputs[i]->NumFeatures == 0 && !(Inputs[i]->SeedInput && KeepSeed)) {
-           // If the seed doesn't represent any features, assign zero energy.
-           Weights[i] = 0.;
-         } else if (Inputs[i]->NumExecutedMutations / kMaxMutationFactor >
-@@ -491,7 +495,7 @@ private:
- 
-     if (VanillaSchedule) {
-       for (size_t i = 0; i < N; i++)
--        Weights[i] = Inputs[i]->NumFeatures
-+        Weights[i] = (Inputs[i]->NumFeatures || (KeepSeed && Inputs[i]->SeedInput))
-                          ? (i + 1) * (Inputs[i]->HasFocusFunction ? 1000 : 1)
-                          : 0.;
-     }
++  InputInfo &ChooseUnitToCrossOverWith(Random &Rand) {
++    InputInfo &II = *Inputs[Rand(Inputs.size())];
++    return II;
++  }
++
+   void PrintStats() {
+     for (size_t i = 0; i < Inputs.size(); i++) {
+       const auto &II = *Inputs[i];
 diff --git a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
-index 00a33a413d2..ef7991c1e27 100644
+index 8339697396c..0933af56804 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
 +++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
 @@ -649,6 +649,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
@@ -77,33 +72,49 @@ index 00a33a413d2..ef7991c1e27 100644
    Options.UnitTimeoutSec = Flags.timeout;
    Options.ErrorExitCode = Flags.error_exitcode;
    Options.TimeoutExitCode = Flags.timeout_exitcode;
-@@ -753,7 +754,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+@@ -657,6 +658,8 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+   Options.IgnoreCrashes = Flags.ignore_crashes;
+   Options.MaxTotalTimeSec = Flags.max_total_time;
+   Options.DoCrossOver = Flags.cross_over;
++  Options.CrossOverUniformDist = Flags.cross_over_uniformdist;
++  Options.TraceSeedInput = Flags.trace_seed_input;
+   Options.MutateDepth = Flags.mutate_depth;
+   Options.ReduceDepth = Flags.reduce_depth;
+   Options.UseCounters = Flags.use_counters;
+@@ -753,7 +756,8 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
  
    Random Rand(Seed);
    auto *MD = new MutationDispatcher(Rand, Options);
 -  auto *Corpus = new InputCorpus(Options.OutputCorpus, Entropic);
-+  auto *Corpus = new InputCorpus(Options.OutputCorpus, Entropic, Options.KeepSeed);
++  auto *Corpus =
++      new InputCorpus(Options.OutputCorpus, Entropic, Options.KeepSeed);
    auto *F = new Fuzzer(Callback, *Corpus, *MD, Options);
  
    for (auto &U: Dictionary)
 diff --git a/compiler-rt/lib/fuzzer/FuzzerFlags.def b/compiler-rt/lib/fuzzer/FuzzerFlags.def
-index 832224a705d..0dac7e705a3 100644
+index 832224a705d..10b1f5f539a 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerFlags.def
 +++ b/compiler-rt/lib/fuzzer/FuzzerFlags.def
-@@ -23,6 +23,8 @@ FUZZER_FLAG_INT(len_control, 100, "Try generating small inputs first, "
+@@ -23,7 +23,14 @@ FUZZER_FLAG_INT(len_control, 100, "Try generating small inputs first, "
  FUZZER_FLAG_STRING(seed_inputs, "A comma-separated list of input files "
    "to use as an additional seed corpus. Alternatively, an \"@\" followed by "
    "the name of a file containing the comma-separated list.")
-+FUZZER_FLAG_INT(keep_seed, 0, "If 1, keep seed inputs for mutation even if "
-+  "they do not produce new coverage.")
++FUZZER_FLAG_INT(keep_seed, 0, "If 1, keep all seed inputs in the corpus even if "
++  "they do not produce new coverage. This also invalidates -reduce_inputs for "
++  "seed input mutations.")
  FUZZER_FLAG_INT(cross_over, 1, "If 1, cross over inputs.")
++FUZZER_FLAG_INT(cross_over_uniformdist, 0, "Experimental. If 1, use a uniform "
++  "probability distribution when choosing inputs to cross over with.")
++FUZZER_FLAG_INT(trace_seed_input, 0, "Internal. Print all seed inputs picked "
++  "up by the fuzzer.")
  FUZZER_FLAG_INT(mutate_depth, 5,
              "Apply this number of consecutive mutations to each input.")
+ FUZZER_FLAG_INT(reduce_depth, 0, "Experimental/internal. "
 diff --git a/compiler-rt/lib/fuzzer/FuzzerFork.cpp b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
-index d9e6b79443e..38fb82fc12d 100644
+index d9e6b79443e..97e91cbe869 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerFork.cpp
 +++ b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
-@@ -309,11 +309,17 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
+@@ -309,11 +309,20 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
    else
      Env.MainCorpusDir = CorpusDirs[0];
  
@@ -115,13 +126,16 @@ index d9e6b79443e..38fb82fc12d 100644
 +  if (Options.KeepSeed) {
 +    for (auto &File : SeedFiles)
 +      Env.Files.push_back(File.File);
-+  }
-+  else {
++  } else {
 +    auto CFPath = DirPlusFile(Env.TempDir, "merge.txt");
 +    CrashResistantMerge(Env.Args, {}, SeedFiles, &Env.Files, {}, &Env.Features,
-+                        {}, &Env.Cov,
-+                        CFPath, false);
++                        {}, &Env.Cov, CFPath, false);
 +    RemoveFile(CFPath);
++  }
++  if (Options.TraceSeedInput) {
++    for (auto &File : Env.Files) {
++      Printf("INFO: seed - %s\n", File.c_str());
++    }
 +  }
    Printf("INFO: -fork=%d: %zd seed inputs, starting to fuzz in %s\n", NumJobs,
           Env.Files.size(), Env.TempDir.c_str());
@@ -140,23 +154,53 @@ index 31096ce804b..e75807209f5 100644
    size_t NumberOfLeakDetectionAttempts = 0;
  
 diff --git a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
-index 02db6d27b0a..a9af25a3070 100644
+index 02db6d27b0a..28d5f32c0d6 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
 +++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
-@@ -487,10 +487,11 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
+@@ -478,7 +478,7 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
+       UniqFeatureSetTmp.push_back(Feature);
+     if (Options.Entropic)
+       Corpus.UpdateFeatureFrequency(II, Feature);
+-    if (Options.ReduceInputs && II)
++    if (Options.ReduceInputs && II && !(Options.KeepSeed && II->SeedInput))
+       if (std::binary_search(II->UniqFeatureSet.begin(),
+                              II->UniqFeatureSet.end(), Feature))
+         FoundUniqFeaturesOfII++;
+@@ -487,11 +487,12 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
      *FoundUniqFeatures = FoundUniqFeaturesOfII;
    PrintPulseAndReportSlowInput(Data, Size);
    size_t NumNewFeatures = Corpus.NumFeatureUpdates() - NumUpdatesBefore;
 -  if (NumNewFeatures) {
 +  if (NumNewFeatures || (Options.KeepSeed && IsExecutingSeedCorpora)) {
      TPC.UpdateObservedPCs();
-     auto NewII = Corpus.AddToCorpus({Data, Data + Size}, NumNewFeatures,
-                                     MayDeleteFile, TPC.ObservedFocusFunction(),
-+                                    IsExecutingSeedCorpora,
-                                     UniqFeatureSetTmp, DFT, II);
+-    auto NewII = Corpus.AddToCorpus({Data, Data + Size}, NumNewFeatures,
+-                                    MayDeleteFile, TPC.ObservedFocusFunction(),
+-                                    UniqFeatureSetTmp, DFT, II);
++    auto NewII =
++        Corpus.AddToCorpus({Data, Data + Size}, NumNewFeatures, MayDeleteFile,
++                           TPC.ObservedFocusFunction(),
++                           IsExecutingSeedCorpora, UniqFeatureSetTmp, DFT, II);
      WriteFeatureSetToFile(Options.FeaturesDir, Sha1ToString(NewII->Sha1),
                            NewII->UniqFeatureSet);
-@@ -764,6 +765,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+     return true;
+@@ -664,8 +665,14 @@ void Fuzzer::MutateAndTestOne() {
+   MD.StartMutationSequence();
+ 
+   auto &II = Corpus.ChooseUnitToMutate(MD.GetRand());
+-  if (Options.DoCrossOver)
+-    MD.SetCrossOverWith(&Corpus.ChooseUnitToMutate(MD.GetRand()).U);
++  if (Options.DoCrossOver) {
++    if (Options.CrossOverUniformDist) {
++      MD.SetCrossOverWith(&Corpus.ChooseUnitToCrossOverWith(MD.GetRand()).U);
++    }
++    else {
++      MD.SetCrossOverWith(&Corpus.ChooseUnitToMutate(MD.GetRand()).U);
++    }
++  }
+   const auto &U = II.U;
+   memcpy(BaseSha1, II.Sha1, sizeof(BaseSha1));
+   assert(CurrentUnitData);
+@@ -764,6 +771,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
        assert(CorporaFiles.front().Size <= CorporaFiles.back().Size);
      }
  
@@ -165,7 +209,7 @@ index 02db6d27b0a..a9af25a3070 100644
      // Load and execute inputs one by one.
      for (auto &SF : CorporaFiles) {
        auto U = FileToVector(SF.File, MaxInputLen, /*ExitOnError=*/false);
-@@ -773,6 +776,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+@@ -773,6 +782,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
        TryDetectingAMemoryLeak(U.data(), U.size(),
                                /*DuringInitialCorpusExecution*/ true);
      }
@@ -174,7 +218,7 @@ index 02db6d27b0a..a9af25a3070 100644
    }
  
    PrintStats("INITED");
-@@ -785,6 +790,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+@@ -785,6 +796,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
               Corpus.NumInputsThatTouchFocusFunction());
    }
  
@@ -184,7 +228,7 @@ index 02db6d27b0a..a9af25a3070 100644
      Printf("ERROR: no interesting inputs were found. "
             "Is the code instrumented for coverage? Exiting.\n");
 diff --git a/compiler-rt/lib/fuzzer/FuzzerOptions.h b/compiler-rt/lib/fuzzer/FuzzerOptions.h
-index 9d975bd61fe..ccd0b3dcb56 100644
+index 9d975bd61fe..bb2c14be47b 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerOptions.h
 +++ b/compiler-rt/lib/fuzzer/FuzzerOptions.h
 @@ -18,6 +18,7 @@ struct FuzzingOptions {
@@ -195,6 +239,15 @@ index 9d975bd61fe..ccd0b3dcb56 100644
    int UnitTimeoutSec = 300;
    int TimeoutExitCode = 70;
    int OOMExitCode = 71;
+@@ -30,6 +31,8 @@ struct FuzzingOptions {
+   int RssLimitMb = 0;
+   int MallocLimitMb = 0;
+   bool DoCrossOver = true;
++  bool CrossOverUniformDist = false;
++  bool TraceSeedInput = false;
+   int MutateDepth = 5;
+   bool ReduceDepth = false;
+   bool UseCounters = false;
 diff --git a/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp b/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
 index 0e9435ab8fc..dfc642ab6d0 100644
 --- a/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -19,6 +19,13 @@
 # are still testing this feature. You should request an experiment by contacting
 # us as you normally do.
 
+- experiment: 2020-08-15
+  fuzzers:
+    - libfuzzer_fixcrossover
+    - entropic_fixcrossover
+    - libfuzzer_keepseed
+    - entropic_keepseed
+
 - experiment: 2020-08-14
   fuzzers:
     - aflplusplus


### PR DESCRIPTION
This patch modifies the patch for the libfuzzer/entropic's keepseed variants such that (i) seed inputs are not replaced even if -reduce_inputs=1, and (ii) the crossover mutator uses a uniform probability distribution when selecting inputs to cross over with, while using the original probability distribution computed by either Vanilla or Entropic schedule when selecting an input to mutate.