### PR TITLE
Add (libfuzzer|entropic)_(before|after) variants

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -35,8 +35,12 @@ jobs:
           - honggfuzz_qemu
           - weizz
           # Temporary variants.
+          - libfuzzer_before
+          - libfuzzer_after
           - libfuzzer_keepseed
           - libfuzzer_magicbytes
+          - entropic_before
+          - entropic_after
           - entropic_keepseed
           - entropic_magicbytes
           - entropic_exectime

--- a/fuzzers/entropic_after/builder.Dockerfile
+++ b/fuzzers/entropic_after/builder.Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+COPY patch.diff /
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project && \
+    git checkout bb54bcf84970c04c9748004f3a4cf59b0c1832a7 && \
+    patch -p1 < /patch.diff && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /libEntropic.a *.o

--- a/fuzzers/entropic_after/fuzzer.py
+++ b/fuzzers/entropic_after/fuzzer.py
@@ -1,0 +1,34 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+from fuzzers.entropic_before import fuzzer as entropic_fuzzer
+from fuzzers.libfuzzer_before import fuzzer as libfuzzer_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    entropic_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    libfuzzer_fuzzer.run_fuzzer(input_corpus,
+                                output_corpus,
+                                target_binary,
+                                extra_flags=[
+                                    '-entropic=1', '-keep_seed=1',
+                                    '-cross_over_uniformdist=1',
+                                    '-entropic_scale_per_exec_time=1'
+                                ])

