### PR TITLE
Clang code coverage fixes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -257,7 +257,8 @@ good-names=i,
            Run,
            logger,
            _,
-           df
+           df,
+           fs
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no

--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -92,7 +92,7 @@ class BenchmarkResults:
     def _benchmark_aggregated_coverage_df(self):
         """Aggregated covered regions of each fuzzer on this benchmark."""
         return coverage_data_utils.get_benchmark_aggregated_cov_df(
-            self._benchmark_coverage_dict)
+            self._coverage_dict, self.name)
 
     @property
     @functools.lru_cache()

--- a/analysis/coverage_data_utils.py
+++ b/analysis/coverage_data_utils.py
@@ -115,15 +115,16 @@ def get_benchmark_cov_dict(coverage_dict, benchmark):
     return benchmark_cov_dict
 
 
-def get_benchmark_aggregated_cov_df(benchmark_coverage_dict):
+def get_benchmark_aggregated_cov_df(coverage_dict, benchmark):
     """Returns a dataframe where each row represents a fuzzer and its
     aggregated coverage number."""
     dict_to_transform = {'fuzzer': [], 'aggregated_edges_covered': []}
-    for fuzzer in benchmark_coverage_dict:
-        aggregated_edges_covered = len(benchmark_coverage_dict[fuzzer])
-        dict_to_transform['fuzzer'].append(fuzzer)
-        dict_to_transform['aggregated_edges_covered'].append(
-            aggregated_edges_covered)
+    for key_pair, covered_regions in coverage_dict.items():
+        current_fuzzer, current_benchmark = key_pair.split()
+        if current_benchmark == benchmark:
+            dict_to_transform['fuzzer'].append(current_fuzzer)
+            dict_to_transform['aggregated_edges_covered'].append(
+                len(covered_regions))
     return pd.DataFrame(dict_to_transform)
 
 

--- a/analysis/plotting.py
+++ b/analysis/plotting.py
@@ -206,7 +206,7 @@ class Plotter:
                        ax=axes)
 
         axes.set_title(_formatted_title(benchmark_snapshot_df))
-        axes.set(ylabel='Reached edge coverage')
+        axes.set(ylabel='Reached region coverage')
         axes.set(xlabel='Fuzzer (highest median coverage on the left)')
         axes.set_xticklabels(axes.get_xticklabels(),
                              rotation=_DEFAULT_LABEL_ROTATION,
@@ -274,7 +274,7 @@ class Plotter:
                            ax=axes)
 
         axes.set_title(_formatted_title(benchmark_snapshot_df))
