### PR TITLE
Add libfuzzer and entropic norestart variants

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -35,8 +35,11 @@ jobs:
           - honggfuzz_qemu
           - weizz
           # Temporary variants.
+          - libfuzzer_norestart
           - libfuzzer_magicbytes
           - entropic_magicbytes
+          - entropic_norestart_noexectime
+          - entropic_norestart_yesexectime
           - aflplusplus_qemu5
           - aflplusplus_pre3
           - aflplusplus_pre3_fix

--- a/fuzzers/entropic/builder.Dockerfile
+++ b/fuzzers/entropic/builder.Dockerfile
@@ -18,7 +18,7 @@ FROM $parent_image
 RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
     cd /llvm-project && \
     git checkout 5cda4dc7b4d28fcd11307d4234c513ff779a1c6f && \
-    cd /llvm-project/compiler-rt/lib/fuzzer && \
+    cd compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
       clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
     done && wait) && \

--- a/fuzzers/entropic/fuzzer.py
+++ b/fuzzers/entropic/fuzzer.py
@@ -18,8 +18,6 @@ import os
 from fuzzers import utils
 from fuzzers.libfuzzer import fuzzer as libfuzzer_fuzzer
 
-# TODO(metzman): Delete entropic before making the project public.
-
 
 def build():
     """Build benchmark."""

--- a/fuzzers/entropic_norestart_noexectime/builder.Dockerfile
+++ b/fuzzers/entropic_norestart_noexectime/builder.Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+COPY patch.diff /
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project && \
+    git checkout 5cda4dc7b4d28fcd11307d4234c513ff779a1c6f && \
+    patch -p1 < /patch.diff && \
+    cd compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /libEntropic.a *.o