--- a/fuzzers/entropic_after/patch.diff
+++ b/fuzzers/entropic_after/patch.diff
@@ -1,0 +1,400 @@
+diff --git a/compiler-rt/lib/fuzzer/FuzzerCorpus.h b/compiler-rt/lib/fuzzer/FuzzerCorpus.h
+index 54d1e09ec6d..ed7d0837659 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerCorpus.h
++++ b/compiler-rt/lib/fuzzer/FuzzerCorpus.h
+@@ -18,6 +18,7 @@
+ #include "FuzzerSHA1.h"
+ #include "FuzzerTracePC.h"
+ #include <algorithm>
++#include <chrono>
+ #include <numeric>
+ #include <random>
+ #include <unordered_set>
+@@ -26,6 +27,7 @@ namespace fuzzer {
+ 
+ struct InputInfo {
+   Unit U;  // The actual input data.
++  std::chrono::microseconds TimeOfUnit;
+   uint8_t Sha1[kSHA1NumBytes];  // Checksum.
+   // Number of features that this input has and no smaller input has.
+   size_t NumFeatures = 0;
+@@ -33,6 +35,7 @@ struct InputInfo {
+   // Stats.
+   size_t NumExecutedMutations = 0;
+   size_t NumSuccessfullMutations = 0;
++  bool SeedInput = false;
+   bool MayDeleteFile = false;
+   bool Reduced = false;
+   bool HasFocusFunction = false;
+@@ -65,7 +68,8 @@ struct InputInfo {
+   // of the seed. Since we do not know the entropy of a seed that has
+   // never been executed we assign fresh seeds maximum entropy and
+   // let II->Energy approach the true entropy from above.
+-  void UpdateEnergy(size_t GlobalNumberOfFeatures) {
++  void UpdateEnergy(size_t GlobalNumberOfFeatures, bool ScalePerExecTime,
++                    uint64_t AverageTimeOfUnit) {
+     Energy = 0.0;
+     SumIncidence = 0;
+ 
+@@ -88,6 +92,27 @@ struct InputInfo {
+     // Normalize.
+     if (SumIncidence != 0)
+       Energy = (Energy / SumIncidence) + logl(SumIncidence);
++
++    if (ScalePerExecTime) {
++      // Scaling to favor inputs with lower execution time.
++      uint32_t PerfScore = 100;
++      if (TimeOfUnit.count() * 0.1 > AverageTimeOfUnit)
++        PerfScore = 10;
++      else if (TimeOfUnit.count() * 0.25 > AverageTimeOfUnit)
++        PerfScore = 25;
++      else if (TimeOfUnit.count() * 0.5 > AverageTimeOfUnit)
++        PerfScore = 50;
++      else if (TimeOfUnit.count() * 0.75 > AverageTimeOfUnit)
++        PerfScore = 75;
++      else if (TimeOfUnit.count() * 4 < AverageTimeOfUnit)
++        PerfScore = 300;
++      else if (TimeOfUnit.count() * 3 < AverageTimeOfUnit)
++        PerfScore = 200;
++      else if (TimeOfUnit.count() * 2 < AverageTimeOfUnit)
++        PerfScore = 150;
++
++      Energy *= PerfScore;
++    }
+   }
+ 
+   // Increment the frequency of the feature Idx.
+@@ -120,6 +145,7 @@ struct EntropicOptions {
+   bool Enabled;
+   size_t NumberOfRarestFeatures;
+   size_t FeatureFrequencyThreshold;
++  bool ScalePerExecTime;
+ };
+ 
+ class InputCorpus {
+@@ -131,9 +157,12 @@ class InputCorpus {
+ 
+   EntropicOptions Entropic;
+ 
++  bool KeepSeed = false;
++
+ public:
+-  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic)
+-      : Entropic(Entropic), OutputCorpus(OutputCorpus) {
++  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic,
++              bool KeepSeed)
++      : Entropic(Entropic), OutputCorpus(OutputCorpus), KeepSeed(KeepSeed) {
+     memset(InputSizesPerFeature, 0, sizeof(InputSizesPerFeature));
+     memset(SmallestElementPerFeature, 0, sizeof(SmallestElementPerFeature));
+   }
+@@ -177,7 +206,8 @@ public:
+   bool empty() const { return Inputs.empty(); }
+   const Unit &operator[] (size_t Idx) const { return Inputs[Idx]->U; }
+   InputInfo *AddToCorpus(const Unit &U, size_t NumFeatures, bool MayDeleteFile,
+-                         bool HasFocusFunction,
++                         bool HasFocusFunction, bool SeedInput,
++                         std::chrono::microseconds TimeOfUnit,
+                          const Vector<uint32_t> &FeatureSet,
+                          const DataFlowTrace &DFT, const InputInfo *BaseII) {
+     assert(!U.empty());
+@@ -187,6 +217,8 @@ public:
+     InputInfo &II = *Inputs.back();
+     II.U = U;
+     II.NumFeatures = NumFeatures;
++    II.SeedInput = SeedInput;
++    II.TimeOfUnit = TimeOfUnit;
+     II.MayDeleteFile = MayDeleteFile;
+     II.UniqFeatureSet = FeatureSet;
+     II.HasFocusFunction = HasFocusFunction;
+@@ -276,6 +308,11 @@ public:
+     return Idx;
+   }
+ 
++  InputInfo &ChooseUnitToCrossOverWith(Random &Rand) {
++    InputInfo &II = *Inputs[Rand(Inputs.size())];
++    return II;
++  }
++
+   void PrintStats() {
+     for (size_t i = 0; i < Inputs.size(); i++) {
+       const auto &II = *Inputs[i];
+@@ -460,12 +497,18 @@ private:
+     Weights.resize(N);
+     std::iota(Intervals.begin(), Intervals.end(), 0);
+ 
++    std::chrono::microseconds TotalTimeOfUnit(0);
++    for (auto II : Inputs) {
++      TotalTimeOfUnit += II->TimeOfUnit;
++    }
++
+     bool VanillaSchedule = true;
+     if (Entropic.Enabled) {
+       for (auto II : Inputs) {
+         if (II->NeedsEnergyUpdate && II->Energy != 0.0) {
+           II->NeedsEnergyUpdate = false;
+-          II->UpdateEnergy(RareFeatures.size());
++          II->UpdateEnergy(RareFeatures.size(), Entropic.ScalePerExecTime,
++                           TotalTimeOfUnit.count() / N);
+         }
+       }
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+index bed9e84de67..c11e6a0084a 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+@@ -649,6 +649,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+   Options.Verbosity = Flags.verbosity;
+   Options.MaxLen = Flags.max_len;
+   Options.LenControl = Flags.len_control;
++  Options.KeepSeed = Flags.keep_seed;
+   Options.UnitTimeoutSec = Flags.timeout;
+   Options.ErrorExitCode = Flags.error_exitcode;
+   Options.TimeoutExitCode = Flags.timeout_exitcode;
+@@ -657,6 +658,8 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+   Options.IgnoreCrashes = Flags.ignore_crashes;
+   Options.MaxTotalTimeSec = Flags.max_total_time;
+   Options.DoCrossOver = Flags.cross_over;
++  Options.CrossOverUniformDist = Flags.cross_over_uniformdist;
++  Options.TraceSeedInput = Flags.trace_seed_input;
+   Options.MutateDepth = Flags.mutate_depth;
+   Options.ReduceDepth = Flags.reduce_depth;
+   Options.UseCounters = Flags.use_counters;
+@@ -718,6 +721,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+       (size_t)Flags.entropic_feature_frequency_threshold;
+   Options.EntropicNumberOfRarestFeatures =
+       (size_t)Flags.entropic_number_of_rarest_features;
++  Options.EntropicScalePerExecTime = Flags.entropic_scale_per_exec_time;
+   if (Options.Entropic) {
+     if (!Options.FocusFunction.empty()) {
+       Printf("ERROR: The parameters `--entropic` and `--focus_function` cannot "
+@@ -733,6 +737,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+   Entropic.FeatureFrequencyThreshold =
+       Options.EntropicFeatureFrequencyThreshold;
+   Entropic.NumberOfRarestFeatures = Options.EntropicNumberOfRarestFeatures;
++  Entropic.ScalePerExecTime = Options.EntropicScalePerExecTime;
+ 
+   unsigned Seed = Flags.seed;
+   // Initialize Seed.
+@@ -753,7 +758,8 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+ 
+   Random Rand(Seed);
+   auto *MD = new MutationDispatcher(Rand, Options);
+-  auto *Corpus = new InputCorpus(Options.OutputCorpus, Entropic);
++  auto *Corpus =
++      new InputCorpus(Options.OutputCorpus, Entropic, Options.KeepSeed);
+   auto *F = new Fuzzer(Callback, *Corpus, *MD, Options);
+ 
+   for (auto &U: Dictionary)
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFlags.def b/compiler-rt/lib/fuzzer/FuzzerFlags.def
+index 832224a705d..3f66242985d 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFlags.def
++++ b/compiler-rt/lib/fuzzer/FuzzerFlags.def
+@@ -23,7 +23,14 @@ FUZZER_FLAG_INT(len_control, 100, "Try generating small inputs first, "
+ FUZZER_FLAG_STRING(seed_inputs, "A comma-separated list of input files "
+   "to use as an additional seed corpus. Alternatively, an \"@\" followed by "
+   "the name of a file containing the comma-separated list.")
++FUZZER_FLAG_INT(keep_seed, 0, "If 1, keep all seed inputs in the corpus even if "
++  "they do not produce new coverage. This also invalidates -reduce_inputs for "
++  "seed input mutations.")
+ FUZZER_FLAG_INT(cross_over, 1, "If 1, cross over inputs.")
++FUZZER_FLAG_INT(cross_over_uniformdist, 0, "Experimental. If 1, use a uniform "
++  "probability distribution when choosing inputs to cross over with.")
++FUZZER_FLAG_INT(trace_seed_input, 0, "Internal. Print all seed inputs picked "
++  "up by the fuzzer.")
+ FUZZER_FLAG_INT(mutate_depth, 5,
+             "Apply this number of consecutive mutations to each input.")
+ FUZZER_FLAG_INT(reduce_depth, 0, "Experimental/internal. "
+@@ -161,6 +168,7 @@ FUZZER_FLAG_INT(entropic_number_of_rarest_features, 100, "Experimental. If "
+      "entropic is enabled, we keep track of the frequencies only for the "
+      "Top-X least abundant features (union features that are considered as "
+      "rare).")
++FUZZER_FLAG_INT(entropic_scale_per_exec_time, 0, "Experimental.")
+ 
+ FUZZER_FLAG_INT(analyze_dict, 0, "Experimental")
+ FUZZER_DEPRECATED_FLAG(use_clang_coverage)
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFork.cpp b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+index d9e6b79443e..97e91cbe869 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFork.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+@@ -309,11 +309,20 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
+   else
+     Env.MainCorpusDir = CorpusDirs[0];
+ 
+-  auto CFPath = DirPlusFile(Env.TempDir, "merge.txt");
+-  CrashResistantMerge(Env.Args, {}, SeedFiles, &Env.Files, {}, &Env.Features,
+-                      {}, &Env.Cov,
+-                      CFPath, false);
+-  RemoveFile(CFPath);
++  if (Options.KeepSeed) {
++    for (auto &File : SeedFiles)
++      Env.Files.push_back(File.File);
++  } else {
++    auto CFPath = DirPlusFile(Env.TempDir, "merge.txt");
++    CrashResistantMerge(Env.Args, {}, SeedFiles, &Env.Files, {}, &Env.Features,
++                        {}, &Env.Cov, CFPath, false);
++    RemoveFile(CFPath);
++  }
++  if (Options.TraceSeedInput) {
++    for (auto &File : Env.Files) {
++      Printf("INFO: seed - %s\n", File.c_str());
++    }
++  }
+   Printf("INFO: -fork=%d: %zd seed inputs, starting to fuzz in %s\n", NumJobs,
+          Env.Files.size(), Env.TempDir.c_str());
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerInternal.h b/compiler-rt/lib/fuzzer/FuzzerInternal.h
+index 31096ce804b..e75807209f5 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerInternal.h
++++ b/compiler-rt/lib/fuzzer/FuzzerInternal.h
+@@ -119,6 +119,8 @@ private:
+ 
+   size_t LastCorpusUpdateRun = 0;
+ 
++  bool IsExecutingSeedCorpora = false;
++
+   bool HasMoreMallocsThanFrees = false;
+   size_t NumberOfLeakDetectionAttempts = 0;
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+index 02db6d27b0a..65a02c35758 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+@@ -469,6 +469,7 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
+     return false;
+ 
+   ExecuteCallback(Data, Size);
++  auto TimeOfUnit = duration_cast<microseconds>(UnitStopTime - UnitStartTime);
+ 
+   UniqFeatureSetTmp.clear();
+   size_t FoundUniqFeaturesOfII = 0;
+@@ -478,7 +479,7 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
+       UniqFeatureSetTmp.push_back(Feature);
+     if (Options.Entropic)
+       Corpus.UpdateFeatureFrequency(II, Feature);
+-    if (Options.ReduceInputs && II)
++    if (Options.ReduceInputs && II && !(Options.KeepSeed && II->SeedInput))
+       if (std::binary_search(II->UniqFeatureSet.begin(),
+                              II->UniqFeatureSet.end(), Feature))
+         FoundUniqFeaturesOfII++;
+@@ -487,11 +488,12 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
+     *FoundUniqFeatures = FoundUniqFeaturesOfII;
+   PrintPulseAndReportSlowInput(Data, Size);
+   size_t NumNewFeatures = Corpus.NumFeatureUpdates() - NumUpdatesBefore;
+-  if (NumNewFeatures) {
++  if (NumNewFeatures || (Options.KeepSeed && IsExecutingSeedCorpora)) {
+     TPC.UpdateObservedPCs();
+     auto NewII = Corpus.AddToCorpus({Data, Data + Size}, NumNewFeatures,
+                                     MayDeleteFile, TPC.ObservedFocusFunction(),
+-                                    UniqFeatureSetTmp, DFT, II);
++                                    IsExecutingSeedCorpora,
++                                    TimeOfUnit, UniqFeatureSetTmp, DFT, II);
+     WriteFeatureSetToFile(Options.FeaturesDir, Sha1ToString(NewII->Sha1),
+                           NewII->UniqFeatureSet);
+     return true;
+@@ -664,8 +666,14 @@ void Fuzzer::MutateAndTestOne() {
+   MD.StartMutationSequence();
+ 
+   auto &II = Corpus.ChooseUnitToMutate(MD.GetRand());
+-  if (Options.DoCrossOver)
+-    MD.SetCrossOverWith(&Corpus.ChooseUnitToMutate(MD.GetRand()).U);
++  if (Options.DoCrossOver) {
++    if (Options.CrossOverUniformDist) {
++      MD.SetCrossOverWith(&Corpus.ChooseUnitToCrossOverWith(MD.GetRand()).U);
++    }
++    else {
++      MD.SetCrossOverWith(&Corpus.ChooseUnitToMutate(MD.GetRand()).U);
++    }
++  }
+   const auto &U = II.U;
+   memcpy(BaseSha1, II.Sha1, sizeof(BaseSha1));
+   assert(CurrentUnitData);
+@@ -764,6 +772,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+       assert(CorporaFiles.front().Size <= CorporaFiles.back().Size);
+     }
+ 
++    IsExecutingSeedCorpora = true;
++
+     // Load and execute inputs one by one.
+     for (auto &SF : CorporaFiles) {
+       auto U = FileToVector(SF.File, MaxInputLen, /*ExitOnError=*/false);
+@@ -773,6 +783,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+       TryDetectingAMemoryLeak(U.data(), U.size(),
+                               /*DuringInitialCorpusExecution*/ true);
+     }
++
++    IsExecutingSeedCorpora = false;
+   }
+ 
+   PrintStats("INITED");
+@@ -785,6 +797,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+              Corpus.NumInputsThatTouchFocusFunction());
+   }
+ 
++  Printf("INFO: corpus size = %d\n", Corpus.size());
++
+   if (Corpus.empty() && Options.MaxNumberOfRuns) {
+     Printf("ERROR: no interesting inputs were found. "
+            "Is the code instrumented for coverage? Exiting.\n");
+diff --git a/compiler-rt/lib/fuzzer/FuzzerOptions.h b/compiler-rt/lib/fuzzer/FuzzerOptions.h
+index b75e7c7af70..9b98383b4aa 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerOptions.h
++++ b/compiler-rt/lib/fuzzer/FuzzerOptions.h
+@@ -18,6 +18,7 @@ struct FuzzingOptions {
+   int Verbosity = 1;
+   size_t MaxLen = 0;
+   size_t LenControl = 1000;
++  bool KeepSeed = false;
+   int UnitTimeoutSec = 300;
+   int TimeoutExitCode = 70;
+   int OOMExitCode = 71;
+@@ -30,6 +31,8 @@ struct FuzzingOptions {
+   int RssLimitMb = 0;
+   int MallocLimitMb = 0;
+   bool DoCrossOver = true;
++  bool CrossOverUniformDist = false;
++  bool TraceSeedInput = false;
+   int MutateDepth = 5;
+   bool ReduceDepth = false;
+   bool UseCounters = false;
+@@ -47,6 +50,7 @@ struct FuzzingOptions {
+   bool Entropic = false;
+   size_t EntropicFeatureFrequencyThreshold = 0xFF;
+   size_t EntropicNumberOfRarestFeatures = 100;
++  bool EntropicScalePerExecTime = false;
+   std::string OutputCorpus;
+   std::string ArtifactPrefix = "./";
+   std::string ExactArtifactPath;
+diff --git a/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp b/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
+index 0e9435ab8fc..dfc642ab6d0 100644
+--- a/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
++++ b/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
+@@ -593,7 +593,8 @@ TEST(Corpus, Distribution) {
+   DataFlowTrace DFT;
+   Random Rand(0);
+   struct EntropicOptions Entropic = {false, 0xFF, 100};
+-  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic));
++  bool KeepSeed = false;
++  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic, KeepSeed));
+   size_t N = 10;
+   size_t TriesPerUnit = 1<<16;
+   for (size_t i = 0; i < N; i++)
+@@ -1057,7 +1058,8 @@ TEST(Entropic, UpdateFrequency) {
+   size_t Index;
+   // Create input corpus with default entropic configuration
+   struct EntropicOptions Entropic = {true, 0xFF, 100};
+-  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic));
++  bool KeepSeed = false;
++  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic, KeepSeed));
+   std::unique_ptr<InputInfo> II(new InputInfo());
+ 
+   C->AddRareFeature(FeatIdx1);
+@@ -1094,7 +1096,8 @@ double SubAndSquare(double X, double Y) {
+ TEST(Entropic, ComputeEnergy) {
+   const double Precision = 0.01;
+   struct EntropicOptions Entropic = {true, 0xFF, 100};
+-  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic));
++  bool KeepSeed = false;
++  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic, KeepSeed));
+   std::unique_ptr<InputInfo> II(new InputInfo());
+   Vector<std::pair<uint32_t, uint16_t>> FeatureFreqs = {{1, 3}, {2, 3}, {3, 3}};
+   II->FeatureFreqs = FeatureFreqs;

--- a/fuzzers/entropic_after/runner.Dockerfile
+++ b/fuzzers/entropic_after/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-runner

--- a/fuzzers/entropic_before/builder.Dockerfile
+++ b/fuzzers/entropic_before/builder.Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project && \
+    git checkout 8ef9e2bf355d05bc81d8b0fe1e5333eec59a0a91 && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /libEntropic.a *.o

--- a/fuzzers/entropic_before/fuzzer.py
+++ b/fuzzers/entropic_before/fuzzer.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for Entropic fuzzer."""
+
+import os
+
+from fuzzers import utils
+from fuzzers.libfuzzer_before import fuzzer as libfuzzer_fuzzer
+
+# TODO(metzman): Delete entropic before making the project public.
+
+
+def build():
+    """Build benchmark."""
+    cflags = ['-fsanitize=fuzzer-no-link']
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cflags)
+
+    os.environ['CC'] = 'clang'
+    os.environ['CXX'] = 'clang++'
+    os.environ['FUZZER_LIB'] = '/libEntropic.a'
+
+    utils.build_benchmark()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    libfuzzer_fuzzer.run_fuzzer(input_corpus,
+                                output_corpus,
+                                target_binary,
+                                extra_flags=['-entropic=1'])

--- a/fuzzers/entropic_before/runner.Dockerfile
+++ b/fuzzers/entropic_before/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/libfuzzer_after/builder.Dockerfile
+++ b/fuzzers/libfuzzer_after/builder.Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+COPY patch.diff /
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/ && \
+    git checkout bb54bcf84970c04c9748004f3a4cf59b0c1832a7 && \
+    patch -p1 < /patch.diff && \
+    cd compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_after/fuzzer.py
+++ b/fuzzers/libfuzzer_after/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+from fuzzers.libfuzzer_before import fuzzer as libfuzzer_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    libfuzzer_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    libfuzzer_fuzzer.run_fuzzer(
+        input_corpus,
+        output_corpus,
+        target_binary,
+        extra_flags=['-keep_seed=1', '-cross_over_uniformdist=1'])

--- a/fuzzers/libfuzzer_after/patch.diff
+++ b/fuzzers/libfuzzer_after/patch.diff
@@ -1,0 +1,284 @@
+commit 72e16fc7160185305eee536c257a478ae84f7082
+Author: Dokyung Song <dokyungs@google.com>
+Date:   Fri Jul 31 00:07:20 2020 +0000
+
+    [libFuzzer] Optionally keep initial seed inputs regardless of whether they discover new features or not.
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerCorpus.h b/compiler-rt/lib/fuzzer/FuzzerCorpus.h
+index 54d1e09ec6d..5c687013c59 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerCorpus.h
++++ b/compiler-rt/lib/fuzzer/FuzzerCorpus.h
+@@ -33,6 +33,7 @@ struct InputInfo {
+   // Stats.
+   size_t NumExecutedMutations = 0;
+   size_t NumSuccessfullMutations = 0;
++  bool SeedInput = false;
+   bool MayDeleteFile = false;
+   bool Reduced = false;
+   bool HasFocusFunction = false;
+@@ -131,9 +132,12 @@ class InputCorpus {
+ 
+   EntropicOptions Entropic;
+ 
++  bool KeepSeed = false;
++
+ public:
+-  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic)
+-      : Entropic(Entropic), OutputCorpus(OutputCorpus) {
++  InputCorpus(const std::string &OutputCorpus, EntropicOptions Entropic,
++              bool KeepSeed)
++      : Entropic(Entropic), OutputCorpus(OutputCorpus), KeepSeed(KeepSeed) {
+     memset(InputSizesPerFeature, 0, sizeof(InputSizesPerFeature));
+     memset(SmallestElementPerFeature, 0, sizeof(SmallestElementPerFeature));
+   }
+@@ -177,7 +181,7 @@ public:
+   bool empty() const { return Inputs.empty(); }
+   const Unit &operator[] (size_t Idx) const { return Inputs[Idx]->U; }
+   InputInfo *AddToCorpus(const Unit &U, size_t NumFeatures, bool MayDeleteFile,
+-                         bool HasFocusFunction,
++                         bool HasFocusFunction, bool SeedInput,
+                          const Vector<uint32_t> &FeatureSet,
+                          const DataFlowTrace &DFT, const InputInfo *BaseII) {
+     assert(!U.empty());
+@@ -187,6 +191,7 @@ public:
+     InputInfo &II = *Inputs.back();
+     II.U = U;
+     II.NumFeatures = NumFeatures;
++    II.SeedInput = SeedInput;
+     II.MayDeleteFile = MayDeleteFile;
+     II.UniqFeatureSet = FeatureSet;
+     II.HasFocusFunction = HasFocusFunction;
+@@ -276,6 +281,11 @@ public:
+     return Idx;
+   }
+ 
++  InputInfo &ChooseUnitToCrossOverWith(Random &Rand) {
++    InputInfo &II = *Inputs[Rand(Inputs.size())];
++    return II;
++  }
++
+   void PrintStats() {
+     for (size_t i = 0; i < Inputs.size(); i++) {
+       const auto &II = *Inputs[i];
+diff --git a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+index 8339697396c..0933af56804 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+@@ -649,6 +649,7 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+   Options.Verbosity = Flags.verbosity;
+   Options.MaxLen = Flags.max_len;
+   Options.LenControl = Flags.len_control;
++  Options.KeepSeed = Flags.keep_seed;
+   Options.UnitTimeoutSec = Flags.timeout;
+   Options.ErrorExitCode = Flags.error_exitcode;
+   Options.TimeoutExitCode = Flags.timeout_exitcode;
+@@ -657,6 +658,8 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+   Options.IgnoreCrashes = Flags.ignore_crashes;
+   Options.MaxTotalTimeSec = Flags.max_total_time;
+   Options.DoCrossOver = Flags.cross_over;
++  Options.CrossOverUniformDist = Flags.cross_over_uniformdist;
++  Options.TraceSeedInput = Flags.trace_seed_input;
+   Options.MutateDepth = Flags.mutate_depth;
+   Options.ReduceDepth = Flags.reduce_depth;
+   Options.UseCounters = Flags.use_counters;
+@@ -753,7 +756,8 @@ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
+ 
+   Random Rand(Seed);
+   auto *MD = new MutationDispatcher(Rand, Options);
+-  auto *Corpus = new InputCorpus(Options.OutputCorpus, Entropic);
++  auto *Corpus =
++      new InputCorpus(Options.OutputCorpus, Entropic, Options.KeepSeed);
+   auto *F = new Fuzzer(Callback, *Corpus, *MD, Options);
+ 
+   for (auto &U: Dictionary)
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFlags.def b/compiler-rt/lib/fuzzer/FuzzerFlags.def
+index 832224a705d..10b1f5f539a 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFlags.def
++++ b/compiler-rt/lib/fuzzer/FuzzerFlags.def
+@@ -23,7 +23,14 @@ FUZZER_FLAG_INT(len_control, 100, "Try generating small inputs first, "
+ FUZZER_FLAG_STRING(seed_inputs, "A comma-separated list of input files "
+   "to use as an additional seed corpus. Alternatively, an \"@\" followed by "
+   "the name of a file containing the comma-separated list.")
++FUZZER_FLAG_INT(keep_seed, 0, "If 1, keep all seed inputs in the corpus even if "
++  "they do not produce new coverage. This also invalidates -reduce_inputs for "
++  "seed input mutations.")
+ FUZZER_FLAG_INT(cross_over, 1, "If 1, cross over inputs.")
++FUZZER_FLAG_INT(cross_over_uniformdist, 0, "Experimental. If 1, use a uniform "
++  "probability distribution when choosing inputs to cross over with.")
++FUZZER_FLAG_INT(trace_seed_input, 0, "Internal. Print all seed inputs picked "
++  "up by the fuzzer.")
+ FUZZER_FLAG_INT(mutate_depth, 5,
+             "Apply this number of consecutive mutations to each input.")
+ FUZZER_FLAG_INT(reduce_depth, 0, "Experimental/internal. "
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFork.cpp b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+index d9e6b79443e..97e91cbe869 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFork.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+@@ -309,11 +309,20 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
+   else
+     Env.MainCorpusDir = CorpusDirs[0];
+ 
+-  auto CFPath = DirPlusFile(Env.TempDir, "merge.txt");
+-  CrashResistantMerge(Env.Args, {}, SeedFiles, &Env.Files, {}, &Env.Features,
+-                      {}, &Env.Cov,
+-                      CFPath, false);
+-  RemoveFile(CFPath);
++  if (Options.KeepSeed) {
++    for (auto &File : SeedFiles)
++      Env.Files.push_back(File.File);
++  } else {
++    auto CFPath = DirPlusFile(Env.TempDir, "merge.txt");
++    CrashResistantMerge(Env.Args, {}, SeedFiles, &Env.Files, {}, &Env.Features,
++                        {}, &Env.Cov, CFPath, false);
++    RemoveFile(CFPath);
++  }
++  if (Options.TraceSeedInput) {
++    for (auto &File : Env.Files) {
++      Printf("INFO: seed - %s\n", File.c_str());
++    }
++  }
+   Printf("INFO: -fork=%d: %zd seed inputs, starting to fuzz in %s\n", NumJobs,
+          Env.Files.size(), Env.TempDir.c_str());
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerInternal.h b/compiler-rt/lib/fuzzer/FuzzerInternal.h
+index 31096ce804b..e75807209f5 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerInternal.h
++++ b/compiler-rt/lib/fuzzer/FuzzerInternal.h
+@@ -119,6 +119,8 @@ private:
+ 
+   size_t LastCorpusUpdateRun = 0;
+ 
++  bool IsExecutingSeedCorpora = false;
++
+   bool HasMoreMallocsThanFrees = false;
+   size_t NumberOfLeakDetectionAttempts = 0;
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+index 02db6d27b0a..28d5f32c0d6 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+@@ -478,7 +478,7 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
+       UniqFeatureSetTmp.push_back(Feature);
+     if (Options.Entropic)
+       Corpus.UpdateFeatureFrequency(II, Feature);
+-    if (Options.ReduceInputs && II)
++    if (Options.ReduceInputs && II && !(Options.KeepSeed && II->SeedInput))
+       if (std::binary_search(II->UniqFeatureSet.begin(),
+                              II->UniqFeatureSet.end(), Feature))
+         FoundUniqFeaturesOfII++;
+@@ -487,11 +487,12 @@ bool Fuzzer::RunOne(const uint8_t *Data, size_t Size, bool MayDeleteFile,
+     *FoundUniqFeatures = FoundUniqFeaturesOfII;
+   PrintPulseAndReportSlowInput(Data, Size);
+   size_t NumNewFeatures = Corpus.NumFeatureUpdates() - NumUpdatesBefore;
+-  if (NumNewFeatures) {
++  if (NumNewFeatures || (Options.KeepSeed && IsExecutingSeedCorpora)) {
+     TPC.UpdateObservedPCs();
+-    auto NewII = Corpus.AddToCorpus({Data, Data + Size}, NumNewFeatures,
+-                                    MayDeleteFile, TPC.ObservedFocusFunction(),
+-                                    UniqFeatureSetTmp, DFT, II);
++    auto NewII =
++        Corpus.AddToCorpus({Data, Data + Size}, NumNewFeatures, MayDeleteFile,
++                           TPC.ObservedFocusFunction(),
++                           IsExecutingSeedCorpora, UniqFeatureSetTmp, DFT, II);
+     WriteFeatureSetToFile(Options.FeaturesDir, Sha1ToString(NewII->Sha1),
+                           NewII->UniqFeatureSet);
+     return true;
+@@ -664,8 +665,14 @@ void Fuzzer::MutateAndTestOne() {
+   MD.StartMutationSequence();
+ 
+   auto &II = Corpus.ChooseUnitToMutate(MD.GetRand());
+-  if (Options.DoCrossOver)
+-    MD.SetCrossOverWith(&Corpus.ChooseUnitToMutate(MD.GetRand()).U);
++  if (Options.DoCrossOver) {
++    if (Options.CrossOverUniformDist) {
++      MD.SetCrossOverWith(&Corpus.ChooseUnitToCrossOverWith(MD.GetRand()).U);
++    }
++    else {
++      MD.SetCrossOverWith(&Corpus.ChooseUnitToMutate(MD.GetRand()).U);
++    }
++  }
+   const auto &U = II.U;
+   memcpy(BaseSha1, II.Sha1, sizeof(BaseSha1));
+   assert(CurrentUnitData);
+@@ -764,6 +771,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+       assert(CorporaFiles.front().Size <= CorporaFiles.back().Size);
+     }
+ 
++    IsExecutingSeedCorpora = true;
++
+     // Load and execute inputs one by one.
+     for (auto &SF : CorporaFiles) {
+       auto U = FileToVector(SF.File, MaxInputLen, /*ExitOnError=*/false);
+@@ -773,6 +782,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+       TryDetectingAMemoryLeak(U.data(), U.size(),
+                               /*DuringInitialCorpusExecution*/ true);
+     }
++
++    IsExecutingSeedCorpora = false;
+   }
+ 
+   PrintStats("INITED");
+@@ -785,6 +796,8 @@ void Fuzzer::ReadAndExecuteSeedCorpora(Vector<SizedFile> &CorporaFiles) {
+              Corpus.NumInputsThatTouchFocusFunction());
+   }
+ 
++  Printf("INFO: corpus size = %d\n", Corpus.size());
++
+   if (Corpus.empty() && Options.MaxNumberOfRuns) {
+     Printf("ERROR: no interesting inputs were found. "
+            "Is the code instrumented for coverage? Exiting.\n");
+diff --git a/compiler-rt/lib/fuzzer/FuzzerOptions.h b/compiler-rt/lib/fuzzer/FuzzerOptions.h
+index 9d975bd61fe..bb2c14be47b 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerOptions.h
++++ b/compiler-rt/lib/fuzzer/FuzzerOptions.h
+@@ -18,6 +18,7 @@ struct FuzzingOptions {
+   int Verbosity = 1;
+   size_t MaxLen = 0;
+   size_t LenControl = 1000;
++  bool KeepSeed = false;
+   int UnitTimeoutSec = 300;
+   int TimeoutExitCode = 70;
+   int OOMExitCode = 71;
+@@ -30,6 +31,8 @@ struct FuzzingOptions {
+   int RssLimitMb = 0;
+   int MallocLimitMb = 0;
+   bool DoCrossOver = true;
++  bool CrossOverUniformDist = false;
++  bool TraceSeedInput = false;
+   int MutateDepth = 5;
+   bool ReduceDepth = false;
+   bool UseCounters = false;
+diff --git a/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp b/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
+index 0e9435ab8fc..dfc642ab6d0 100644
+--- a/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
++++ b/compiler-rt/lib/fuzzer/tests/FuzzerUnittest.cpp
+@@ -593,7 +593,8 @@ TEST(Corpus, Distribution) {
+   DataFlowTrace DFT;
+   Random Rand(0);
+   struct EntropicOptions Entropic = {false, 0xFF, 100};
+-  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic));
++  bool KeepSeed = false;
++  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic, KeepSeed));
+   size_t N = 10;
+   size_t TriesPerUnit = 1<<16;
+   for (size_t i = 0; i < N; i++)
+@@ -1057,7 +1058,8 @@ TEST(Entropic, UpdateFrequency) {
+   size_t Index;
+   // Create input corpus with default entropic configuration
+   struct EntropicOptions Entropic = {true, 0xFF, 100};
+-  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic));
++  bool KeepSeed = false;
++  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic, KeepSeed));
+   std::unique_ptr<InputInfo> II(new InputInfo());
+ 
+   C->AddRareFeature(FeatIdx1);
+@@ -1094,7 +1096,8 @@ double SubAndSquare(double X, double Y) {
+ TEST(Entropic, ComputeEnergy) {
+   const double Precision = 0.01;
+   struct EntropicOptions Entropic = {true, 0xFF, 100};
+-  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic));
++  bool KeepSeed = false;
++  std::unique_ptr<InputCorpus> C(new InputCorpus("", Entropic, KeepSeed));
+   std::unique_ptr<InputInfo> II(new InputInfo());
+   Vector<std::pair<uint32_t, uint16_t>> FeatureFreqs = {{1, 3}, {2, 3}, {3, 3}};
+   II->FeatureFreqs = FeatureFreqs;

--- a/fuzzers/libfuzzer_after/runner.Dockerfile
+++ b/fuzzers/libfuzzer_after/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-runner

--- a/fuzzers/libfuzzer_before/builder.Dockerfile
+++ b/fuzzers/libfuzzer_before/builder.Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/ && \
+    git checkout 8ef9e2bf355d05bc81d8b0fe1e5333eec59a0a91 && \
+    cd compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_before/fuzzer.py
+++ b/fuzzers/libfuzzer_before/fuzzer.py
@@ -1,0 +1,73 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+import subprocess
+import os
+
+from fuzzers import utils
+
+
+def build():
+    """Build benchmark."""
+    # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
+    # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
+    # allows us to link against a version of LibFuzzer that we specify.
+    cflags = ['-fsanitize=fuzzer-no-link']
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cflags)
+
+    os.environ['CC'] = 'clang'
+    os.environ['CXX'] = 'clang++'
+    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
+
+    utils.build_benchmark()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling
+    run_fuzzer."""
+    run_fuzzer(input_corpus, output_corpus, target_binary)
+
+
+def run_fuzzer(input_corpus, output_corpus, target_binary, extra_flags=None):
+    """Run fuzzer."""
+    if extra_flags is None:
+        extra_flags = []
+
+    flags = [
+        '-print_final_stats=1',
+        # `close_fd_mask` to prevent too much logging output from the target.
+        '-close_fd_mask=3',
+        # Run in fork mode to allow ignoring ooms, timeouts, crashes and
+        # continue fuzzing indefinitely.
+        '-fork=1',
+        '-ignore_ooms=1',
+        '-ignore_timeouts=1',
+        '-ignore_crashes=1',
+
+        # Don't use LSAN's leak detection. Other fuzzers won't be using it and
+        # using it will cause libFuzzer to find "crashes" no one cares about.
+        '-detect_leaks=0',
+    ]
+    flags += extra_flags
+    if 'ADDITIONAL_ARGS' in os.environ:
+        flags += os.environ['ADDITIONAL_ARGS'].split(' ')
+    dictionary_path = utils.get_dictionary_path(target_binary)
+    if dictionary_path:
+        flags.append('-dict=' + dictionary_path)
+
+    command = [target_binary, output_corpus, input_corpus] + flags
+    print('[run_fuzzer] Running command: ' + ' '.join(command))
+    subprocess.check_call(command)

--- a/fuzzers/libfuzzer_before/runner.Dockerfile
+++ b/fuzzers/libfuzzer_before/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -16,6 +16,13 @@
 # You can run "make presubmit" to do basic validation on this file.
 # Please add new experiment requests towards the top of this file.
 
+- experiment: 2020-08-26
+  fuzzers:
+    - libfuzzer_before
+    - libfuzzer_after
+    - entropic_before
+    - entropic_after
+
 - experiment: 2020-08-25
   fuzzers:
     - libfuzzer_magicbytes


### PR DESCRIPTION
`libfuzzer_after` is the same as `libfuzzer_keepseed`.
`entropic_after` is the same as `entropic_keepseed` (which in turn is based on `entropic_exectime`).

The above two variants are all based on the following llvm commit, which contains interceptor/fixcrossover patch.
https://github.com/llvm/llvm-project/commits/bb54bcf84970c04c9748004f3a4cf59b0c1832a7

`libfuzzer_before` and `entropic_before` are based on the following llvm commit, before interceptor/fixcrossover appeared.
https://github.com/llvm/llvm-project/commits/8ef9e2bf355d05bc81d8b0fe1e5333eec59a0a91