### PR TITLE
Archive OSS-Fuzz corpus in GCS, use at runtime based on flag.

### DIFF
--- a/benchmarks/libxslt_xpath/Dockerfile
+++ b/benchmarks/libxslt_xpath/Dockerfile
@@ -25,4 +25,3 @@ RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxslt.git
 WORKDIR libxslt
 COPY build.sh $SRC/
-COPY oss_fuzz_corpus.zip $SRC/xpath_seed_corpus.zip

--- a/benchmarks/libxslt_xpath/benchmark.yaml
+++ b/benchmarks/libxslt_xpath/benchmark.yaml
@@ -1,6 +1,7 @@
 commit: 2c20c70cd81e5ba51dc8e160fbd1c855eb97f065
 commit_date: 2020-09-20 15:01:51+00:00
 fuzz_target: xpath
+oss_fuzz_corpus_url: gs://fuzzbench-oss-fuzz-corpora/libxslt/xpath_oss_fuzz_corpus.zip
 project: libxslt
 unsupported_fuzzers:
   - aflcc

--- a/benchmarks/libxslt_xpath/build.sh
+++ b/benchmarks/libxslt_xpath/build.sh
@@ -71,4 +71,3 @@ for fuzzer in xpath; do
 done
 
 cp tests/fuzz/xpath.dict tests/fuzz/xpath.xml $OUT/
-cp $SRC/xpath_seed_corpus.zip $OUT/

--- a/common/benchmark_utils.py
+++ b/common/benchmark_utils.py
@@ -28,8 +28,13 @@ BENCHMARKS_DIR = os.path.join(utils.ROOT_DIR, 'benchmarks')
 
 
 def get_fuzz_target(benchmark):
-    """Returns the fuzz target of |benchmark|"""
+    """Returns the fuzz target of |benchmark|."""
     return benchmark_config.get_config(benchmark)['fuzz_target']
+
+
+def get_oss_fuzz_corpus_url(benchmark):
+    """Returns the OSS-Fuzz corpus of |benchmark| if exists."""
+    return benchmark_config.get_config(benchmark).get('oss_fuzz_corpus_url', '')
 
 
 def get_runner_image_url(experiment, benchmark, fuzzer, docker_registry):

--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -38,6 +38,7 @@ docker run \
 -e MAX_TOTAL_TIME={{max_total_time}} \
 -e NO_SEEDS={{no_seeds}} \
 -e NO_DICTIONARIES={{no_dictionaries}} \
+-e OSS_FUZZ_CORPUS_URL={{oss_fuzz_corpus_url}} \
 -e DOCKER_REGISTRY={{docker_registry}} {% if not local_experiment %}-e CLOUD_PROJECT={{cloud_project}} -e CLOUD_COMPUTE_ZONE={{cloud_compute_zone}} {% endif %}\
 -e EXPERIMENT_FILESTORE={{experiment_filestore}} {% if local_experiment %}-v {{experiment_filestore}}:{{experiment_filestore}} {% endif %}\
 -e REPORT_FILESTORE={{report_filestore}} {% if local_experiment %}-v {{report_filestore}}:{{report_filestore}} {% endif %}\

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -204,7 +204,8 @@ def start_experiment(  # pylint: disable=too-many-arguments
         benchmarks: List[str],
         fuzzers: List[str],
         no_seeds=False,
-        no_dictionaries=False):
+        no_dictionaries=False,
+        oss_fuzz_corpus=False):
     """Start a fuzzer benchmarking experiment."""
     check_no_local_changes()
 
@@ -218,6 +219,7 @@ def start_experiment(  # pylint: disable=too-many-arguments
     config['git_hash'] = get_git_hash()
     config['no_seeds'] = no_seeds
     config['no_dictionaries'] = no_dictionaries
+    config['oss_fuzz_corpus'] = oss_fuzz_corpus
 
     set_up_experiment_config_file(config)
 
@@ -466,6 +468,13 @@ def main():
                         required=False,
                         default=False,
                         action='store_true')
+    parser.add_argument(
+        '-o',
+        '--oss-fuzz-corpus',
+        help='Should trials be conducted with OSS-Fuzz corpus (if available).',
+        required=False,
+        default=False,
+        action='store_true')
 
     args = parser.parse_args()
     fuzzers = args.fuzzers or all_fuzzers
@@ -475,7 +484,8 @@ def main():
                      args.benchmarks,
                      fuzzers,
                      no_seeds=args.no_seeds,
-                     no_dictionaries=args.no_dictionaries)
+                     no_dictionaries=args.no_dictionaries,
+                     oss_fuzz_corpus=args.oss_fuzz_corpus)
     return 0
 
 

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -665,8 +665,12 @@ def render_startup_script_template(instance_name: str, fuzzer: str,
     docker_image_url = benchmark_utils.get_runner_image_url(
         experiment, benchmark, fuzzer, experiment_config['docker_registry'])
     fuzz_target = benchmark_utils.get_fuzz_target(benchmark)
-
     local_experiment = experiment_utils.is_local_experiment()
+
+    oss_fuzz_corpus_url = ''
+    if experiment_config['oss_fuzz_corpus']:
+        oss_fuzz_corpus_url = benchmark_utils.get_oss_fuzz_corpus_url(benchmark)
+
     template = JINJA_ENV.get_template('runner-startup-script-template.sh')
     kwargs = {
         'instance_name': instance_name,
@@ -683,6 +687,7 @@ def render_startup_script_template(instance_name: str, fuzzer: str,
         'local_experiment': local_experiment,
         'no_seeds': experiment_config['no_seeds'],
         'no_dictionaries': experiment_config['no_dictionaries'],
+        'oss_fuzz_corpus_url': oss_fuzz_corpus_url,
     }
 
     if not local_experiment:

--- a/experiment/test_data/experiment-config.yaml
+++ b/experiment/test_data/experiment-config.yaml
@@ -30,3 +30,4 @@ fuzzers:
 git_hash: "git-hash"
 no_seeds: false
 no_dictionaries: false
+oss_fuzz_corpus: false

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -109,6 +109,7 @@ docker run \\
 -e MAX_TOTAL_TIME=86400 \\
 -e NO_SEEDS=False \\
 -e NO_DICTIONARIES=False \\
+-e OSS_FUZZ_CORPUS_URL= \\
 -e DOCKER_REGISTRY=gcr.io/fuzzbench -e CLOUD_PROJECT=fuzzbench -e CLOUD_COMPUTE_ZONE=us-central1-a \\
 -e EXPERIMENT_FILESTORE=gs://experiment-data \\
 -e REPORT_FILESTORE=gs://web-reports \\


### PR DESCRIPTION
- Add support in oss_fuzz_benchmark_integration.py to copy
  OSS-Fuzz corpus to GCS bucket gs://fuzzbench-oss-fuzz-corpora
  instead of benchmark directory. This saves space and allows
  easy update and large corpus support.
- Add flag --oss-fuzz-corpus in run_experiment.py to allow
  running benchmarks that have OSS-Fuzz corpus to use it
  as seed corpus.
- Add support in runner to download OSS-Fuzz corpus and
  use as seed corpus if flag is set.
- Migrage libxslt_xpath benchmark to the new system.

Fixes https://github.com/google/fuzzbench/issues/162