### PR TITLE
Some fix and improvements on differential plots.

### DIFF
--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -295,8 +295,10 @@ class BenchmarkResults:
     @functools.lru_cache()
     def pairwise_unique_coverage_table(self):
         """Pairwise unique coverage table for each pair of fuzzers."""
+        fuzzers = self.unique_region_cov_df.sort_values(
+            by='unique_regions_covered', ascending=False).fuzzer
         return coverage_data_utils.get_pairwise_unique_coverage_table(
-            self._benchmark_coverage_dict)
+            self._benchmark_coverage_dict, fuzzers)
 
     @property
     def pairwise_unique_coverage_plot(self):

--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -103,7 +103,7 @@ class BenchmarkResults:
 
     @property
     @functools.lru_cache()
-    def _unique_region_cov_df(self):
+    def unique_region_cov_df(self):
         """Fuzzers with the number of covered unique regions."""
         return coverage_data_utils.get_unique_region_cov_df(
             self._unique_region_dict, self.fuzzer_names)
@@ -285,7 +285,7 @@ class BenchmarkResults:
     def unique_coverage_ranking_plot(self):
         """Ranking plot for unique coverage."""
         plot_filename = self._prefix_with_benchmark('ranking_unique_region.svg')
-        unique_region_cov_df_combined = self._unique_region_cov_df.merge(
+        unique_region_cov_df_combined = self.unique_region_cov_df.merge(
             self._benchmark_aggregated_coverage_df, on='fuzzer')
         self._plotter.write_unique_coverage_ranking_plot(
             unique_region_cov_df_combined, self._get_full_path(plot_filename))

--- a/analysis/coverage_data_utils.py
+++ b/analysis/coverage_data_utils.py
@@ -160,11 +160,9 @@ def get_unique_covered_percentage(fuzzer_row_covered_regions,
     return unique_region_count
 
 
-def rank_by_unique_coverage_average_normalized_score(unique_coverage_df_list):
+def rank_by_average_normalized_score(benchmarks_unique_coverage_list):
     """Returns the rank based on average normalized score on unique coverage."""
-    df_list = [df.set_index('fuzzer') for df in unique_coverage_df_list]
-    print(df_list)
+    df_list = [df.set_index('fuzzer') for df in benchmarks_unique_coverage_list]
     combined_df = pd.concat(df_list, axis=1).astype(float).T
-    print(combined_df)
-    rank_series = data_utils.experiment_rank_by_average_normalized_score(combined_df)
-    return rank_series
+    scores = data_utils.experiment_rank_by_average_normalized_score(combined_df)
+    return scores

--- a/analysis/coverage_data_utils.py
+++ b/analysis/coverage_data_utils.py
@@ -122,7 +122,7 @@ def get_benchmark_aggregated_cov_df(benchmark_coverage_dict):
     return pd.DataFrame(dict_to_transform)
 
 
-def get_pairwise_unique_coverage_table(benchmark_coverage_dict):
+def get_pairwise_unique_coverage_table(benchmark_coverage_dict, fuzzers):
     """Returns a table that shows the unique coverage between
     each pair of fuzzers.
 
@@ -130,8 +130,6 @@ def get_pairwise_unique_coverage_table(benchmark_coverage_dict):
     row and column represents a fuzzer, and each cell contains a number
     showing the regions covered by the fuzzer of the column but not by
     the fuzzer of the row."""
-
-    fuzzers = benchmark_coverage_dict.keys()
 
     pairwise_unique_coverage_values = []
     for fuzzer_in_row in fuzzers:

--- a/analysis/coverage_data_utils.py
+++ b/analysis/coverage_data_utils.py
@@ -20,6 +20,7 @@ import posixpath
 import tempfile
 import pandas as pd
 
+from analysis import data_utils
 from common import filestore_utils
 
 
@@ -157,3 +158,13 @@ def get_unique_covered_percentage(fuzzer_row_covered_regions,
         if region not in fuzzer_row_covered_regions:
             unique_region_count += 1
     return unique_region_count
+
+
+def rank_by_unique_coverage_average_normalized_score(unique_coverage_df_list):
+    """Returns the rank based on average normalized score on unique coverage."""
+    df_list = [df.set_index('fuzzer') for df in unique_coverage_df_list]
+    print(df_list)
+    combined_df = pd.concat(df_list, axis=1).astype(float).T
+    print(combined_df)
+    rank_series = data_utils.experiment_rank_by_average_normalized_score(combined_df)
+    return rank_series

--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -105,17 +105,18 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
         """A pivot table of medians for each fuzzer on each benchmark."""
         return data_utils.experiment_pivot_table(
             self._experiment_snapshots_df, data_utils.benchmark_rank_by_median)
-    
+
     @property
-    def benchmark_unique_coverage_list(self):
+    def _benchmarks_unique_coverage_list(self):
         """A list containing unique coverage dataframe for each benchmark."""
-        return [benchmark._unique_region_cov_df for benchmark in self.benchmarks]
-    
+        return [benchmark.unique_region_cov_df for benchmark in self.benchmarks]
+
     @property
     def rank_by_unique_coverage_average_normalized_score(self):
         """Rank fuzzers using average normalized score on unique coverage across
         benchmarks."""
-        return coverage_data_utils.rank_by_unique_coverage_average_normalized_score(self.benchmark_unique_coverage_list)
+        return coverage_data_utils.rank_by_average_normalized_score(
+            self._benchmarks_unique_coverage_list)
 
     @property
     def rank_by_average_rank_and_average_rank(self):

--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -17,6 +17,7 @@ import functools
 import os
 
 from analysis import benchmark_results
+from analysis import coverage_data_utils
 from analysis import data_utils
 from analysis import stat_tests
 
@@ -104,6 +105,17 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
         """A pivot table of medians for each fuzzer on each benchmark."""
         return data_utils.experiment_pivot_table(
             self._experiment_snapshots_df, data_utils.benchmark_rank_by_median)
+    
+    @property
+    def benchmark_unique_coverage_list(self):
+        """A list containing unique coverage dataframe for each benchmark."""
+        return [benchmark._unique_region_cov_df for benchmark in self.benchmarks]
+    
+    @property
+    def rank_by_unique_coverage_average_normalized_score(self):
+        """Rank fuzzers using average normalized score on unique coverage across
+        benchmarks."""
+        return coverage_data_utils.rank_by_unique_coverage_average_normalized_score(self.benchmark_unique_coverage_list)
 
     @property
     def rank_by_average_rank_and_average_rank(self):

--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -107,16 +107,14 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
             self._experiment_snapshots_df, data_utils.benchmark_rank_by_median)
 
     @property
-    def _benchmarks_unique_coverage_list(self):
-        """A list containing unique coverage dataframe for each benchmark."""
-        return [benchmark.unique_region_cov_df for benchmark in self.benchmarks]
-
-    @property
     def rank_by_unique_coverage_average_normalized_score(self):
         """Rank fuzzers using average normalized score on unique coverage across
         benchmarks."""
+        benchmarks_unique_coverage_list = [
+            benchmark.unique_region_cov_df for benchmark in self.benchmarks
+        ]
         return coverage_data_utils.rank_by_average_normalized_score(
-            self._benchmarks_unique_coverage_list)
+            benchmarks_unique_coverage_list)
 
     @property
     def rank_by_average_rank_and_average_rank(self):

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -95,6 +95,10 @@
                     <h5 class="center-align">By avg. rank</h5>
                     {{ experiment.rank_by_median_and_average_rank.round(2).to_frame().to_html() }}
                 </div>
+                <div class="col s5">
+                    <h5 class="center-align">By avg. score on unique coverage</h5>
+                    {{ experiment.rank_by_unique_coverage_average_normalized_score.round(2).to_frame().to_html() }}
+                </div>
             </div>
 
             <ul class="collapsible">

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -96,13 +96,6 @@
                     {{ experiment.rank_by_median_and_average_rank.round(2).to_frame().to_html() }}
                 </div>
             </div>
-            
-            <div class="row">
-                <div class="col s5 offset-s1">
-                    <h5 class="center-align">By avg. score on unique coverage</h5>
-                    {{ experiment.rank_by_unique_coverage_average_normalized_score.round(2).to_frame().to_html() }}
-                </div>
-            </div>
 
             <ul class="collapsible">
                 <li>
@@ -278,13 +271,9 @@
                         Coverage reports for each fuzzer on this benchmark
                     </div>
                     <div class="collapsible-body">
-                        <div class="row">
+                        <div class="collection">
                             {% for fuzzer in benchmark.fuzzer_names %}
-                            <div class="col">
-                                <p>
-                                    <a class="waves-effect waves-light btn" href="{{ benchmark.get_filestore_name(fuzzer) }}/coverage/reports/{{ benchmark.name }}/{{ fuzzer }}/index.html">{{ fuzzer }}</a>
-                                </p>
-                            </div>
+                            <a href="{{ benchmark.get_filestore_name(fuzzer) }}/coverage/reports/{{ benchmark.name }}/{{ fuzzer }}/index.html" class="collection-item">{{ fuzzer }}</a>
                             {% endfor %}
                         </div>
                     </div>

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -95,7 +95,10 @@
                     <h5 class="center-align">By avg. rank</h5>
                     {{ experiment.rank_by_median_and_average_rank.round(2).to_frame().to_html() }}
                 </div>
-                <div class="col s5">
+            </div>
+            
+            <div class="row">
+                <div class="col s5 offset-s1">
                     <h5 class="center-align">By avg. score on unique coverage</h5>
                     {{ experiment.rank_by_unique_coverage_average_normalized_score.round(2).to_frame().to_html() }}
                 </div>
@@ -278,7 +281,9 @@
                         <div class="row">
                             {% for fuzzer in benchmark.fuzzer_names %}
                             <div class="col">
-                                <a class="waves-effect waves-light btn" href="{{ benchmark.get_filestore_name(fuzzer) }}/coverage/reports/{{ benchmark.name }}/{{ fuzzer }}/index.html">{{ fuzzer }}</a>
+                                <p>
+                                    <a class="waves-effect waves-light btn" href="{{ benchmark.get_filestore_name(fuzzer) }}/coverage/reports/{{ benchmark.name }}/{{ fuzzer }}/index.html">{{ fuzzer }}</a>
+                                </p>
                             </div>
                             {% endfor %}
                         </div>

--- a/analysis/report_templates/experimental.html
+++ b/analysis/report_templates/experimental.html
@@ -53,5 +53,12 @@
     </div>
 </div>
 
+<h5>Rank by average normalized score of unique coverage on benchmarks</h5>
+<div class="row">
+    <div class="col s5 offset-s1">
+        {{ experiment.rank_by_unique_coverage_average_normalized_score.round(2).to_frame().to_html() }}
+    </div>
+</div>
+
 {% endblock %}
 

--- a/analysis/test_coverage_data_utils.py
+++ b/analysis/test_coverage_data_utils.py
@@ -84,10 +84,10 @@ def test_get_pairwise_unique_coverage_table():
     coverage_dict = create_coverage_data()
     benchmark_coverage_dict = coverage_data_utils.get_benchmark_cov_dict(
         coverage_dict, 'libpng-1.2.56')
+    fuzzers = ['libfuzzer', 'afl']
     table = coverage_data_utils.get_pairwise_unique_coverage_table(
-        benchmark_coverage_dict)
-    fuzzers = ['afl', 'libfuzzer']
-    expected_table = pd.DataFrame([[0, 2], [1, 0]],
+        benchmark_coverage_dict, fuzzers)
+    expected_table = pd.DataFrame([[0, 1], [2, 0]],
                                   index=fuzzers,
                                   columns=fuzzers)
     pd_test.assert_frame_equal(table, expected_table)


### PR DESCRIPTION
This patch adds a new ranking graph to summarize the rank of each fuzzer based on their unique coverage on each benchmark.
![Screenshot 2020-08-17 at 5 45 15 PM](https://user-images.githubusercontent.com/44593802/90447499-741b4980-e0b1-11ea-834a-40d0f0fe01eb.png)

This patch also adds space between lines of fuzzer buttons in coverage reports collapsible box.
