### PR TITLE
Build all benchmarks with latest clang.

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -33,7 +33,7 @@ jobs:
           - afl_qemu
           - aflplusplus_qemu
           - honggfuzz_qemu
-          - weizz
+          - weizz_qemu
           # Temporary variants.
           - libfuzzer_keepseed
           - entropic_keepseed

--- a/benchmarks/bloaty_fuzz_target/Dockerfile
+++ b/benchmarks/bloaty_fuzz_target/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:12125f1ecb9e4905a19c35700a3402c1eba43c82ea2d227f01c28833d75e3574
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y cmake ninja-build g++
 RUN git clone --depth 1 https://github.com/google/bloaty.git bloaty
 WORKDIR bloaty

--- a/benchmarks/curl_curl_fuzzer_http/Dockerfile
+++ b/benchmarks/curl_curl_fuzzer_http/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:aea783f76a46298085620e73d9943fad84c912e38b8a1a482177ae84360152ec
+FROM gcr.io/oss-fuzz-base/base-builder
 
 # Curl will be checked out to the commit hash specified in benchmark.yaml.
 RUN git clone --depth 1 https://github.com/curl/curl.git /src/curl

--- a/benchmarks/jsoncpp_jsoncpp_fuzzer/Dockerfile
+++ b/benchmarks/jsoncpp_jsoncpp_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:8e56964113db5e06130b8bc5b94becb5d90a88e90c9b593f2ea24f33b0a467d0
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y build-essential make curl wget
 
 # Install latest cmake.

--- a/benchmarks/libpcap_fuzz_both/Dockerfile
+++ b/benchmarks/libpcap_fuzz_both/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:c18f9615c9824b61ce982e0bac4b157b2eff5b9240cc6310a4815a826bb804e3
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make cmake flex bison
 RUN git clone --depth 1 https://github.com/the-tcpdump-group/libpcap.git libpcap
 # for corpus as wireshark

--- a/benchmarks/mbedtls_fuzz_dtlsclient/Dockerfile
+++ b/benchmarks/mbedtls_fuzz_dtlsclient/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:fee307a212b2f77f208b209e2335e4a5e640f55dbe6dbe76a3e50475f9160eca
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make cmake
 RUN git clone --recursive --depth 1 https://github.com/ARMmbed/mbedtls.git mbedtls
 RUN git clone --depth 1 https://github.com/google/boringssl.git boringssl

--- a/benchmarks/openssl_x509/Dockerfile
+++ b/benchmarks/openssl_x509/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:02b6f53c6220b84cfb671dfc65bb8f1e224e8a5c56940e358f0fbcbd74b44734
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/openssl/openssl.git
 WORKDIR openssl

--- a/benchmarks/php_php-fuzz-parser/Dockerfile
+++ b/benchmarks/php_php-fuzz-parser/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:59fdabfe72127e145d8a387b68e883121bddd7cf391d600edb97ecbdacbc9ff8
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y autoconf automake libtool bison re2c pkg-config
 

--- a/benchmarks/sqlite3_ossfuzz/Dockerfile
+++ b/benchmarks/sqlite3_ossfuzz/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:32d87afee8e52e1550905b43d5e8583b33f37c2600446b6b9efeb14bfc25c71f
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool curl tcl zlib1g-dev
 
 RUN mkdir $SRC/sqlite3 && \

--- a/benchmarks/systemd_fuzz-link-parser/Dockerfile
+++ b/benchmarks/systemd_fuzz-link-parser/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:02b6f53c6220b84cfb671dfc65bb8f1e224e8a5c56940e358f0fbcbd74b44734
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update &&\
     apt-get install -y gperf m4 gettext python3-pip \
         libcap-dev libmount-dev libkmod-dev \

--- a/benchmarks/zlib_zlib_uncompress_fuzzer/Dockerfile
+++ b/benchmarks/zlib_zlib_uncompress_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:84df55d087d82b65e3a594c01248d59f49d513d4d7362014b417e640317b11f4
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 -b develop https://github.com/madler/zlib.git
 WORKDIR zlib


### PR DESCRIPTION
This will help us the use the same latest clang from latest OSS-Fuzz images across all benchmarks. This is important as sometimes they can be new tool additions or image changes over time, e.g. https://github.com/google/oss-fuzz/pull/4332