-        axes.set(ylabel='Reached edge coverage')
+        axes.set(ylabel='Reached region coverage')
         axes.set(xlabel='Fuzzer (highest median coverage on the left)')
         axes.set_xticklabels(axes.get_xticklabels(),
                              rotation=_DEFAULT_LABEL_ROTATION,

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -242,12 +242,12 @@
 
                         <div class="row">
                             <div class="col s6 offset-s3">
-                                <h5 class="center-align">Ranking by unique edge covered</h4>
+                                <h5 class="center-align">Ranking by unique regions covered</h4>
                                     <img class="responsive-img materialboxed"
                                          src="{{ benchmark.unique_coverage_ranking_plot }}">
-                                    Each bar shows the total number of edges found by a given fuzzer.
-                                    The colored area shows the number of unique edges
-                                    (i.e., edges that were not covered by any other fuzzers).
+                                    Each bar shows the total number of regions found by a given fuzzer.
+                                    The colored area shows the number of unique regions
+                                    (i.e., regions that were not covered by any other fuzzers).
                             </div>
                         </div> <!-- row -->
 
@@ -256,7 +256,7 @@
                                 <h5 class="center-align">Pairwise unique coverage</h4>
                                     <img class="responsive-img materialboxed"
                                          src="{{ benchmark.pairwise_unique_coverage_plot }}">
-                                    Each cell represents the number of edges covered by the fuzzer
+                                    Each cell represents the number of regions covered by the fuzzer
                                     of the column but not by the fuzzer of the row
                             </div>
                         </div> <!-- row -->

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -16,6 +16,7 @@
 import os
 import json
 
+from common import experiment_path as exp_path
 from common import experiment_utils as exp_utils
 from common import new_process
 from common import benchmark_utils
@@ -39,15 +40,9 @@ def get_coverage_info_dir():
     return os.path.join(work_dir, 'coverage')
 
 
-def upload_coverage_info_to_bucket():
-    """Copies the coverage reports and json summary files to gcs bucket."""
-    src_dir = get_coverage_info_dir()
-    dst_dir = exp_utils.get_experiment_filestore_path()
-    filestore_utils.cp(src_dir, dst_dir, recursive=True, parallel=True)
-
-
 def generate_coverage_reports(experiment_config: dict):
     """Generates coverage reports for each benchmark and fuzzer."""
+    logs.initialize()
     logger.info('Start generating coverage reports.')
 
     benchmarks = experiment_config['benchmarks']
@@ -63,19 +58,29 @@ def generate_coverage_reports(experiment_config: dict):
 
 def generate_coverage_report(experiment, benchmark, fuzzer):
     """Generates the coverage report for one pair of benchmark and fuzzer."""
-    logs.initialize()
     logger.info(
         ('Generating coverage report for '
          'benchmark: {benchmark} fuzzer: {fuzzer}.').format(benchmark=benchmark,
                                                             fuzzer=fuzzer))
 
-    coverage_reporter = CoverageReporter(experiment, fuzzer, benchmark)
-    # Merges all the profdata files.
-    coverage_reporter.merge_profdata_files()
-    # Generates the reports using llvm-cov.
-    coverage_reporter.generate_cov_report()
+    try:
+        coverage_reporter = CoverageReporter(experiment, fuzzer, benchmark)
 
-    logger.info('Finished generating coverage report.')
+        # Merges all the profdata files.
+        coverage_reporter.merge_profdata_files()
+
+        # Generate the coverage summary json file based on merged profdata file.
+        coverage_reporter.generate_coverage_summary_json()
+
+        # Generate the coverage regions json file.
+        coverage_reporter.generate_coverage_regions_json()
+
+        # Generates the html reports using llvm-cov.
+        coverage_reporter.generate_coverage_report()
+
+        logger.info('Finished generating coverage report.')
+    except Exception:  # pylint: disable=broad-except
+        logger.error('Error occurred when generating coverage report.')
 
 
 class CoverageReporter:  # pylint: disable=too-many-instance-attributes
@@ -88,18 +93,25 @@ class CoverageReporter:  # pylint: disable=too-many-instance-attributes
         self.benchmark = benchmark
         self.experiment = experiment
         self.trial_ids = get_trial_ids(experiment, fuzzer, benchmark)
-        cov_report_directory = get_coverage_report_dir()
-        self.report_dir = os.path.join(cov_report_directory, benchmark, fuzzer)
+
         coverage_info_dir = get_coverage_info_dir()
-        self.json_file_dir = os.path.join(coverage_info_dir, 'data', benchmark,
-                                          fuzzer)
+        self.report_dir = os.path.join(coverage_info_dir, 'reports', benchmark,
+                                       fuzzer)
+        self.data_dir = os.path.join(coverage_info_dir, 'data', benchmark,
+                                     fuzzer)
+
         benchmark_fuzzer_dir = exp_utils.get_benchmark_fuzzer_dir(
             benchmark, fuzzer)
         work_dir = exp_utils.get_work_dir()
-        self.merged_profdata_file = os.path.join(work_dir,
-                                                 'measurement-folders',
-                                                 benchmark_fuzzer_dir,
-                                                 'merged.profdata')
+
+        benchmark_fuzzer_measurement_dir = os.path.join(work_dir,
+                                                        'measurement-folders',
+                                                        benchmark_fuzzer_dir)
+        self.merged_profdata_file = os.path.join(
+            benchmark_fuzzer_measurement_dir, 'merged.profdata')
+        self.merged_summary_json_file = os.path.join(
+            benchmark_fuzzer_measurement_dir, 'merged.json')
+
         coverage_binaries_dir = build_utils.get_coverage_binaries_dir()
         self.source_files_dir = os.path.join(coverage_binaries_dir, benchmark)
         self.binary_file = get_coverage_binary(benchmark)
@@ -109,16 +121,34 @@ class CoverageReporter:  # pylint: disable=too-many-instance-attributes
         logger.info('Merging profdata for fuzzer: '
                     '{fuzzer},benchmark: {benchmark}.'.format(
                         fuzzer=self.fuzzer, benchmark=self.benchmark))
-        files_to_merge = [
-            TrialCoverage(self.fuzzer, self.benchmark, trial_id,
-                          logger).profdata_file for trial_id in self.trial_ids
-        ]
+
+        files_to_merge = []
+        for trial_id in self.trial_ids:
+            profdata_file = TrialCoverage(self.fuzzer, self.benchmark,
+                                          trial_id).profdata_file
+            if not os.path.exists(profdata_file):
+                continue
+            files_to_merge.append(profdata_file)
+
         result = merge_profdata_files(files_to_merge, self.merged_profdata_file)
         if result.retcode != 0:
             logger.error('Profdata files merging failed.')
 
-    def generate_cov_report(self):
-        """Generates the coverage report."""
+    def generate_coverage_summary_json(self):
+        """Generates the coverage summary json from merged profdata file."""
+        coverage_binary = get_coverage_binary(self.benchmark)
+        result = generate_json_summary(coverage_binary,
+                                       self.merged_profdata_file,
+                                       self.merged_summary_json_file,
+                                       summary_only=False)
+        if result.retcode != 0:
+            logger.error(
+                'Merged coverage summary json file generation failed for '
+                'fuzzer: {fuzzer},benchmark: {benchmark}.'.format(
+                    fuzzer=self.fuzzer, benchmark=self.benchmark))
+
+    def generate_coverage_report(self):
+        """Generates the coverage report and stores in bucket."""
         command = [
             'llvm-cov', 'show', '-format=html',
             '-path-equivalence=/,{prefix}'.format(prefix=self.source_files_dir),
@@ -127,19 +157,29 @@ class CoverageReporter:  # pylint: disable=too-many-instance-attributes
             '-instr-profile={profdata}'.format(
                 profdata=self.merged_profdata_file)
         ]
-        result = new_process.execute(command)
+        result = new_process.execute(command, expect_zero=False)
         if result.retcode != 0:
             logger.error('Coverage report generation failed for '
                          'fuzzer: {fuzzer},benchmark: {benchmark}.'.format(
                              fuzzer=self.fuzzer, benchmark=self.benchmark))
+            return
 
-    def generate_json_summary_file(self, covered_regions):
+        src_dir = self.report_dir
+        dst_dir = exp_path.filestore(self.report_dir)
+        filestore_utils.cp(src_dir, dst_dir, recursive=True, parallel=True)
+
+    def generate_coverage_regions_json(self):
         """Stores the coverage data in a json file."""
-        json_src_dir = self.json_file_dir
-        filesystem.create_directory(json_src_dir)
-        json_src = os.path.join(json_src_dir, 'covered_regions.json')
-        with open(json_src, 'w') as src_file:
-            json.dump(covered_regions, src_file)
+        covered_regions = extract_covered_regions_from_summary_json(
+            self.merged_summary_json_file)
+        coverage_json_src = os.path.join(self.data_dir, 'covered_regions.json')
+        coverage_json_dst = exp_path.filestore(coverage_json_src)
+        filesystem.create_directory(self.data_dir)
+        with open(coverage_json_src, 'w') as file_handle:
+            json.dump(covered_regions, file_handle)
+        filestore_utils.cp(coverage_json_src,
+                           coverage_json_dst,
+                           expect_zero=False)
 
 
 def get_coverage_archive_name(benchmark):
@@ -150,12 +190,6 @@ def get_coverage_archive_name(benchmark):
 def get_profdata_file_name(trial_id):
     """Returns the profdata file name for |trial_id|."""
     return 'data-{id}.profdata'.format(id=trial_id)
-
-
-def get_coverage_report_dir():
-    """Returns the directory to store all the coverage reports."""
-    coverage_info_dir = get_coverage_info_dir()
-    return os.path.join(coverage_info_dir, 'reports')
 
 
 def get_coverage_binary(benchmark: str) -> str:
@@ -195,68 +229,13 @@ def get_coverage_infomation(coverage_summary_file):
         return json.loads(summary.readlines()[-1])
 
 
-def store_coverage_data(experiment_config: dict):
-    """Generates the specific coverage data and store in cloud bucket."""
-    logger.info('Storing all fuzzer-benchmark pairs for final coverage data.')
-
-    benchmarks = experiment_config['benchmarks']
-    fuzzers = experiment_config['fuzzers']
-    experiment = experiment_config['experiment']
-
-    for benchmark in benchmarks:
-        for fuzzer in fuzzers:
-            store_covered_region(experiment, fuzzer, benchmark)
-
-    logger.info('Finished storing coverage data')
-
-
-def store_covered_region(experiment: str, fuzzer: str, benchmark: str):
-    """Gets the final covered region for a specific pair of fuzzer-benchmark."""
-    logs.initialize()
-    logger.debug('Storing covered region: fuzzer: %s, benchmark: %s.', fuzzer,
-                 benchmark)
-
-    covered_regions = get_covered_region(experiment, fuzzer, benchmark)
-    coverage_reporter = CoverageReporter(experiment, fuzzer, benchmark)
-    coverage_reporter.generate_json_summary_file(covered_regions)
-
-    logger.debug('Finished storing covered region: fuzzer: %s, benchmark: %s.',
-                 fuzzer, benchmark)
-
-
-def get_covered_region(experiment: str, fuzzer: str, benchmark: str):
-    """Gets covered regions for |fuzzer| on |benchmark|."""
-    logger.debug('Measuring covered region: fuzzer: %s, benchmark: %s.', fuzzer,
-                 benchmark)
-    covered_regions = set()
-    trial_ids = get_trial_ids(experiment, fuzzer, benchmark)
-    for trial_id in trial_ids:
-        logger.info('Measuring covered region: trial_id = %d.', trial_id)
-        snapshot_logger = logs.Logger('measurer',
-                                      default_extras={
-                                          'fuzzer': fuzzer,
-                                          'benchmark': benchmark,
-                                          'trial_id': str(trial_id),
-                                      })
-        trial_coverage = TrialCoverage(fuzzer, benchmark, trial_id,
-                                       snapshot_logger)
-        trial_coverage.generate_summary(0, summary_only=False)
-        new_covered_regions = trial_coverage.get_current_covered_regions()
-        covered_regions = covered_regions.union(new_covered_regions)
-    logger.debug('Done measuring covered region: fuzzer: %s, benchmark: %s.',
-                 fuzzer, benchmark)
-    return list(covered_regions)
-
-
 class TrialCoverage:  # pylint: disable=too-many-instance-attributes
     """Base class for storing and getting coverage data for a trial."""
 
-    def __init__(self, fuzzer: str, benchmark: str, trial_num: int,
-                 trial_logger: logs.Logger):
+    def __init__(self, fuzzer: str, benchmark: str, trial_num: int):
         self.fuzzer = fuzzer
         self.benchmark = benchmark
         self.trial_num = trial_num
-        self.logger = trial_logger
         self.benchmark_fuzzer_trial_dir = exp_utils.get_trial_dir(
             fuzzer, benchmark, trial_num)
         self.work_dir = exp_utils.get_work_dir()
@@ -268,58 +247,48 @@ class TrialCoverage:  # pylint: disable=too-many-instance-attributes
         # Store the profdata file for the current trial.
         self.profdata_file = os.path.join(self.report_dir, 'data.profdata')
 
-        # Store the coverage information in json form.
-        self.cov_summary_file = os.path.join(self.report_dir,
-                                             'cov_summary.json')
 
-    def get_current_covered_regions(self):
-        """Get the covered regions for the current trial."""
-        covered_regions = set()
-        try:
-            coverage_info = get_coverage_infomation(self.cov_summary_file)
-            functions_data = coverage_info['data'][0]['functions']
-            # The fourth number in the region-list indicates if the region
-            # is hit.
-            hit_index = 4
-            # The last number in the region-list indicates what type of the
-            # region it is; 'code_region' is used to obtain various code
-            # coverage statistic and is represented by number 0.
-            type_index = -1
-            # The number of index 5 represents the file number.
-            file_index = 5
-            for function_data in functions_data:
-                for region in function_data['regions']:
-                    if region[hit_index] != 0 and region[type_index] == 0:
-                        covered_regions.add(
-                            tuple(region[:hit_index] + region[file_index:]))
-        except Exception:  # pylint: disable=broad-except
-            self.logger.error(
-                'Coverage summary json file defective or missing.')
-        return covered_regions
+def generate_json_summary(coverage_binary,
+                          profdata_file,
+                          output_file,
+                          summary_only=True):
+    """Generates the json summary file from |coverage_binary|
+    and |profdata_file|."""
+    command = [
+        'llvm-cov', 'export', '-format=text', coverage_binary,
+        '-instr-profile=%s' % profdata_file
+    ]
 
-    def generate_summary(self, cycle: int, summary_only=True):
-        """Transforms the .profdata file into json form."""
-        coverage_binary = get_coverage_binary(self.benchmark)
-        command = [
-            'llvm-cov', 'export', '-format=text', coverage_binary,
-            '-instr-profile=%s' % self.profdata_file
-        ]
+    if summary_only:
+        command.append('-summary-only')
 
-        if summary_only:
-            command.append('-summary-only')
+    with open(output_file, 'w') as dst_file:
+        result = new_process.execute(command,
+                                     output_file=dst_file,
+                                     expect_zero=False)
+    return result
 
-        with open(self.cov_summary_file, 'w') as output_file:
-            result = new_process.execute(command,
-                                         output_file=output_file,
-                                         expect_zero=False)
-        if result.retcode != 0:
-            self.logger.error(
-                'Coverage summary json file generation failed for \
-                    cycle: %d.', cycle)
-            if cycle != 0:
-                self.logger.error(
-                    'Coverage summary json file generation failed for \
-                        cycle: %d.', cycle)
-            else:
-                self.logger.error(
-                    'Coverage summary json file generation failed in the end.')
+
+def extract_covered_regions_from_summary_json(summary_json_file):
+    """Returns the covered regions given a coverage summary json file."""
+    covered_regions = []
+    try:
+        coverage_info = get_coverage_infomation(summary_json_file)
+        functions_data = coverage_info['data'][0]['functions']
+        # The fourth number in the region-list indicates if the region
+        # is hit.
+        hit_index = 4
+        # The last number in the region-list indicates what type of the
+        # region it is; 'code_region' is used to obtain various code
+        # coverage statistic and is represented by number 0.
+        type_index = -1
+        # The number of index 5 represents the file number.
+        file_index = 5
+        for function_data in functions_data:
+            for region in function_data['regions']:
+                if region[hit_index] != 0 and region[type_index] == 0:
+                    covered_regions.append(region[:hit_index] +
+                                           region[file_index:])
+    except Exception:  # pylint: disable=broad-except
+        logger.error('Coverage summary json file defective or missing.')
+    return covered_regions

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -15,6 +15,7 @@
 """Module for measuring snapshots from trial runners."""
 
 import collections
+import gc
 import multiprocessing
 import os
 import pathlib
@@ -69,10 +70,11 @@ def measure_main(experiment_config):
     max_total_time = experiment_config['max_total_time']
     measure_loop(experiment, max_total_time)
 
+    # Clean up resources.
+    gc.collect()
+
     # Do the final measuring and store the coverage data.
-    coverage_utils.store_coverage_data(experiment_config)
     coverage_utils.generate_coverage_reports(experiment_config)
-    coverage_utils.upload_coverage_info_to_bucket()
 
     logger.info('Finished measuring.')
 
@@ -319,7 +321,8 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
 
     def __init__(self, fuzzer: str, benchmark: str, trial_num: int,
                  trial_logger: logs.Logger):
-        super().__init__(fuzzer, benchmark, trial_num, trial_logger)
+        super().__init__(fuzzer, benchmark, trial_num)
+        self.logger = trial_logger
         self.corpus_dir = os.path.join(self.measurement_dir, 'corpus')
 
         self.crashes_dir = os.path.join(self.measurement_dir, 'crashes')
@@ -363,6 +366,26 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
 
         self.UNIT_BLACKLIST[self.benchmark] = (
             self.UNIT_BLACKLIST[self.benchmark].union(set(crashing_units)))
+
+    def generate_summary(self, cycle: int, summary_only=True):
+        """Transforms the .profdata file into json form."""
+        coverage_binary = coverage_utils.get_coverage_binary(self.benchmark)
+        result = coverage_utils.generate_json_summary(coverage_binary,
+                                                      self.profdata_file,
+                                                      self.cov_summary_file,
+                                                      summary_only=summary_only)
+
+        if result.retcode != 0:
+            self.logger.error(
+                'Coverage summary json file generation failed for '
+                'cycle: %d.', cycle)
+            if cycle != 0:
+                self.logger.error(
+                    'Coverage summary json file generation failed for '
+                    'cycle: %d.', cycle)
+            else:
+                self.logger.error(
+                    'Coverage summary json file generation failed in the end.')
 
     def get_current_coverage(self) -> int:
         """Get the current number of lines covered."""

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -374,11 +374,7 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
                                                       self.profdata_file,
                                                       self.cov_summary_file,
                                                       summary_only=summary_only)
