### PR TITLE
Fix for oauth2client exception, use google-auth library.

### DIFF
--- a/common/gce.py
+++ b/common/gce.py
@@ -14,8 +14,8 @@
 """Module for using the Google Compute Engine (GCE) API."""
 import threading
 
+import google.auth
 from googleapiclient import discovery
-from oauth2client.client import GoogleCredentials
 
 thread_local = threading.local()  # pylint: disable=invalid-name
 
@@ -23,7 +23,7 @@ thread_local = threading.local()  # pylint: disable=invalid-name
 def initialize():
     """Initialize the thread-local configuration with things we need to use the
     GCE API."""
-    credentials = GoogleCredentials.get_application_default()
+    credentials, _ = google.auth.default()
     thread_local.service = discovery.build('compute',
                                            'v1',
                                            credentials=credentials)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
 alembic==1.4.0
 google-api-python-client==1.8.2
-google-auth==1.19.1
+google-auth==1.21.2
 google-cloud-error-reporting==0.33.0
 google-cloud-logging==1.14.0
 Jinja2==2.11.1
 numpy==1.18.1
-oauth2client==4.1.3
 Orange3==3.24.1
 pandas==1.0.1
 psycopg2-binary==2.8.4


### PR DESCRIPTION
This is leading to preempted instances not getting deleted, and keeping cores occupied. oauth2client is deprecated as well, so no need to use it when we have google-auth library.

Fix for exception:
See also https://github.com/googleapis/google-api-python-client/issues/218#issuecomment-257918269

Traceback (most recent call last):
  File "/work/src/experiment/scheduler.py", line 602, in schedule_loop
    trial_instance_manager.handle_preempted_trials()
  File "/work/src/experiment/scheduler.py", line 538, in handle_preempted_trials
    if not delete_instances(instances, self.experiment_config):
  File "/work/src/experiment/scheduler.py", line 112, in delete_instances
    i for i in gce.get_instances(cloud_project, cloud_compute_zone)
  File "/work/src/experiment/scheduler.py", line 112, in <listcomp>
    i for i in gce.get_instances(cloud_project, cloud_compute_zone)
  File "/work/src/common/gce.py", line 46, in get_instances
    for instance in _get_instance_items(project, zone):
  File "/work/src/common/gce.py", line 37, in _get_instance_items
    response = request.execute()
  File "/work/.venv/lib/python3.7/site-packages/googleapiclient/_helpers.py", line 134, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/work/.venv/lib/python3.7/site-packages/googleapiclient/http.py", line 901, in execute
    headers=self.headers,
  File "/work/.venv/lib/python3.7/site-packages/googleapiclient/http.py", line 204, in _retry_request
    raise exception
  File "/work/.venv/lib/python3.7/site-packages/googleapiclient/http.py", line 177, in _retry_request
    resp, content = http.request(uri, method, *args, **kwargs)
  File "/work/.venv/lib/python3.7/site-packages/oauth2client/transport.py", line 186, in new_request
    credentials._refresh(orig_request_method)
  File "/work/.venv/lib/python3.7/site-packages/oauth2client/client.py", line 749, in _refresh
    self._do_refresh_request(http)
  File "/work/.venv/lib/python3.7/site-packages/oauth2client/client.py", line 780, in _do_refresh_request
    body=body, headers=headers)
  File "/work/.venv/lib/python3.7/site-packages/oauth2client/transport.py", line 282, in request
    connection_type=connection_type)
  File "/work/.venv/lib/python3.7/site-packages/httplib2/__init__.py", line 1994, in request
    cachekey,
  File "/work/.venv/lib/python3.7/site-packages/httplib2/__init__.py", line 1651, in _request
    conn, request_uri, method, body, headers
  File "/work/.venv/lib/python3.7/site-packages/httplib2/__init__.py", line 1558, in _conn_request
    conn.request(method, request_uri, body, headers)
  File "/usr/local/lib/python3.7/http/client.py", line 1252, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/local/lib/python3.7/http/client.py", line 1298, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/local/lib/python3.7/http/client.py", line 1247, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/local/lib/python3.7/http/client.py", line 1065, in _send_output
    self.send(chunk)
  File "/usr/local/lib/python3.7/http/client.py", line 987, in send
    self.sock.sendall(data)
  File "/usr/local/lib/python3.7/ssl.py", line 1034, in sendall
    v = self.send(byte_view[count:])
  File "/usr/local/lib/python3.7/ssl.py", line 1003, in send
    return self._sslobj.write(data)
BrokenPipeError: [Errno 32] Broken pipe

Message: Error occurred during scheduling."