### PR TITLE
Generate reports directory

### DIFF
--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -92,7 +92,7 @@ class BenchmarkResults:
     def _benchmark_aggregated_coverage_df(self):
         """Aggregated covered regions of each fuzzer on this benchmark."""
         return coverage_data_utils.get_benchmark_aggregated_cov_df(
-            self._benchmark_coverage_dict)
+            self._coverage_dict, self.name)
 
     @property
     @functools.lru_cache()

--- a/analysis/coverage_data_utils.py
+++ b/analysis/coverage_data_utils.py
@@ -110,15 +110,16 @@ def get_benchmark_cov_dict(coverage_dict, benchmark):
     return benchmark_cov_dict
 
 
-def get_benchmark_aggregated_cov_df(benchmark_coverage_dict):
+def get_benchmark_aggregated_cov_df(coverage_dict, benchmark):
     """Returns a dataframe where each row represents a fuzzer and its
     aggregated coverage number."""
     dict_to_transform = {'fuzzer': [], 'aggregated_edges_covered': []}
-    for fuzzer in benchmark_coverage_dict:
-        aggregated_edges_covered = len(benchmark_coverage_dict[fuzzer])
-        dict_to_transform['fuzzer'].append(fuzzer)
-        dict_to_transform['aggregated_edges_covered'].append(
-            aggregated_edges_covered)
+    for key_pair, covered_regions in coverage_dict.items():
+        current_fuzzer, current_benchmark = key_pair.split()
+        if current_benchmark == benchmark:
+            dict_to_transform['fuzzer'].append(current_fuzzer)
+            dict_to_transform['aggregated_edges_covered'].append(
+                len(covered_regions))
     return pd.DataFrame(dict_to_transform)
 
 

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -273,7 +273,7 @@
                     <div class="collapsible-body">
                         <div class="collection">
                             {% for fuzzer in benchmark.fuzzer_names %}
-                            <a href="{{ benchmark.get_filestore_name(fuzzer) }}/coverage/reports/{{ benchmark.name }}/{{ fuzzer }}/index.html" class="collection-item">{{ fuzzer }}</a>
+                            <a href="{{ benchmark.get_filestore_name(fuzzer) }}/coverage/reports/{{ benchmark.name }}/{{ fuzzer }}/linux/index.html" class="collection-item">{{ fuzzer }}</a>
                             {% endfor %}
                         </div>
                     </div>

--- a/docker/dispatcher-image/Dockerfile
+++ b/docker/dispatcher-image/Dockerfile
@@ -45,4 +45,7 @@ RUN chmod +x /usr/local/bin/cloud_sql_proxy
 COPY --from=base-clang /usr/local/bin/llvm-cov /usr/local/bin/
 COPY --from=base-clang /usr/local/bin/llvm-profdata /usr/local/bin/
 
+# Get the Chromium tool for post processing HTML report.
+RUN git clone https://chromium.googlesource.com/chromium/src/tools/code_coverage /opt/code_coverage
+
 COPY startup-dispatcher.sh $WORK/

--- a/docker/dispatcher-image/Dockerfile
+++ b/docker/dispatcher-image/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update -y && apt-get install -y \
     libglib2.0-0 \
     libxml2 \
     libarchive13 \
-    libgss3
+    libgss3 \
+    git
 
 RUN virtualenv --python=$(which python3) $WORK/.venv
 

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -147,7 +147,8 @@ class CoverageReporter:  # pylint: disable=too-many-instance-attributes
         coverage_binary = get_coverage_binary(self.benchmark)
         result = generate_json_summary(coverage_binary,
                                        self.merged_profdata_file,
-                                       self.merged_json_summary_file)
+                                       self.merged_json_summary_file,
+                                       summary_only=False)
         if result.retcode != 0:
             logger.error(
                 'Merged coverage summary json file generation failed for '

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -71,6 +71,8 @@ def generate_coverage_info(experiment, benchmark, fuzzer):
     generator = CoverageReporter(fuzzer, benchmark, experiment)
     # Merge all the profdata files.
     generator.merge_profdata_files()
+    # Generate the json file based on merged profdata file.
+    generator.generate_merged_json_summary()
     # Generate the reports using llvm-cov.
     generator.generate_cov_report()
     # Post process the report.

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -136,7 +136,7 @@ class CoverageReporter:  # pylint: disable=too-many-instance-attributes
             '-instr-profile={profdata}'.format(
                 profdata=self.merged_profdata_file)
         ]