-
         if result.retcode != 0:
-            self.logger.error(
-                'Coverage summary json file generation failed for '
-                'cycle: %d.', cycle)
             if cycle != 0:
                 self.logger.error(
                     'Coverage summary json file generation failed for '

--- a/experiment/test_coverage_utils.py
+++ b/experiment/test_coverage_utils.py
@@ -24,7 +24,7 @@ def get_test_data_path(*subpaths):
     return os.path.join(TEST_DATA_PATH, *subpaths)
 
 
-def test_get_current_covered_regions(fs):
+def test_extract_covered_regions_from_summary_json(fs):
     """Tests that extract_covered_regions_from_summary_json returns the covered
     regions from summary json file."""
     summary_json_file = get_test_data_path('cov_summary.json')

--- a/experiment/test_coverage_utils.py
+++ b/experiment/test_coverage_utils.py
@@ -1,0 +1,34 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions andsss
+# limitations under the License.
+"""Tests for coverage_utils.py"""
+import os
+
+from experiment import coverage_utils
+
+TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'test_data')
+
+
+def get_test_data_path(*subpaths):
+    """Returns the path of |subpaths| relative to TEST_DATA_PATH."""
+    return os.path.join(TEST_DATA_PATH, *subpaths)
+
+
+def test_get_current_covered_regions(fs):
+    """Tests that extract_covered_regions_from_summary_json returns the covered
+    regions from summary json file."""
+    summary_json_file = get_test_data_path('cov_summary.json')
+    fs.add_real_file(summary_json_file, read_only=False)
+    covered_regions = coverage_utils.extract_covered_regions_from_summary_json(
+        summary_json_file)
+    assert len(covered_regions) == 15

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -56,17 +56,6 @@ def db_experiment(experiment_config, db):
     yield
 
 