--- a/fuzzers/entropic_norestart_noexectime/fuzzer.py
+++ b/fuzzers/entropic_norestart_noexectime/fuzzer.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for Entropic fuzzer."""
+
+import os
+
+from fuzzers import utils
+from fuzzers.libfuzzer import fuzzer as libfuzzer_fuzzer
+
+def build():
+    """Build benchmark."""
+    cflags = ['-fsanitize=fuzzer-no-link']
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cflags)
+
+    os.environ['CC'] = 'clang'
+    os.environ['CXX'] = 'clang++'
+    os.environ['FUZZER_LIB'] = '/libEntropic.a'
+
+    utils.build_benchmark()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    libfuzzer_fuzzer.run_fuzzer(input_corpus,
+                                output_corpus,
+                                target_binary,
+                                extra_flags=[
+                                    '-entropic=1', '-keep_seed=1',
+                                    '-cross_over_uniform_dist=1'
+                                ])

--- a/fuzzers/entropic_norestart_noexectime/patch.diff
+++ b/fuzzers/entropic_norestart_noexectime/patch.diff
@@ -1,0 +1,100 @@
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFork.cpp b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+index 84725d2..4e1a506 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFork.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+@@ -26,6 +26,8 @@
+ #include <queue>
+ #include <sstream>
+ #include <thread>
++#include <sys/stat.h>
++#include <iostream>
+ 
+ namespace fuzzer {
+ 
+@@ -70,6 +72,8 @@ struct FuzzJob {
+   std::string SeedListPath;
+   std::string CFPath;
+   size_t      JobId;
++  bool        Executing = false;
++  Vector<std::string> CopiedSeeds;
+ 
+   int         DftTimeInSeconds = 0;
+ 
+@@ -124,7 +128,6 @@ struct GlobalEnv {
+     Cmd.addFlag("reload", "0");  // working in an isolated dir, no reload.
+     Cmd.addFlag("print_final_stats", "1");
+     Cmd.addFlag("print_funcs", "0");  // no need to spend time symbolizing.
+-    Cmd.addFlag("max_total_time", std::to_string(std::min((size_t)300, JobId)));
+     Cmd.addFlag("stop_file", StopFile());
+     if (!DataFlowBinary.empty()) {
+       Cmd.addFlag("data_flow_trace", DFTDir);
+@@ -133,11 +136,10 @@ struct GlobalEnv {
+     }
+     auto Job = new FuzzJob;
+     std::string Seeds;
+-    if (size_t CorpusSubsetSize =
+-            std::min(Files.size(), (size_t)sqrt(Files.size() + 2))) {
++    if (size_t CorpusSubsetSize = Files.size()) {
+       auto Time1 = std::chrono::system_clock::now();
+       for (size_t i = 0; i < CorpusSubsetSize; i++) {
+-        auto &SF = Files[Rand->SkewTowardsLast(Files.size())];
++        auto &SF = Files[i];
+         Seeds += (Seeds.empty() ? "" : ",") + SF;
+         CollectDFT(SF);
+       }
+@@ -213,11 +215,20 @@ struct GlobalEnv {
+     Set<uint32_t> NewFeatures, NewCov;
+     CrashResistantMerge(Args, {}, MergeCandidates, &FilesToAdd, Features,
+                         &NewFeatures, Cov, &NewCov, Job->CFPath, false);
++    RemoveFile(Job->CFPath);
+     for (auto &Path : FilesToAdd) {
+-      auto U = FileToVector(Path);
+-      auto NewPath = DirPlusFile(MainCorpusDir, Hash(U));
+-      WriteToFile(U, NewPath);
+-      Files.push_back(NewPath);
++      // Only merge files that have not been merged already.
++      if (std::find(Job->CopiedSeeds.begin(), Job->CopiedSeeds.end(), Path) == Job->CopiedSeeds.end()) {
++        // NOT THREAD SAFE: Fast check whether file still exists.
++        struct stat buffer;
++        if (stat (Path.c_str(), &buffer) == 0) {
++          auto U = FileToVector(Path);
++          auto NewPath = DirPlusFile(MainCorpusDir, Hash(U));
++          WriteToFile(U, NewPath);
++          Files.push_back(NewPath);
++          Job->CopiedSeeds.push_back(Path);
++        }
++      }
+     }
+     Features.insert(NewFeatures.begin(), NewFeatures.end());
+     Cov.insert(NewCov.begin(), NewCov.end());
+@@ -271,10 +282,19 @@ struct JobQueue {
+   }
+ };
+ 
+-void WorkerThread(JobQueue *FuzzQ, JobQueue *MergeQ) {
++void WorkerThread(GlobalEnv *Env, JobQueue *FuzzQ, JobQueue *MergeQ) {
+   while (auto Job = FuzzQ->Pop()) {
+-    // Printf("WorkerThread: job %p\n", Job);
++    Job->Executing = true;
++    int Sleep_ms = 5 * 60 * 1000;
++    std::thread([=]() {
++      std::this_thread::sleep_for(std::chrono::milliseconds(Sleep_ms / 5));
++      while (Job->Executing) {
++        Env->RunOneMergeJob(Job);
++        std::this_thread::sleep_for(std::chrono::milliseconds(Sleep_ms));
++      }
++    }).detach();
+     Job->ExitCode = ExecuteCommand(Job->Cmd);
++    Job->Executing = false;
+     MergeQ->Push(Job);
+   }
+ }
+@@ -335,7 +355,7 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
+   size_t JobId = 1;
+   Vector<std::thread> Threads;
+   for (int t = 0; t < NumJobs; t++) {
+-    Threads.push_back(std::thread(WorkerThread, &FuzzQ, &MergeQ));
++    Threads.push_back(std::thread(WorkerThread, &Env, &FuzzQ, &MergeQ));
+     FuzzQ.Push(Env.CreateNewJob(JobId++));
+   }
+ 

--- a/fuzzers/entropic_norestart_noexectime/runner.Dockerfile
+++ b/fuzzers/entropic_norestart_noexectime/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/entropic_norestart_yesexectime/builder.Dockerfile
+++ b/fuzzers/entropic_norestart_yesexectime/builder.Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+COPY patch.diff /
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project && \
+    git checkout 5cda4dc7b4d28fcd11307d4234c513ff779a1c6f && \
+    patch -p1 < /patch.diff && \
+    cd compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /libEntropic.a *.o

--- a/fuzzers/entropic_norestart_yesexectime/fuzzer.py
+++ b/fuzzers/entropic_norestart_yesexectime/fuzzer.py
@@ -1,0 +1,44 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for Entropic fuzzer."""
+
+import os
+
+from fuzzers import utils
+from fuzzers.libfuzzer import fuzzer as libfuzzer_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    cflags = ['-fsanitize=fuzzer-no-link']
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cflags)
+
+    os.environ['CC'] = 'clang'
+    os.environ['CXX'] = 'clang++'
+    os.environ['FUZZER_LIB'] = '/libEntropic.a'
+
+    utils.build_benchmark()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    libfuzzer_fuzzer.run_fuzzer(input_corpus,
+                                output_corpus,
+                                target_binary,
+                                extra_flags=[
+                                    '-entropic=1', '-keep_seed=1',
+                                    '-cross_over_uniform_dist=1',
+                                    '-entropic_scale_per_exec_time=1'
+                                ])

