### PR TITLE
Fix openthread compiler failures on CI.

### DIFF
--- a/benchmarks/openthread-2019-12-23/build.sh
+++ b/benchmarks/openthread-2019-12-23/build.sh
@@ -41,6 +41,7 @@ export CPPFLAGS="                                     \
     -DOPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE=1  \
     -DOPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE=1 \
     -DOPENTHREAD_CONFIG_UDP_FORWARD_ENABLE=1"
+sed -i 's/ -Werror/ -Wno-error/g' config*  # Disable compiler warnings.
 ./configure --enable-fuzz-targets --enable-cli --enable-ftd --enable-joiner \
     --enable-ncp --disable-docs
 make V=1 -j $(nproc)

--- a/benchmarks/openthread-2019-12-23/build.sh
+++ b/benchmarks/openthread-2019-12-23/build.sh
@@ -41,7 +41,7 @@ export CPPFLAGS="                                     \
     -DOPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE=1  \
     -DOPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE=1 \
     -DOPENTHREAD_CONFIG_UDP_FORWARD_ENABLE=1"
-sed -i 's/ -Werror/ -Wno-error/g' config*  # Disable compiler warnings.
+sed -i 's/ -Werror//g' config*  # Disable compiler warnings.
 ./configure --enable-fuzz-targets --enable-cli --enable-ftd --enable-joiner \
     --enable-ncp --disable-docs
 make V=1 -j $(nproc)


### PR DESCRIPTION
We don't need compiler warnings for fuzzing builds.

Fixes https://github.com/google/fuzzbench/pull/728#issuecomment-691801723. We cannot bump up revision as it breaks KLEE benchmark.