-        result = new_process.execute(command)
+        result = new_process.execute(command, expect_zero=False)
         if result.retcode != 0:
             logger.error('Coverage report generation failed for '
                          'fuzzer: {fuzzer},benchmark: {benchmark}.'.format(
@@ -165,7 +165,7 @@ class CoverageReporter:  # pylint: disable=too-many-instance-attributes
             '-output-dir={report_dir}'.format(report_dir=self.report_dir),
             '-path-equivalence=/,{prefix}'.format(prefix=self.source_files_dir)
         ]
-        result = new_process.execute(command)
+        result = new_process.execute(command, expect_zero=False)
         if result.retcode != 0:
             logger.error('Coverage report post process failed for '
                          'fuzzer: {fuzzer},benchmark: {benchmark}.'.format(
@@ -257,7 +257,7 @@ def generate_json_summary(coverage_binary,
                           profdata_file,
                           output_file,
                           summary_only=True):
-    """Generate the json summary file from |coverage_binary|
+    """Generates the json summary file from |coverage_binary|
     and |profdata_file|."""
     command = [
         'llvm-cov', 'export', '-format=text', coverage_binary,
@@ -275,7 +275,7 @@ def generate_json_summary(coverage_binary,
 
 
 def extract_coverage_from_json(json_file):
-    """Get the covered regions for the current trial."""
+    """Returns the covered regions for the current trial."""
     covered_regions = []
     try:
         coverage_info = get_coverage_infomation(json_file)

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -266,13 +266,11 @@ def generate_json_summary(coverage_binary,
 
     if summary_only:
         command.append('-summary-only')
-
-    try:
-        with open(output_file, 'w') as dst_file:
-            result = new_process.execute(command,
-                                        output_file=dst_file)
-    except Exception:
-        logger.error('llvm export error.')
+    
+    with open(output_file, 'w') as dst_file:
+        result = new_process.execute(command,
+                                     output_file=dst_file,
+                                     expect_zero=False)
     return result
 
 

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -276,7 +276,7 @@ def generate_json_summary(coverage_binary,
 
 def extract_coverage_from_json(json_file):
     """Get the covered regions for the current trial."""
-    covered_regions = set()
+    covered_regions = []
     try:
         coverage_info = get_coverage_infomation(json_file)
         functions_data = coverage_info['data'][0]['functions']
@@ -292,8 +292,8 @@ def extract_coverage_from_json(json_file):
         for function_data in functions_data:
             for region in function_data['regions']:
                 if region[hit_index] != 0 and region[type_index] == 0:
-                    covered_regions.add(
-                        tuple(region[:hit_index] + region[file_index:]))
+                    covered_regions.append(region[:hit_index] +
+                                           region[file_index:])
     except Exception:  # pylint: disable=broad-except
         logger.error('Coverage summary json file defective or missing.')
     return covered_regions

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -267,10 +267,12 @@ def generate_json_summary(coverage_binary,
     if summary_only:
         command.append('-summary-only')
 
-    with open(output_file, 'w') as dst_file:
-        result = new_process.execute(command,
-                                     output_file=dst_file,
-                                     expect_zero=False)
+    try:
+        with open(output_file, 'w') as dst_file:
+            result = new_process.execute(command,
+                                        output_file=dst_file)
+    except Exception:
+        logger.error('llvm export error.')
     return result
 
 

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -266,7 +266,7 @@ def generate_json_summary(coverage_binary,
 
     if summary_only:
         command.append('-summary-only')
-    
+
     with open(output_file, 'w') as dst_file:
         result = new_process.execute(command,
                                      output_file=dst_file,

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -47,30 +47,36 @@ def upload_coverage_info_to_bucket():
     filestore_utils.cp(src_dir, dst_dir, recursive=True, parallel=True)
 
 
-def generate_coverage_reports(experiment_config: dict):
-    """Generates coverage reports for each benchmark and fuzzer."""
+def generate_all_coverage_info(experiment_config: dict):
+    """Generates coverage reports and summary json file
+    for each benchmark and fuzzer."""
     logger.info('Start generating coverage report for benchmarks.')
     benchmarks = experiment_config['benchmarks'].split(',')
     fuzzers = experiment_config['fuzzers'].split(',')
     experiment = experiment_config['experiment']
     with multiprocessing.Pool() as pool:
-        generate_coverage_report_args = [(experiment, benchmark, fuzzer)
-                                         for benchmark in benchmarks
-                                         for fuzzer in fuzzers]
-        pool.starmap(generate_coverage_report, generate_coverage_report_args)
+        generate_coverage_info_args = [(experiment, benchmark, fuzzer)
+                                       for benchmark in benchmarks
+                                       for fuzzer in fuzzers]
+        pool.starmap(generate_coverage_info, generate_coverage_info_args)
     logger.info('Finished generating coverage report.')
 
 
-def generate_coverage_report(experiment, benchmark, fuzzer):
-    """Generates the coverage report for one pair of benchmark and fuzzer."""
+def generate_coverage_info(experiment, benchmark, fuzzer):
+    """Generates the coverage report and summary json file
+    for one pair of benchmark and fuzzer."""
     logs.initialize()
     logger.info('Generating coverage report for benchmark: {benchmark} \
                 fuzzer: {fuzzer}.'.format(benchmark=benchmark, fuzzer=fuzzer))
     generator = CoverageReporter(fuzzer, benchmark, experiment)
-    # Merges all the profdata files.
+    # Merge all the profdata files.
     generator.merge_profdata_files()
-    # Generates the reports using llvm-cov.
+    # Generate the reports using llvm-cov.
     generator.generate_cov_report()
+    # Post process the report.
+    generator.post_process_report()
+    # Generate the json file to store all coverage data.
+    generator.generate_coverage_data_json_file()
 
     logger.info('Finished generating coverage report for '
                 'benchmark:{benchmark} fuzzer:{fuzzer}.'.format(
@@ -92,25 +98,27 @@ class CoverageReporter:  # pylint: disable=too-many-instance-attributes
         coverage_info_dir = get_coverage_info_dir()
         self.json_file_dir = os.path.join(coverage_info_dir, 'data', benchmark,
                                           fuzzer)
+        self.json_file = os.path.join(self.json_file_dir,
+                                      'covered_regions.json')
         benchmark_fuzzer_dir = exp_utils.get_benchmark_fuzzer_dir(
             benchmark, fuzzer)
         work_dir = exp_utils.get_work_dir()
-        self.merged_profdata_file = os.path.join(work_dir,
-                                                 'measurement-folders',
-                                                 benchmark_fuzzer_dir,
-                                                 'merged.profdata')
+        benchmark_fuzzer_measurement_dir = os.path.join(work_dir,
+                                                        'measurement-folders',
+                                                        benchmark_fuzzer_dir)
+        self.merged_profdata_file = os.path.join(
+            benchmark_fuzzer_measurement_dir, 'merged.profdata')
+        self.merged_json_summary_file = os.path.join(
+            benchmark_fuzzer_measurement_dir, 'merged.json')
         coverage_binaries_dir = build_utils.get_coverage_binaries_dir()
         self.source_files_dir = os.path.join(coverage_binaries_dir, benchmark)
         self.binary_file = get_coverage_binary(benchmark)
 
     def merge_profdata_files(self):
         """Merge profdata files from |src_files| to |dst_files|."""
-        logger.info('Merging profdata for fuzzer: '
-                    '{fuzzer},benchmark: {benchmark}.'.format(
-                        fuzzer=self.fuzzer, benchmark=self.benchmark))
         files_to_merge = [
-            TrialCoverage(self.fuzzer, self.benchmark, trial_id,
-                          logger).profdata_file for trial_id in self.trial_ids
+            TrialCoverage(self.fuzzer, self.benchmark, trial_id).profdata_file
+            for trial_id in self.trial_ids
         ]
         result = merge_profdata_files(files_to_merge, self.merged_profdata_file)
         if result.retcode != 0:
@@ -132,12 +140,41 @@ class CoverageReporter:  # pylint: disable=too-many-instance-attributes
                          'fuzzer: {fuzzer},benchmark: {benchmark}.'.format(
                              fuzzer=self.fuzzer, benchmark=self.benchmark))
 
-    def generate_json_summary_file(self, covered_regions):
+    def generate_merged_json_summary(self):
+        """Generates the json summary file."""
+        coverage_binary = get_coverage_binary(self.benchmark)
+        result = generate_json_summary(coverage_binary,
+                                       self.merged_profdata_file,
+                                       self.merged_json_summary_file)
+        if result.retcode != 0:
+            logger.error(
+                'Merged coverage summary json file generation failed for '
+                'fuzzer: {fuzzer},benchmark: {benchmark}.'.format(
+                    fuzzer=self.fuzzer, benchmark=self.benchmark))
+
+    def post_process_report(self):
+        """Posts process the html report to generate hierarchical directory."""
+        command = [
+            'python3', '/opt/code_coverage/coverage_utils.py', '-v',
+            'post_process', '-src-root-dir=/',
+            '-summary-file={json_file}'.format(
+                json_file=self.merged_json_summary_file),
+            '-output-dir={report_dir}'.format(report_dir=self.report_dir),
+            '-path-equivalence=/,{prefix}'.format(prefix=self.source_files_dir)
+        ]
+        result = new_process.execute(command)
+        if result.retcode != 0:
+            logger.error('Coverage report post process failed for '
+                         'fuzzer: {fuzzer},benchmark: {benchmark}.'.format(
+                             fuzzer=self.fuzzer, benchmark=self.benchmark))
+
+    def generate_coverage_data_json_file(self):
         """Stores the coverage data in a json file."""
+        covered_regions = extract_coverage_from_json(
+            self.merged_json_summary_file)
         json_src_dir = self.json_file_dir
         filesystem.create_directory(json_src_dir)
-        json_src = os.path.join(json_src_dir, 'covered_regions.json')
-        with open(json_src, 'w') as src_file:
+        with open(self.json_file, 'w') as src_file:
             json.dump(covered_regions, src_file)
 
 
@@ -194,77 +231,13 @@ def get_coverage_infomation(coverage_summary_file):
         return json.loads(summary.readlines()[-1])
 
 
-def store_coverage_data(experiment_config: dict):
-    """Generates the specific coverage data and store in cloud bucket."""
-    logger.info('Start storing coverage data')
-    with multiprocessing.Pool() as pool:
-        store_all_covered_regions(experiment_config, pool)
-
-    logger.info('Finished storing coverage data')
-
-
-def store_all_covered_regions(experiment_config: dict, pool):
-    """Stores regions covered for each pair for fuzzer and benchmark."""
-    logger.info('Storing all fuzzer-benchmark pairs for final coverage data.')
-
-    benchmarks = experiment_config['benchmarks'].split(',')
-    fuzzers = experiment_config['fuzzers'].split(',')
-    experiment = experiment_config['experiment']
-
-    store_covered_region_args = [(experiment, fuzzer, benchmark)
-                                 for fuzzer in fuzzers
-                                 for benchmark in benchmarks]
-
-    pool.starmap(store_covered_region, store_covered_region_args)
-    logger.info('Done storing all coverage data.')
-
-
-def store_covered_region(experiment: str, fuzzer: str, benchmark: str):
-    """Gets the final covered region for a specific pair of fuzzer-benchmark."""
-    logs.initialize()
-    logger.debug('Storing covered region: fuzzer: %s, benchmark: %s.', fuzzer,
-                 benchmark)
-    covered_regions = get_covered_region(experiment, fuzzer, benchmark)
-    generator = CoverageReporter(fuzzer, benchmark, experiment)
-    generator.generate_json_summary_file(covered_regions)
-
-    logger.debug('Finished storing covered region: fuzzer: %s, benchmark: %s.',
-                 fuzzer, benchmark)
-
-
-def get_covered_region(experiment: str, fuzzer: str, benchmark: str):
-    """Gets covered regions for |fuzzer| on |benchmark|."""
-    logger.debug('Measuring covered region: fuzzer: %s, benchmark: %s.', fuzzer,
-                 benchmark)
-    covered_regions = set()
-    trial_ids = get_trial_ids(experiment, fuzzer, benchmark)
-    for trial_id in trial_ids:
-        logger.info('Measuring covered region: trial_id = %d.', trial_id)
-        snapshot_logger = logs.Logger('measurer',
-                                      default_extras={
-                                          'fuzzer': fuzzer,
-                                          'benchmark': benchmark,
-                                          'trial_id': str(trial_id),
-                                      })
-        trial_coverage = TrialCoverage(fuzzer, benchmark, trial_id,
-                                       snapshot_logger)
-        trial_coverage.generate_summary(0, summary_only=False)
-        new_covered_regions = trial_coverage.get_current_covered_regions()
-        covered_regions = covered_regions.union(new_covered_regions)
-    logger.debug('Done measuring covered region: fuzzer: %s, benchmark: %s.',
-                 fuzzer, benchmark)
-    return list(covered_regions)
-
-
 class TrialCoverage:  # pylint: disable=too-many-instance-attributes
     """Base class for storing and getting coverage data for a trial."""
 
-    def __init__(self, fuzzer: str, benchmark: str, trial_num: int,
-                 trial_logger: logs.Logger):
+    def __init__(self, fuzzer: str, benchmark: str, trial_num: int):
         self.fuzzer = fuzzer
         self.benchmark = benchmark
         self.trial_num = trial_num
-        self.logger = trial_logger
         self.benchmark_fuzzer_trial_dir = exp_utils.get_trial_dir(
             fuzzer, benchmark, trial_num)
         self.work_dir = exp_utils.get_work_dir()
@@ -276,58 +249,48 @@ class TrialCoverage:  # pylint: disable=too-many-instance-attributes
         # Store the profdata file for the current trial.
         self.profdata_file = os.path.join(self.report_dir, 'data.profdata')
 
-        # Store the coverage information in json form.
-        self.cov_summary_file = os.path.join(self.report_dir,
-                                             'cov_summary.json')
 
-    def get_current_covered_regions(self):
-        """Get the covered regions for the current trial."""
-        covered_regions = set()
-        try:
-            coverage_info = get_coverage_infomation(self.cov_summary_file)
-            functions_data = coverage_info['data'][0]['functions']
-            # The fourth number in the region-list indicates if the region
-            # is hit.
-            hit_index = 4
-            # The last number in the region-list indicates what type of the
-            # region it is; 'code_region' is used to obtain various code
-            # coverage statistic and is represented by number 0.
-            type_index = -1
-            # The number of index 5 represents the file number.
-            file_index = 5
-            for function_data in functions_data:
-                for region in function_data['regions']:
-                    if region[hit_index] != 0 and region[type_index] == 0:
-                        covered_regions.add(
-                            tuple(region[:hit_index] + region[file_index:]))
-        except Exception:  # pylint: disable=broad-except
-            self.logger.error(
-                'Coverage summary json file defective or missing.')
-        return covered_regions
+def generate_json_summary(coverage_binary,
+                          profdata_file,
+                          output_file,
+                          summary_only=True):
+    """Generate the json summary file from |coverage_binary|
+    and |profdata_file|."""
+    command = [
+        'llvm-cov', 'export', '-format=text', coverage_binary,
+        '-instr-profile=%s' % profdata_file
+    ]
 
-    def generate_summary(self, cycle: int, summary_only=True):
-        """Transforms the .profdata file into json form."""
-        coverage_binary = get_coverage_binary(self.benchmark)
-        command = [
-            'llvm-cov', 'export', '-format=text', coverage_binary,
-            '-instr-profile=%s' % self.profdata_file
-        ]
+    if summary_only:
+        command.append('-summary-only')
 
-        if summary_only:
-            command.append('-summary-only')
+    with open(output_file, 'w') as dst_file:
+        result = new_process.execute(command,
+                                     output_file=dst_file,
+                                     expect_zero=False)
+    return result
 
-        with open(self.cov_summary_file, 'w') as output_file:
-            result = new_process.execute(command,
-                                         output_file=output_file,
-                                         expect_zero=False)
-        if result.retcode != 0:
-            self.logger.error(
-                'Coverage summary json file generation failed for \
-                    cycle: %d.', cycle)
-            if cycle != 0:
-                self.logger.error(
-                    'Coverage summary json file generation failed for \
-                        cycle: %d.', cycle)
-            else:
-                self.logger.error(
-                    'Coverage summary json file generation failed in the end.')
+
+def extract_coverage_from_json(json_file):
+    """Get the covered regions for the current trial."""
+    covered_regions = set()
+    try:
+        coverage_info = get_coverage_infomation(json_file)
+        functions_data = coverage_info['data'][0]['functions']
+        # The fourth number in the region-list indicates if the region
+        # is hit.
+        hit_index = 4
+        # The last number in the region-list indicates what type of the
+        # region it is; 'code_region' is used to obtain various code
+        # coverage statistic and is represented by number 0.
+        type_index = -1
+        # The number of index 5 represents the file number.
+        file_index = 5
+        for function_data in functions_data:
+            for region in function_data['regions']:
+                if region[hit_index] != 0 and region[type_index] == 0:
+                    covered_regions.add(
+                        tuple(region[:hit_index] + region[file_index:]))
+    except Exception:  # pylint: disable=broad-except
+        logger.error('Coverage summary json file defective or missing.')
+    return covered_regions

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -70,8 +70,11 @@ def measure_main(experiment_config):
     measure_loop(experiment, max_total_time)
 
     # Do the final measuring and store the coverage data.
-    coverage_utils.generate_all_coverage_info(experiment_config)
-    coverage_utils.upload_coverage_info_to_bucket()
+    try:
+        coverage_utils.generate_all_coverage_info(experiment_config)
+        coverage_utils.upload_coverage_info_to_bucket()
+    except Exception:
+        logger.error('Error when generating coverage info.')
 
     logger.info('Finished measuring.')
 

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -70,9 +70,8 @@ def measure_main(experiment_config):
     measure_loop(experiment, max_total_time)
 
     # Do the final measuring and store the coverage data.
-    try:
-        coverage_utils.generate_all_coverage_info(experiment_config)
-        coverage_utils.upload_coverage_info_to_bucket()
+    coverage_utils.generate_all_coverage_info(experiment_config)
+    coverage_utils.upload_coverage_info_to_bucket()
 
     logger.info('Finished measuring.')
 

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -73,8 +73,6 @@ def measure_main(experiment_config):
     try:
         coverage_utils.generate_all_coverage_info(experiment_config)
         coverage_utils.upload_coverage_info_to_bucket()
-    except Exception:
-        logger.error('Error when generating coverage info.')
 
     logger.info('Finished measuring.')
 

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -370,12 +370,12 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
 
         if result.retcode != 0:
             self.logger.error(
-                'Coverage summary json file generation failed for \
-                    cycle: %d.', cycle)
+                'Coverage summary json file generation failed for '
+                'cycle: %d.', cycle)
             if cycle != 0:
                 self.logger.error(
-                    'Coverage summary json file generation failed for \
-                        cycle: %d.', cycle)
+                    'Coverage summary json file generation failed for '
+                    'cycle: %d.', cycle)
             else:
                 self.logger.error(
                     'Coverage summary json file generation failed in the end.')

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -56,17 +56,6 @@ def db_experiment(experiment_config, db):
     yield
 
 
-def test_get_current_covered_regions(fs, experiment):
-    """Tests that get_current_coverage reads the correct data from json file."""
-    snapshot_measurer = measurer.SnapshotMeasurer(FUZZER, BENCHMARK, TRIAL_NUM,
-                                                  SNAPSHOT_LOGGER)
-    json_cov_summary_file = get_test_data_path('cov_summary.json')
-    fs.add_real_file(json_cov_summary_file, read_only=False)
-    snapshot_measurer.cov_summary_file = json_cov_summary_file
-    covered_regions = snapshot_measurer.get_current_covered_regions()
-    assert len(covered_regions) == 8
-
-
 def test_get_current_coverage(fs, experiment):
     """Tests that get_current_coverage reads the correct data from json file."""
     snapshot_measurer = measurer.SnapshotMeasurer(FUZZER, BENCHMARK, TRIAL_NUM,


### PR DESCRIPTION
This patch will
-generate hierarchical directory for clang coverage reports
-simplify the logic and structure of `coverage_utils.py`
-fix the edge mismatch issue by using the list