--- a/fuzzers/entropic_norestart_yesexectime/patch.diff
+++ b/fuzzers/entropic_norestart_yesexectime/patch.diff
@@ -1,0 +1,100 @@
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFork.cpp b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+index 84725d2..4e1a506 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFork.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+@@ -26,6 +26,8 @@
+ #include <queue>
+ #include <sstream>
+ #include <thread>
++#include <sys/stat.h>
++#include <iostream>
+ 
+ namespace fuzzer {
+ 
+@@ -70,6 +72,8 @@ struct FuzzJob {
+   std::string SeedListPath;
+   std::string CFPath;
+   size_t      JobId;
++  bool        Executing = false;
++  Vector<std::string> CopiedSeeds;
+ 
+   int         DftTimeInSeconds = 0;
+ 
+@@ -124,7 +128,6 @@ struct GlobalEnv {
+     Cmd.addFlag("reload", "0");  // working in an isolated dir, no reload.
+     Cmd.addFlag("print_final_stats", "1");
+     Cmd.addFlag("print_funcs", "0");  // no need to spend time symbolizing.
+-    Cmd.addFlag("max_total_time", std::to_string(std::min((size_t)300, JobId)));
+     Cmd.addFlag("stop_file", StopFile());
+     if (!DataFlowBinary.empty()) {
+       Cmd.addFlag("data_flow_trace", DFTDir);
+@@ -133,11 +136,10 @@ struct GlobalEnv {
+     }
+     auto Job = new FuzzJob;
+     std::string Seeds;
+-    if (size_t CorpusSubsetSize =
+-            std::min(Files.size(), (size_t)sqrt(Files.size() + 2))) {
++    if (size_t CorpusSubsetSize = Files.size()) {
+       auto Time1 = std::chrono::system_clock::now();
+       for (size_t i = 0; i < CorpusSubsetSize; i++) {
+-        auto &SF = Files[Rand->SkewTowardsLast(Files.size())];
++        auto &SF = Files[i];
+         Seeds += (Seeds.empty() ? "" : ",") + SF;
+         CollectDFT(SF);
+       }
+@@ -213,11 +215,20 @@ struct GlobalEnv {
+     Set<uint32_t> NewFeatures, NewCov;
+     CrashResistantMerge(Args, {}, MergeCandidates, &FilesToAdd, Features,
+                         &NewFeatures, Cov, &NewCov, Job->CFPath, false);
++    RemoveFile(Job->CFPath);
+     for (auto &Path : FilesToAdd) {
+-      auto U = FileToVector(Path);
+-      auto NewPath = DirPlusFile(MainCorpusDir, Hash(U));
+-      WriteToFile(U, NewPath);
+-      Files.push_back(NewPath);
++      // Only merge files that have not been merged already.
++      if (std::find(Job->CopiedSeeds.begin(), Job->CopiedSeeds.end(), Path) == Job->CopiedSeeds.end()) {
++        // NOT THREAD SAFE: Fast check whether file still exists.
++        struct stat buffer;
++        if (stat (Path.c_str(), &buffer) == 0) {
++          auto U = FileToVector(Path);
++          auto NewPath = DirPlusFile(MainCorpusDir, Hash(U));
++          WriteToFile(U, NewPath);
++          Files.push_back(NewPath);
++          Job->CopiedSeeds.push_back(Path);
++        }
++      }
+     }
+     Features.insert(NewFeatures.begin(), NewFeatures.end());
+     Cov.insert(NewCov.begin(), NewCov.end());
+@@ -271,10 +282,19 @@ struct JobQueue {
+   }
+ };
+ 
+-void WorkerThread(JobQueue *FuzzQ, JobQueue *MergeQ) {
++void WorkerThread(GlobalEnv *Env, JobQueue *FuzzQ, JobQueue *MergeQ) {
+   while (auto Job = FuzzQ->Pop()) {
+-    // Printf("WorkerThread: job %p\n", Job);
++    Job->Executing = true;
++    int Sleep_ms = 5 * 60 * 1000;
++    std::thread([=]() {
++      std::this_thread::sleep_for(std::chrono::milliseconds(Sleep_ms / 5));
++      while (Job->Executing) {
++        Env->RunOneMergeJob(Job);
++        std::this_thread::sleep_for(std::chrono::milliseconds(Sleep_ms));
++      }
++    }).detach();
+     Job->ExitCode = ExecuteCommand(Job->Cmd);
++    Job->Executing = false;
+     MergeQ->Push(Job);
+   }
+ }
+@@ -335,7 +355,7 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
+   size_t JobId = 1;
+   Vector<std::thread> Threads;
+   for (int t = 0; t < NumJobs; t++) {
+-    Threads.push_back(std::thread(WorkerThread, &FuzzQ, &MergeQ));
++    Threads.push_back(std::thread(WorkerThread, &Env, &FuzzQ, &MergeQ));
+     FuzzQ.Push(Env.CreateNewJob(JobId++));
+   }
+ 

--- a/fuzzers/entropic_norestart_yesexectime/runner.Dockerfile
+++ b/fuzzers/entropic_norestart_yesexectime/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/libfuzzer_norestart/builder.Dockerfile
+++ b/fuzzers/libfuzzer_norestart/builder.Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+COPY patch.diff /
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/ && \
+    git checkout 5cda4dc7b4d28fcd11307d4234c513ff779a1c6f && \
+    patch -p1 < /patch.diff && \    
+    cd compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_norestart/builder.Dockerfile
+++ b/fuzzers/libfuzzer_norestart/builder.Dockerfile
@@ -20,7 +20,7 @@ COPY patch.diff /
 RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
     cd /llvm-project/ && \
     git checkout 5cda4dc7b4d28fcd11307d4234c513ff779a1c6f && \
-    patch -p1 < /patch.diff && \    
+    patch -p1 < /patch.diff && \
     cd compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
       clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \

--- a/fuzzers/libfuzzer_norestart/fuzzer.py
+++ b/fuzzers/libfuzzer_norestart/fuzzer.py
@@ -1,0 +1,76 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+import subprocess
+import os
+
+from fuzzers import utils
+
+
+def build():
+    """Build benchmark."""
+    # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
+    # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
+    # allows us to link against a version of LibFuzzer that we specify.
+    cflags = ['-fsanitize=fuzzer-no-link']
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cflags)
+
+    os.environ['CC'] = 'clang'
+    os.environ['CXX'] = 'clang++'
+    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
+
+    utils.build_benchmark()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling
+    run_fuzzer."""
+    run_fuzzer(input_corpus,
+               output_corpus,
+               target_binary,
+               extra_flags=['-keep_seed=1', '-cross_over_uniform_dist=1'])
+
+
+def run_fuzzer(input_corpus, output_corpus, target_binary, extra_flags=None):
+    """Run fuzzer."""
+    if extra_flags is None:
+        extra_flags = []
+
+    flags = [
+        '-print_final_stats=1',
+        # `close_fd_mask` to prevent too much logging output from the target.
+        '-close_fd_mask=3',
+        # Run in fork mode to allow ignoring ooms, timeouts, crashes and
+        # continue fuzzing indefinitely.
+        '-fork=1',
+        '-ignore_ooms=1',
+        '-ignore_timeouts=1',
+        '-ignore_crashes=1',
+
+        # Don't use LSAN's leak detection. Other fuzzers won't be using it and
+        # using it will cause libFuzzer to find "crashes" no one cares about.
+        '-detect_leaks=0',
+    ]
+    flags += extra_flags
+    if 'ADDITIONAL_ARGS' in os.environ:
+        flags += os.environ['ADDITIONAL_ARGS'].split(' ')
+    dictionary_path = utils.get_dictionary_path(target_binary)
+    if dictionary_path:
+        flags.append('-dict=' + dictionary_path)
+
+    command = [target_binary, output_corpus, input_corpus] + flags
+    print('[run_fuzzer] Running command: ' + ' '.join(command))
+    subprocess.check_call(command)

--- a/fuzzers/libfuzzer_norestart/patch.diff
+++ b/fuzzers/libfuzzer_norestart/patch.diff
@@ -1,0 +1,100 @@
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFork.cpp b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+index 84725d2..4e1a506 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFork.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+@@ -26,6 +26,8 @@
+ #include <queue>
+ #include <sstream>
+ #include <thread>
++#include <sys/stat.h>
++#include <iostream>
+ 
+ namespace fuzzer {
+ 
+@@ -70,6 +72,8 @@ struct FuzzJob {
+   std::string SeedListPath;
+   std::string CFPath;
+   size_t      JobId;
++  bool        Executing = false;
++  Vector<std::string> CopiedSeeds;
+ 
+   int         DftTimeInSeconds = 0;
+ 
+@@ -124,7 +128,6 @@ struct GlobalEnv {
+     Cmd.addFlag("reload", "0");  // working in an isolated dir, no reload.
+     Cmd.addFlag("print_final_stats", "1");
+     Cmd.addFlag("print_funcs", "0");  // no need to spend time symbolizing.
+-    Cmd.addFlag("max_total_time", std::to_string(std::min((size_t)300, JobId)));
+     Cmd.addFlag("stop_file", StopFile());
+     if (!DataFlowBinary.empty()) {
+       Cmd.addFlag("data_flow_trace", DFTDir);
+@@ -133,11 +136,10 @@ struct GlobalEnv {
+     }
+     auto Job = new FuzzJob;
+     std::string Seeds;
+-    if (size_t CorpusSubsetSize =
+-            std::min(Files.size(), (size_t)sqrt(Files.size() + 2))) {
++    if (size_t CorpusSubsetSize = Files.size()) {
+       auto Time1 = std::chrono::system_clock::now();
+       for (size_t i = 0; i < CorpusSubsetSize; i++) {
+-        auto &SF = Files[Rand->SkewTowardsLast(Files.size())];
++        auto &SF = Files[i];
+         Seeds += (Seeds.empty() ? "" : ",") + SF;
+         CollectDFT(SF);
+       }
+@@ -213,11 +215,20 @@ struct GlobalEnv {
+     Set<uint32_t> NewFeatures, NewCov;
+     CrashResistantMerge(Args, {}, MergeCandidates, &FilesToAdd, Features,
+                         &NewFeatures, Cov, &NewCov, Job->CFPath, false);
++    RemoveFile(Job->CFPath);
+     for (auto &Path : FilesToAdd) {
+-      auto U = FileToVector(Path);
+-      auto NewPath = DirPlusFile(MainCorpusDir, Hash(U));
+-      WriteToFile(U, NewPath);
+-      Files.push_back(NewPath);
++      // Only merge files that have not been merged already.
++      if (std::find(Job->CopiedSeeds.begin(), Job->CopiedSeeds.end(), Path) == Job->CopiedSeeds.end()) {
++        // NOT THREAD SAFE: Fast check whether file still exists.
++        struct stat buffer;
++        if (stat (Path.c_str(), &buffer) == 0) {
++          auto U = FileToVector(Path);
++          auto NewPath = DirPlusFile(MainCorpusDir, Hash(U));
++          WriteToFile(U, NewPath);
++          Files.push_back(NewPath);
++          Job->CopiedSeeds.push_back(Path);
++        }
++      }
+     }
+     Features.insert(NewFeatures.begin(), NewFeatures.end());
+     Cov.insert(NewCov.begin(), NewCov.end());
+@@ -271,10 +282,19 @@ struct JobQueue {
+   }
+ };
+ 
+-void WorkerThread(JobQueue *FuzzQ, JobQueue *MergeQ) {
++void WorkerThread(GlobalEnv *Env, JobQueue *FuzzQ, JobQueue *MergeQ) {
+   while (auto Job = FuzzQ->Pop()) {
+-    // Printf("WorkerThread: job %p\n", Job);
++    Job->Executing = true;
++    int Sleep_ms = 5 * 60 * 1000;
++    std::thread([=]() {
++      std::this_thread::sleep_for(std::chrono::milliseconds(Sleep_ms / 5));
++      while (Job->Executing) {
++        Env->RunOneMergeJob(Job);
++        std::this_thread::sleep_for(std::chrono::milliseconds(Sleep_ms));
++      }
++    }).detach();
+     Job->ExitCode = ExecuteCommand(Job->Cmd);
++    Job->Executing = false;
+     MergeQ->Push(Job);
+   }
+ }
+@@ -335,7 +355,7 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
+   size_t JobId = 1;
+   Vector<std::thread> Threads;
+   for (int t = 0; t < NumJobs; t++) {
+-    Threads.push_back(std::thread(WorkerThread, &FuzzQ, &MergeQ));
++    Threads.push_back(std::thread(WorkerThread, &Env, &FuzzQ, &MergeQ));
+     FuzzQ.Push(Env.CreateNewJob(JobId++));
+   }
+ 

--- a/fuzzers/libfuzzer_norestart/runner.Dockerfile
+++ b/fuzzers/libfuzzer_norestart/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -16,6 +16,16 @@
 # You can run "make presubmit" to do basic validation on this file.
 # Please add new experiment requests towards the top of this file.
 
+- experiment: 2020-09-11
+  fuzzers:
+    - libfuzzer
+    - libfuzzer_norestart
+    - entropic
+    - entropic_norestart_noexectime
+    - entropic_norestart_yesexectime
+    - aflplusplus
+    - honggfuzz
+
 - experiment: 2020-09-10
   fuzzers:
     - aflplusplus_same1


### PR DESCRIPTION
This is to evaluate disabling libfuzzer and entropic restart every 5 minutes when -fork=1

Currently, in fork mode, LibFuzzer runs a new instance (job) every five minutes and then merges the generate corpus into the main corpus. The new LF instance (job) starts with a very small subset of the main corpus.

In this commit, in fork mode, LibFuzzer runs a new instance only when a crash is encountered and merges the current corpus into the main corpus every five minutes. The new LF instance (job) always starts with the entire main corpus. 

Some seed files might have been deleted before the merge. So, there is a thread-unsafe quick check whether the file still exists before it is merged.