### PR TITLE
Fix exceptions from clang cov.

### DIFF
--- a/analysis/coverage_data_utils.py
+++ b/analysis/coverage_data_utils.py
@@ -50,6 +50,7 @@ def get_covered_regions_dict(experiment_df):
                 benchmark_df, benchmark, fuzzer)
             key = get_fuzzer_benchmark_key(fuzzer, benchmark)
             covered_regions_dict[key] = fuzzer_covered_regions
+
     return covered_regions_dict
 
 
@@ -61,6 +62,10 @@ def get_fuzzer_covered_regions(benchmark_df, benchmark, fuzzer):
         src_filestore_path = get_fuzzer_filestore_path(benchmark_df, fuzzer)
         src_file = posixpath.join(src_filestore_path, 'coverage', 'data',
                                   benchmark, fuzzer, 'covered_regions.json')
+        if filestore_utils.ls(src_file, must_exist=False).retcode:
+            # Error occurred, coverage file does not exit. Bail out.
+            return {}
+
         filestore_utils.cp(src_file, dst_file)
         with open(dst_file) as json_file:
             return json.load(json_file)

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -161,12 +161,6 @@ def generate_report(experiment_names,
 
     data_utils.validate_data(experiment_df)
 
-    # Load the json summary file.
-    coverage_dict = {}
-    if coverage_report:
-        coverage_dict = coverage_data_utils.get_covered_regions_dict(
-            experiment_df)
-
     if benchmarks is not None:
         experiment_df = data_utils.filter_benchmarks(experiment_df, benchmarks)
 
@@ -182,6 +176,12 @@ def generate_report(experiment_names,
     if merge_with_clobber or merge_with_clobber_nonprivate:
         experiment_df = data_utils.clobber_experiments_data(
             experiment_df, experiment_names)
+
+    # Load the coverage json summary file.
+    coverage_dict = {}
+    if coverage_report:
+        coverage_dict = coverage_data_utils.get_covered_regions_dict(
+            experiment_df)
 
     fuzzer_names = experiment_df.fuzzer.unique()
     plotter = plotting.Plotter(fuzzer_names, quick, log_scale)


### PR DESCRIPTION
- Move coverage calculation after |experiment_df| is filtered.
This avoids iterating on data that is not required, e.g. filtered
fuzzers from an experiment.
- Fix exception when coverage_regions.cov is missing for a particular
fuzzer-benchmark pair.