### PR TITLE
[AFLSmart] support target taking multiple file formats (e.g., bloaty)

### DIFF
--- a/fuzzers/aflsmart/README.md
+++ b/fuzzers/aflsmart/README.md
@@ -12,5 +12,7 @@
 
 5. vorbis-2017-12-11
 
+6. bloaty_fuzz_target
+
 Since the experiment summary diagram of the default FuzzBench report is automatically generated based on the results of all benchmarks, many of them have not been supported by AFLSmart, the ranking of AFLSmart in that diagram may not be correct.
 

--- a/fuzzers/aflsmart/builder.Dockerfile
+++ b/fuzzers/aflsmart/builder.Dockerfile
@@ -38,7 +38,7 @@ RUN add-apt-repository --keyserver hkps://keyserver.ubuntu.com:443 ppa:ubuntu-to
 # Download and compile AFLSmart
 RUN git clone https://github.com/aflsmart/aflsmart /afl && \
     cd /afl && \
-    git checkout 5fb84f3b6a0ec24059958c498fc691de01bc5fcc && \
+    git checkout ce6686245fe051cdb39d0dd52f5335137ab2c14c && \
     AFL_NO_X86=1 make
 
 # Setup Peach.

--- a/fuzzers/aflsmart/fuzzer.py
+++ b/fuzzers/aflsmart/fuzzer.py
@@ -39,6 +39,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     os.environ['PATH'] += os.pathsep + '/out/peach-3.0.202/'
 
+    composite_mode = False
     input_model = ''
     benchmark_name = os.environ['BENCHMARK']
     if benchmark_name == 'libpng-1.2.56':
@@ -51,21 +52,31 @@ def fuzz(input_corpus, output_corpus, target_binary):
         input_model = 'xtf.xml'
     if benchmark_name == 'vorbis-2017-12-11':
         input_model = 'ogg.xml'
+    if benchmark_name == 'bloaty_fuzz_target':
+        input_model = 'bloaty_composite.xml'
+        composite_mode = True
+
+    additional_flags=[
+        # Enable stacked mutations
+        '-h',
+        # Enable structure-aware fuzzing
+        '-w',
+        'peach',
+        # Select input model
+        '-g',
+        input_model,
+    ]
+
+    # Enable composite mode for targets
+    # taking multiple input formats like bloaty
+    if composite_mode == True:
+        additional_flags.append('-c')
 
     if input_model != '':
         afl_fuzzer.run_afl_fuzz(
             input_corpus,
             output_corpus,
             target_binary,
-            additional_flags=[
-                # Enable stacked mutations
-                '-h',
-                # Enable structure-aware fuzzing
-                '-w',
-                'peach',
-                # Select input model
-                '-g',
-                input_model,
-            ])
+            additional_flags)
     else:
         afl_fuzzer.run_afl_fuzz(input_corpus, output_corpus, target_binary)


### PR DESCRIPTION
This PR adds an experimental feature allowing AFLSmart to fuzz programs taking multiple input formats like Bloaty McBloatface (https://github.com/google/bloaty). To fuzz those programs, the -c option should be enabled and a composite pit (like bloaty_composite.xml) should be specified.