### PR TITLE
Make fuzzer names in report link to the descriptions.

### DIFF
--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -74,12 +74,12 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
 
     def linkify_names(self, df):
         """For any DataFrame which is indexed by fuzzer names, turns the fuzzer
-        names into links to their descriptions on GitHub."""
+        names into links to their directory with a description on GitHub."""
         assert df.index.name == 'fuzzer'
 
         def description_link(commit, fuzzer):
             return (f'<a href="https://github.com/google/fuzzbench/blob/'
-                    f'{commit}/fuzzers/{fuzzer}/description.md">{fuzzer}</a>')
+                    f'{commit}/fuzzers/{fuzzer}">{fuzzer}</a>')
 
         commit = self.git_hash if self.git_hash else 'master'
         df.index = df.index.map(lambda fuzzer: description_link(commit, fuzzer))

--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -72,6 +72,19 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
     def _get_full_path(self, filename):
         return os.path.join(self._output_directory, filename)
 
+    def linkify_names(self, df):
+        """For any DataFrame which is indexed by fuzzer names, turns the fuzzer
+        names into links to their descriptions on GitHub."""
+        assert df.index.name == 'fuzzer'
+
+        def description_link(commit, fuzzer):
+            return (f'<a href="https://github.com/google/fuzzbench/blob/'
+                    f'{commit}/fuzzers/{fuzzer}/description.md">{fuzzer}</a>')
+
+        commit = self.git_hash if self.git_hash else 'master'
+        df.index = df.index.map(lambda fuzzer: description_link(commit, fuzzer))
+        return df
+
     @property
     @functools.lru_cache()
     # TODO(lszekeres): With python3.8+, replace above two decorators with:

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -89,11 +89,17 @@
             <div class="row">
                 <div class="col s5 offset-s1">
                     <h5 class="center-align">By avg. score</h5>
-                    {{ experiment.rank_by_median_and_average_normalized_score.round(2).to_frame().to_html() }}
+                    {{ experiment.linkify_names(
+                         experiment.rank_by_median_and_average_normalized_score.round(2).to_frame()
+                       ).to_html(escape=False)
+                    }}
                 </div>
                 <div class="col s5">
                     <h5 class="center-align">By avg. rank</h5>
-                    {{ experiment.rank_by_median_and_average_rank.round(2).to_frame().to_html() }}
+                    {{ experiment.linkify_names(
+                         experiment.rank_by_median_and_average_rank.round(2).to_frame()
+                       ).to_html(escape=False)
+                    }}
                 </div>
             </div>
 

--- a/analysis/test_experiment_results.py
+++ b/analysis/test_experiment_results.py
@@ -30,4 +30,4 @@ def test_linkify_fuzzer_names_in_ranking():
 
     assert ranking.index[0] == (
         '<a href="https://github.com/google/fuzzbench/blob/'
-        'master/fuzzers/afl/description.md">afl</a>')
+        'master/fuzzers/afl">afl</a>')

--- a/analysis/test_experiment_results.py
+++ b/analysis/test_experiment_results.py
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions andsss
+# limitations under the License.
+"""Tests for experiment_results.py"""
+
+from analysis import experiment_results
+from analysis import test_data_utils
+
+
+def test_linkify_fuzzer_names_in_ranking():
+    """Tests turning fuzzer names into links."""
+    experiment_df = test_data_utils.create_experiment_data()
+    results = experiment_results.ExperimentResults(experiment_df,
+                                                   coverage_dict=None,
+                                                   output_directory=None,
+                                                   plotter=None)
+    ranking = results.rank_by_median_and_average_rank
+
+    ranking = results.linkify_names(ranking)
+
+    assert ranking.index[0] == (
+        '<a href="https://github.com/google/fuzzbench/blob/'
+        'master/fuzzers/afl/description.md">afl</a>')


### PR DESCRIPTION
Fixes #717.