### PR TITLE
Improve fuzzer and benchmark validation

### DIFF
--- a/common/benchmark_utils.py
+++ b/common/benchmark_utils.py
@@ -20,7 +20,8 @@ from common import logs
 from common import benchmark_config
 from common import utils
 
-VALID_BENCHMARK_REGEX = re.compile(r'^[A-Za-z0-9\._\-]+$')
+# Must be valid in a docker tag.
+VALID_BENCHMARK_REGEX = re.compile(r'^[a-z0-9\._\-]+$')
 BENCHMARKS_DIR = os.path.join(utils.ROOT_DIR, 'benchmarks')
 
 

--- a/common/benchmark_utils.py
+++ b/common/benchmark_utils.py
@@ -27,12 +27,6 @@ VALID_BENCHMARK_REGEX = re.compile(r'^[a-z0-9\._\-]+$')
 BENCHMARKS_DIR = os.path.join(utils.ROOT_DIR, 'benchmarks')
 
 
-def get_project(benchmark):
-    """Returns the OSS-Fuzz project of |benchmark| if it is based on an
-    OSS-Fuzz project, otherwise raises ValueError."""
-    return benchmark_config.get_config(benchmark)['project']
-
-
 def get_fuzz_target(benchmark):
     """Returns the fuzz target of |benchmark|"""
     return benchmark_config.get_config(benchmark)['fuzz_target']
@@ -69,9 +63,11 @@ def validate(benchmark):
     """Returns True if |benchmark| is a valid fuzzbench benchmark."""
     if not validate_name(benchmark):
         return False
+
     if benchmark not in get_all_benchmarks():
         logs.error('%s must have a benchmark.yaml.', benchmark)
         return False
+
     try:
         get_fuzz_target(benchmark)
     except yaml.parser.ParserError:

