### PR TITLE
Fix local experiment docs to use gcr.io/fuzzbench registry.

### DIFF
--- a/docs/running-a-local-experiment/running_a_local_experiment.md
+++ b/docs/running-a-local-experiment/running_a_local_experiment.md
@@ -46,7 +46,7 @@ trials: 5
 max_total_time: 86400
 
 # The location of your docker registry.
-docker_registry: lab-server:5000
+docker_registry: gcr.io/fuzzbench
 
 # The local experiment folder that will store most of the experiment data.
 # Please use an absolute path.

--- a/docs/running-a-local-experiment/running_a_local_experiment.md
+++ b/docs/running-a-local-experiment/running_a_local_experiment.md
@@ -45,7 +45,9 @@ trials: 5
 # 1 day = 24 * 60 * 60 = 86400
 max_total_time: 86400
 
-# The location of your docker registry.
+# The location of the docker registry.
+# FIXME: Support custom docker registry.
+# See https://github.com/google/fuzzbench/issues/777
 docker_registry: gcr.io/fuzzbench
 
 # The local experiment folder that will store most of the experiment data.


### PR DESCRIPTION
Right now, custom registry e.g. local-server:5000 don't work
due to missing dispatcher-image instructions and missing support
in make. For now, just recommend using gcr.io/fuzzbench, this
still keeps images locally.