-def test_get_current_covered_regions(fs, experiment):
-    """Tests that get_current_coverage reads the correct data from json file."""
-    snapshot_measurer = measurer.SnapshotMeasurer(FUZZER, BENCHMARK, TRIAL_NUM,
-                                                  SNAPSHOT_LOGGER)
-    json_cov_summary_file = get_test_data_path('cov_summary.json')
-    fs.add_real_file(json_cov_summary_file, read_only=False)
-    snapshot_measurer.cov_summary_file = json_cov_summary_file
-    covered_regions = snapshot_measurer.get_current_covered_regions()
-    assert len(covered_regions) == 8
-
-
 def test_get_current_coverage(fs, experiment):
     """Tests that get_current_coverage reads the correct data from json file."""
     snapshot_measurer = measurer.SnapshotMeasurer(FUZZER, BENCHMARK, TRIAL_NUM,


### PR DESCRIPTION
- In preperation for breaking up measurer into individual bots,
  sync report and data files individually for each
  (fuzzer, benchmark) combination. This ensures that we get
  data from non-failing runs, while failing ones will be logged.
- Try-catch global on coverage run for each pair, otherwise
  measurer process will silently exit and it won't be possible
  to debug root cause.
- Fix bug where profdata might not exist for some trial pairs,
  so ignore those. Otherwise, merging of profdata files will
  fail.
- Fix llvm-cov new_process call to not exception when failed
  to generate html files. See expect_zero=False with logging
  of error.
- Fix region calculation issue pointed in
  https://github.com/google/fuzzbench/pull/692. Uptake fix
  after Ruikang internship.
- Fixes #714, use regions instead of edges after clang code
  coverage switch.