--- a/common/fuzzer_utils.py
+++ b/common/fuzzer_utils.py
@@ -98,14 +98,22 @@ def get_fuzz_target_binary(search_directory: str,
     return None
 
 
-def validate(fuzzer):
-    """Return True if |fuzzer| is a valid fuzzbench fuzzer."""
+def validate_name(fuzzer):
+    """Return True if |fuzzer| is a valid fuzzbench fuzzer name."""
     # Although importing probably allows a subset of what the regex allows, use
     # the regex anyway to be safe. The regex is enforcing that the fuzzer is a
     # valid path for GCS or a linux system.
     if VALID_FUZZER_REGEX.match(fuzzer) is None:
-        logs.error('%s does not conform to %s pattern.', fuzzer,
+        logs.error('Fuzzer: %s does not conform to pattern: %s.', fuzzer,
                    VALID_FUZZER_REGEX.pattern)
+        return False
+
+    return True
+
+
+def validate(fuzzer):
+    """Return True if |fuzzer| is a valid fuzzbench fuzzer."""
+    if not validate_name(fuzzer):
         return False
 
     # Try importing the fuzzer module.

--- a/common/fuzzer_utils.py
+++ b/common/fuzzer_utils.py
@@ -23,7 +23,10 @@ from common import utils
 
 DEFAULT_FUZZ_TARGET_NAME = 'fuzz-target'
 FUZZ_TARGET_SEARCH_STRING = b'LLVMFuzzerTestOneInput'
-VALID_FUZZER_REGEX = re.compile(r'^[A-Za-z0-9_]+$')
+
+# Must be a valid python module and docker tag.
+VALID_FUZZER_REGEX = re.compile(r'^[a-z0-9_]+$')
+
 FUZZERS_DIR = os.path.join(utils.ROOT_DIR, 'fuzzers')
 COVERAGE_TOOLS = {'coverage', 'coverage_source_based'}
 

--- a/common/test_benchmark_utils.py
+++ b/common/test_benchmark_utils.py
@@ -40,3 +40,19 @@ def test_get_runner_image_url(benchmark, expected_url, oss_fuzz_benchmark):
     assert benchmark_utils.get_runner_image_url('experiment', benchmark,
                                                 'fuzzer',
                                                 DOCKER_REGISTRY) == expected_url
+
+
+@pytest.mark.parametrize(('benchmark_name',), [
+    ('libPNG',),
+    ('libpng!',),
+])
+def test_validate_name_invalid(benchmark_name):
+    """Tests that validate_name returns False for am invalid benchmark name."""
+    assert not benchmark_utils.validate_name(benchmark_name)
+
+
+@pytest.mark.parametrize(('benchmark_name',), [('libpng',), ('libpng_1',),
+                                               ('libpng-1',), ('libpng.1',)])
+def test_validate_name_valid(benchmark_name):
+    """Tests that validate_name returns True for a valid benchmark name."""
+    assert benchmark_utils.validate_name(benchmark_name)

--- a/common/test_fuzzer_utils.py
+++ b/common/test_fuzzer_utils.py
@@ -59,10 +59,12 @@ def test_found_fuzzer_containing_string_without_fuzzer_name_arg(fs, environ):
 
 @pytest.mark.parametrize(('fuzzer_name',), [('afl++',), ('mopt-afl',),
                                             ('mOptAFL',), ('AFL',)])
-def test_validate_invalid_fuzzer_name(fuzzer_name):
-    assert not fuzzer_utils.validate(fuzzer_name)
+def test_validate_name_invalid(fuzzer_name):
+    """Tests that validate_name returns True for an invalid fuzzer name."""
+    assert not fuzzer_utils.validate_name(fuzzer_name)
 
 
 @pytest.mark.parametrize(('fuzzer_name',), [('afl',), ('mopt_afl',), ('afl2',)])
-def test_validate_valid_fuzzer_name(fuzzer_name):
-    assert not fuzzer_utils.validate(fuzzer_name)
+def test_validate_name_valid(fuzzer_name):
+    """Tests that validate_name returns True for a valid fuzzer name."""
+    assert fuzzer_utils.validate_name(fuzzer_name)

--- a/common/test_fuzzer_utils.py
+++ b/common/test_fuzzer_utils.py
@@ -60,7 +60,7 @@ def test_found_fuzzer_containing_string_without_fuzzer_name_arg(fs, environ):
 @pytest.mark.parametrize(('fuzzer_name',), [('afl++',), ('mopt-afl',),
                                             ('mOptAFL',), ('AFL',)])
 def test_validate_name_invalid(fuzzer_name):
-    """Tests that validate_name returns True for an invalid fuzzer name."""
+    """Tests that validate_name returns False for an invalid fuzzer name."""
     assert not fuzzer_utils.validate_name(fuzzer_name)
 
 

--- a/common/test_fuzzer_utils.py
+++ b/common/test_fuzzer_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for fuzzer_utils.py."""
+import pytest
+
 from common import fuzzer_utils
 
 # pylint: disable=invalid-name,unused-argument
@@ -53,3 +55,14 @@ def test_found_fuzzer_containing_string_without_fuzzer_name_arg(fs, environ):
     fs.create_file('/out/custom-target', contents='\n\nLLVMFuzzerTestOneInput')
     assert fuzzer_utils.get_fuzz_target_binary('/out',
                                                None) == ('/out/custom-target')
+
+
+@pytest.mark.parametrize(('fuzzer_name',), [('afl++',), ('mopt-afl',),
+                                            ('mOptAFL',), ('AFL',)])
+def test_validate_invalid_fuzzer_name(fuzzer_name):
+    assert not fuzzer_utils.validate(fuzzer_name)
+
+
+@pytest.mark.parametrize(('fuzzer_name',), [('afl',), ('mopt_afl',), ('afl2',)])
+def test_validate_valid_fuzzer_name(fuzzer_name):
+    assert not fuzzer_utils.validate(fuzzer_name)


### PR DESCRIPTION
Don't allow capital letters as GCB doesn't like them in docker image names.
Add tests.
Do more to validate benchmark.yaml.