### PR TITLE
Store experimental reports with non-core fuzzers in experimental sub-dir.

### DIFF
--- a/docs/getting-started/adding_a_new_fuzzer.md
+++ b/docs/getting-started/adding_a_new_fuzzer.md
@@ -299,7 +299,7 @@ likely affected by your change).
 
 This report, and a real-time report of your experiment can be viewed at
 `https://www.fuzzbench.com/reports/experimental/$YOUR_EXPERIMENT_NAME` (remove
-the `experimental` directory in path if you are modifying or adding a
+the `experimental/` directory in path if you are modifying or adding a
 [core fuzzer](https://github.com/google/fuzzbench/blob/master/service/core-fuzzers.yaml)).
 Note that real-time reports may not appear until a few hours after the
 experiment starts since every fuzzer-benchmark pair in the experiment must build

--- a/docs/getting-started/adding_a_new_fuzzer.md
+++ b/docs/getting-started/adding_a_new_fuzzer.md
@@ -290,16 +290,20 @@ twice a day at 6:00 AM PT (13:00 UTC) and 6:00 PM PT (01:00 UTC). If you want
 the FuzzBench service to run an experiment on specific fuzzers (such as the one
 you are adding): add an experiment request to
 [service/experiment-requests.yaml](https://github.com/google/fuzzbench/blob/master/service/experiment-requests.yaml).
-`service/experiment-requests.yaml` explains how to do this. At the end of the
-experiment, FuzzBench will generate a report comparing your fuzzer to the latest
-versions of other fuzzers, so you only need to include fuzzers that you've
-modified in a meaningful way (i.e. fuzzers whose results are likely affected by
-your
-change). This report, and a real-time report of your experiment can be viewed at
-`https://www.fuzzbench.com/reports/$YOUR_EXPERIMENT_NAME`. Note that real-time
-reports may not appear until a few hours after the experiment starts since every
-fuzzer-benchmark pair in the experiment must build in order for fuzzing to
-start.
+`service/experiment-requests.yaml` explains how to do this.
+
+At the end of the experiment, FuzzBench will generate a report comparing your
+fuzzer to the latest versions of other fuzzers, so you only need to include
+fuzzers that you've modified in a meaningful way (i.e. fuzzers whose results are
+likely affected by your change).
+
+This report, and a real-time report of your experiment can be viewed at
+`https://www.fuzzbench.com/reports/experimental/$YOUR_EXPERIMENT_NAME` (remove
+the `experimental` directory in path if you are modifying or adding a
+[core fuzzer](https://github.com/google/fuzzbench/blob/master/service/core-fuzzers.yaml)).
+Note that real-time reports may not appear until a few hours after the
+experiment starts since every fuzzer-benchmark pair in the experiment must build
+in order for fuzzing to start.
 
 ## Submitting your integration
 

--- a/experiment/reporter.py
+++ b/experiment/reporter.py
@@ -26,8 +26,9 @@ from common import yaml_utils
 from analysis import generate_report
 from analysis import data_utils
 
-CORE_FUZZERS_YAML = os.path.join(os.path.dirname(__file__), '..', 'service',
-                                 'core-fuzzers.yaml')
+CORE_FUZZERS_YAML = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'service',
+                 'core-fuzzers.yaml'))
 
 logger = logs.Logger('reporter')  # pylint: disable=invalid-name
 
@@ -37,6 +38,11 @@ def get_reports_dir():
     return exp_path.path('reports')
 
 
+def get_core_fuzzers():
+    """Return list of core fuzzers to be used for merging experiment data."""
+    return yaml_utils.read(CORE_FUZZERS_YAML)['fuzzers']
+
+
 def output_report(experiment_config: dict,
                   in_progress=False,
                   coverage_report=False):
@@ -44,7 +50,7 @@ def output_report(experiment_config: dict,
     experiment_name = experiment_utils.get_experiment_name()
     reports_dir = get_reports_dir()
 
-    core_fuzzers = set(yaml_utils.read(CORE_FUZZERS_YAML)['fuzzers'])
+    core_fuzzers = set(get_core_fuzzers())
     experiment_fuzzers = set(experiment_config['fuzzers'])
     fuzzers = sorted(experiment_fuzzers.union(core_fuzzers))
 

--- a/experiment/reporter.py
+++ b/experiment/reporter.py
@@ -56,7 +56,7 @@ def output_report(experiment_config: dict,
 
     # Calculate path to store report files in filestore.
     web_filestore_path = experiment_config['report_filestore']
-    if experiment_fuzzers != core_fuzzers:
+    if len(fuzzers) > len(core_fuzzers):
         # This means that we are running an experimental report with fuzzer
         # variants. So, store these in |experimental| sub-directory.
         web_filestore_path = os.path.join(web_filestore_path, 'experimental')

--- a/experiment/reporter.py
+++ b/experiment/reporter.py
@@ -52,13 +52,13 @@ def output_report(experiment_config: dict,
 
     core_fuzzers = set(get_core_fuzzers())
     experiment_fuzzers = set(experiment_config['fuzzers'])
-    fuzzers = sorted(experiment_fuzzers.union(core_fuzzers))
+    fuzzers = experiment_fuzzers.union(core_fuzzers)
 
     # Calculate path to store report files in filestore.
     web_filestore_path = experiment_config['report_filestore']
-    if len(fuzzers) > len(core_fuzzers):
-        # This means that we are running an experimental report with fuzzer
-        # variants. So, store these in |experimental| sub-directory.
+    if not fuzzers.issubset(core_fuzzers):
+        # This means that we are running an experimental report with fuzzers
+        # not in the core list. So, store these in |experimental| sub-directory.
         web_filestore_path = os.path.join(web_filestore_path, 'experimental')
     web_filestore_path = posixpath.join(web_filestore_path, experiment_name)
 

--- a/experiment/reporter.py
+++ b/experiment/reporter.py
@@ -42,13 +42,19 @@ def output_report(experiment_config: dict,
                   coverage_report=False):
     """Generate the HTML report and write it to |web_bucket|."""
     experiment_name = experiment_utils.get_experiment_name()
-    web_filestore_path = posixpath.join(experiment_config['report_filestore'],
-                                        experiment_name)
-
     reports_dir = get_reports_dir()
 
-    core_fuzzers = yaml_utils.read(CORE_FUZZERS_YAML)['fuzzers']
-    fuzzers = sorted(set(experiment_config['fuzzers']).union(set(core_fuzzers)))
+    core_fuzzers = set(yaml_utils.read(CORE_FUZZERS_YAML)['fuzzers'])
+    experiment_fuzzers = set(experiment_config['fuzzers'])
+    fuzzers = sorted(experiment_fuzzers.union(core_fuzzers))
+
+    # Calculate path to store report files in filestore.
+    web_filestore_path = experiment_config['report_filestore']
+    if experiment_fuzzers != core_fuzzers:
+        # This means that we are running an experimental report with fuzzer
+        # variants. So, store these in |experimental| sub-directory.
+        web_filestore_path = os.path.join(web_filestore_path, 'experimental')
+    web_filestore_path = posixpath.join(web_filestore_path, experiment_name)
 
     # Don't merge with nonprivate experiments until the very end as doing it
     # while the experiment is in progress will produce unusable realtime

--- a/experiment/test_reporter.py
+++ b/experiment/test_reporter.py
@@ -100,7 +100,7 @@ def test_output_report_filestore_with_core_fuzzers_subset(fs, experiment):
 
     with test_utils.mock_popen_ctx_mgr() as mocked_popen:
         with mock.patch('analysis.generate_report.generate_report'
-                        ) as mocked_generate_report:
+                       ) as mocked_generate_report:
             reporter.output_report(experiment_config)
             reports_dir = os.path.join(os.environ['WORK'], 'reports')
             assert mocked_popen.commands == [[

--- a/experiment/test_reporter.py
+++ b/experiment/test_reporter.py
@@ -26,24 +26,21 @@ from test_libs import utils as test_utils
 def _setup_experiment_files(fs):
     """Set up experiment config and core-fuzzers files and return experiment
     config yaml."""
-    core_fuzzers_filepath = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), '..', 'service',
-                     'core-fuzzers.yaml'))
-    fs.add_real_file(core_fuzzers_filepath)
-    core_fuzzers = yaml_utils.read(core_fuzzers_filepath)['fuzzers']
+    fs.add_real_file(reporter.CORE_FUZZERS_YAML)
 
     config_filepath = os.path.join(os.path.dirname(__file__), 'test_data',
                                    'experiment-config.yaml')
     fs.add_real_file(config_filepath)
     experiment_config = yaml_utils.read(config_filepath)
 
-    return experiment_config, core_fuzzers
+    return experiment_config
 
 
 def test_output_report_filestore_with_fuzzer_variants(fs, experiment):
     """Test that output_report writes the report and rsyncs it to the report
     filestore in experimental subdirectory with fuzzer variants."""
-    experiment_config, core_fuzzers = _setup_experiment_files(fs)
+    experiment_config = _setup_experiment_files(fs)
+    core_fuzzers = reporter.get_core_fuzzers()
     expected_fuzzers = sorted(core_fuzzers + ['fuzzer-a', 'fuzzer-b'])
 
     with test_utils.mock_popen_ctx_mgr() as mocked_popen:
@@ -70,7 +67,8 @@ def test_output_report_filestore_with_fuzzer_variants(fs, experiment):
 def test_output_report_filestore_with_core_fuzzers(fs, experiment):
     """Test that output_report writes the report and rsyncs it to the report
     filestore with core fuzzers."""
-    experiment_config, core_fuzzers = _setup_experiment_files(fs)
+    experiment_config = _setup_experiment_files(fs)
+    core_fuzzers = reporter.get_core_fuzzers()
     experiment_config['fuzzers'] = core_fuzzers
 
     with test_utils.mock_popen_ctx_mgr() as mocked_popen:


### PR DESCRIPTION
Fixes #773.