### PR TITLE
Don't clear existing coverage jsons in report generation.

### DIFF
--- a/experiment/reporter.py
+++ b/experiment/reporter.py
@@ -68,12 +68,13 @@ def output_report(experiment_config: dict,
             in_progress=in_progress,
             merge_with_clobber_nonprivate=merge_with_nonprivate,
             coverage_report=coverage_report)
-        filestore_utils.rsync(str(reports_dir),
-                              web_filestore_path,
-                              gsutil_options=[
-                                  '-h',
-                                  'Cache-Control:public,max-age=0,no-transform'
-                              ])
+        filestore_utils.rsync(
+            str(reports_dir),
+            web_filestore_path,
+            delete=False,  # Don't remove existing coverage jsons.
+            gsutil_options=[
+                '-h', 'Cache-Control:public,max-age=0,no-transform'
+            ])
         logger.debug('Done generating report.')
     except data_utils.EmptyDataError:
         logs.warning('No snapshot data.')

--- a/experiment/test_reporter.py
+++ b/experiment/test_reporter.py
@@ -46,8 +46,7 @@ def test_output_report_filestore(fs, experiment):
             reports_dir = os.path.join(os.environ['WORK'], 'reports')
             assert mocked_popen.commands == [[
                 'gsutil', '-h', 'Cache-Control:public,max-age=0,no-transform',
-                'rsync', '-d', '-r', reports_dir,
-                'gs://web-reports/test-experiment'
+                'rsync', '-r', reports_dir, 'gs://web-reports/test-experiment'
             ]]
             experiment_name = os.environ['EXPERIMENT']
             mocked_generate_report.assert_called_with(


### PR DESCRIPTION
Switch report directory rsync to not delete existing reports
directory on GCS as it will contain clang coverage reports.
This is a regression from the recent clang coverage switch
where we keep coverage_reports.json in reports dir.