### PR TITLE
Simplify pre and non-pre vms handling decisions

### DIFF
--- a/common/gce.py
+++ b/common/gce.py
@@ -18,6 +18,7 @@ import google.auth
 from googleapiclient import discovery
 
 thread_local = threading.local()  # pylint: disable=invalid-name
+NUM_RETRIES = 10
 
 
 def initialize():
@@ -34,7 +35,7 @@ def _get_instance_items(project, zone):
     instances = thread_local.service.instances()
     request = instances.list(project=project, zone=zone)
     while request is not None:
-        response = request.execute()
+        response = request.execute(num_retries=NUM_RETRIES)
         for instance in response['items']:
             yield instance
         request = instances.list_next(previous_request=request,

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Code for starting and ending trials."""
 import datetime
-import math
 import multiprocessing
 import os
 import sys
@@ -188,33 +187,16 @@ class TrialInstanceManager:  # pylint: disable=too-many-instance-attributes
     handle_preempted_trials method should be called in the scheduling loop.
     See the docstring for handle_preempted_trials for how it works.
     """
-    # Hard limit on the number of nonpreemptibles we will use. This bounds
-    # costs.
-    MAX_NONPREEMPTIBLES = 500
-
-    # The maximum fraction of total trials in the experiment that can be done
-    # using nonpreemptibles. This helps bound the cost in unexpected situations.
-    NONPREEMPTIBLES_FRACTION = 1 / 20
-
-    MAX_FRACTION_FOR_NONPREEMPTIBLES = 1 / 4
-
     # How many times the number of trials we need preemptibles can we launch.
-    MAX_PREEMPTIBLES_MULTIPLIER = 2
+    MAX_PREEMPTIBLES_MULTIPLIER = 4
 
     # How long can we keep trying preemptibles before we have to switch to a
     # nonpreemptibles or stopping the experiment.
-    PREEMPTIBLE_WINDOW_MULTIPLIER = 3
+    PREEMPTIBLE_WINDOW_MULTIPLIER = 1
 
     def __init__(self, num_trials, experiment_config):
         self.experiment_config = experiment_config
         self.num_trials = num_trials
-
-        # Bound for the number of nonpreemptibles we can start if the experiment
-        # specified preemptible_runners.
-        self.max_nonpreemptibles = min(
-            math.ceil(self.num_trials * self.NONPREEMPTIBLES_FRACTION),
-            self.MAX_NONPREEMPTIBLES)
-        logger.info('Max nonpreemptibles: %d.', self.max_nonpreemptibles)
 
         # Bound for the number of preemptibles we can start if the experiment
         # specified preemptible_runners.
@@ -233,7 +215,6 @@ class TrialInstanceManager:  # pylint: disable=too-many-instance-attributes
         self._max_time_started = None
 
         self.preempted_trials = {}
-        self.preemptible_starts_futile = False
 
         # Filter operations happening before the experiment started.
         self.last_preemptible_query = (db_utils.query(models.Experiment).filter(
@@ -312,39 +293,6 @@ class TrialInstanceManager:  # pylint: disable=too-many-instance-attributes
         # Otherwise, it's fine to create a preemptible instance.
         return True
 
-    def can_start_nonpreemptible(self, nonpreemptible_starts: int,
-                                 trials_to_run: int) -> bool:
-        """Returns True if we can start a nonpreemptible trial."""
-        if not self.experiment_config.get('preemptible_runners'):
-            # This code shouldn't be executed in a preemptible experiment.
-            # But just in case it is, it's not always OK to a non-preemptible
-            # trial in a non-preemptible experiment.
-            return True
-
-        if self.preemptible_starts_futile:
-            return False
-
-        if nonpreemptible_starts >= self.max_nonpreemptibles:
-            # Don't exceed the maximum number of nonpreemptibles.
-            return False
-
-        if (trials_to_run * self.MAX_FRACTION_FOR_NONPREEMPTIBLES >
-                self.max_nonpreemptibles):
-            # When we have trials left that can't be run on preemptibles, don't
-            # naively allow nonpreemptible creation until we hit the limit.
-            # Instead if we can't create enough nonpreemptibles to replace at
-            # least 1/4 of the remaining trials, don't create nonpreemptibles at
-            # all, the experiment can't be salvaged cheaply.
-            # TODO(metzman): This policy can be bypassed if instances are
-            # preempted one at a time. Fix this or get rid of the policy.
-            self.preemptible_starts_futile = True
-            logs.warning('Futile to replace preempted with nonpreemptibles.')
-            return False
-
-        # Supplement with nonpreemptibles if the experiment results are not so
-        # messed up that doing so won't make the result useable.
-        return True
-
     def get_preemptible_starts(self) -> int:
         """Returns the count of preemptible trials that have been started."""
         return get_started_trials(self.experiment_config['experiment']).filter(
@@ -381,14 +329,11 @@ class TrialInstanceManager:  # pylint: disable=too-many-instance-attributes
                 replacements.append(replace_trial(trial, preemptible=True))
                 continue
 
-            if self.can_start_nonpreemptible(nonpreemptible_starts,
-                                             num_to_replace):
-                # If a trial can't be replaced with a preemptible see if we can
-                # replace it with a nonpreemptible.
-                nonpreemptible_starts += 1
-                num_to_replace -= 1
-                replacements.append(replace_trial(trial, preemptible=False))
-                continue
+            # If a trial can't be replaced with a preemptible, replace it
+            # with a nonpreemptible.
+            nonpreemptible_starts += 1
+            num_to_replace -= 1
+            replacements.append(replace_trial(trial, preemptible=False))
 
         return replacements
 

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -312,21 +312,13 @@ def test_can_start_preemptible_not_preemptible_runners(preempt_exp_conf):
     'preemptible_runners' is not set to True in the experiment_config."""
     trial_instance_manager = get_trial_instance_manager(preempt_exp_conf)
     trial_instance_manager.experiment_config['preemptible_runners'] = False
-    assert not trial_instance_manager.can_start_preemptible(100)
-
-
-def test_can_start_preemptible_over_max_num(preempt_exp_conf):
-    """Tests that we bound the number of preemptible trials we start."""
-    trial_instance_manager = get_trial_instance_manager(preempt_exp_conf)
-    preemptible_starts = trial_instance_manager.max_preemptibles + 1
-    assert not trial_instance_manager.can_start_preemptible(preemptible_starts)
+    assert not trial_instance_manager.can_start_preemptible()
 
 
 def test_can_start_preemptible(preempt_exp_conf, pending_trials):
     """Tests that we can start a preemptible instance when expected."""
     trial_instance_manager = get_trial_instance_manager(preempt_exp_conf)
-    preemptible_starts = 0
-    assert trial_instance_manager.can_start_preemptible(preemptible_starts)
+    assert trial_instance_manager.can_start_preemptible()
 
 
 def test_get_preempted_trials_nonpreemptible(experiment_config, db):

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -307,46 +307,6 @@ def get_trial_instance_manager(experiment_config: dict):
     return scheduler.TrialInstanceManager(default_num_trials, experiment_config)
 
 
-def test_can_start_nonpreemptible_not_preemptible_runners(preempt_exp_conf):
-    """Tests that test_can_start_nonpreemptible returns True when
-    'preemptible_runners' is not set to True in the experiment_config."""
-    trial_instance_manager = get_trial_instance_manager(preempt_exp_conf)
-    trial_instance_manager.experiment_config['preemptible_runners'] = False
-    assert trial_instance_manager.can_start_nonpreemptible(100000, 10)
-
-
-def test_can_start_nonpreemptible_above_max(preempt_exp_conf):
-    """Tests that test_can_start_nonpreemptible returns True when we are above
-    the maximum allowed for nonpreemptibles (and 'preemptible_runners' is not
-    set to True in the experiment_config)."""
-    trial_instance_manager = get_trial_instance_manager(preempt_exp_conf)
-    trials_left_to_run = 1
-    assert not trial_instance_manager.can_start_nonpreemptible(
-        trial_instance_manager.max_nonpreemptibles, trials_left_to_run)
-
-
-def test_can_start_nonpreemptible_too_many_left(preempt_exp_conf):
-    """Tests that we don't start using nonpreemptibles when there is so much
-    left to run that using nonpreemptibles won't salvage the experiment."""
-    trial_instance_manager = get_trial_instance_manager(preempt_exp_conf)
-    trials_left_to_run = (
-        trial_instance_manager.max_nonpreemptibles /
-        trial_instance_manager.MAX_FRACTION_FOR_NONPREEMPTIBLES) + 1
-    assert not trial_instance_manager.can_start_nonpreemptible(
-        trial_instance_manager.max_nonpreemptibles - 1, trials_left_to_run)
-
-
-def test_can_start_nonpreemptible(preempt_exp_conf):
-    """Tests that we can start a nonpreemptible under the right conditions."""
-    trial_instance_manager = get_trial_instance_manager(preempt_exp_conf)
-    trials_left_to_run = (
-        trial_instance_manager.max_nonpreemptibles /
-        trial_instance_manager.MAX_FRACTION_FOR_NONPREEMPTIBLES)
-    nonpreemptible_starts = trial_instance_manager.max_nonpreemptibles - 1
-    assert trial_instance_manager.can_start_nonpreemptible(
-        nonpreemptible_starts, trials_left_to_run)
-
-
 def test_can_start_preemptible_not_preemptible_runners(preempt_exp_conf):
     """Tests that test_can_start_preemptible returns False when
     'preemptible_runners' is not set to True in the experiment_config."""

--- a/service/experiment-config.yaml
+++ b/service/experiment-config.yaml
@@ -2,7 +2,7 @@
 # Unless you are a fuzzbench maintainer running this service, this
 # will not work with your setup.
 
-trials: 15
+trials: 20
 max_total_time: 82800  # 23 hours, the default time for preemptible experiments.
 cloud_project: fuzzbench
 docker_registry: gcr.io/fuzzbench

--- a/service/experiment-config.yaml
+++ b/service/experiment-config.yaml
@@ -2,7 +2,7 @@
 # Unless you are a fuzzbench maintainer running this service, this
 # will not work with your setup.
 
-trials: 20
+trials: 15
 max_total_time: 82800  # 23 hours, the default time for preemptible experiments.
 cloud_project: fuzzbench
 docker_registry: gcr.io/fuzzbench


### PR DESCRIPTION
Currently, the logic is too complicated that decides whether to
spin a preemptible or non-preemptible vm once a current vm preempts.
Simplify to start a non-preemptible vm always after experiment
expected end time. This also takes care of a case where vms are never
started if can_start_nonpreemptible is false.