### PR TITLE
Don't stop on crashes for afl based fuzzers.

### DIFF
--- a/fuzzers/afl/fuzzer.py
+++ b/fuzzers/afl/fuzzer.py
@@ -54,6 +54,9 @@ def prepare_fuzz_environment(input_corpus):
     # AFL will abort on startup if the core pattern sends notifications to
     # external programs. We don't care about this.
     os.environ['AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES'] = '1'
+    # Don't exit when crashes are found. This can happen when corpus from
+    # OSS-Fuzz is used.
+    os.environ['AFL_SKIP_CRASHES'] = '1'
 
     # AFL needs at least one non-empty seed to start.
     utils.create_seed_file_for_empty_corpus(input_corpus)

--- a/fuzzers/weizz_qemu/fuzzer.py
+++ b/fuzzers/weizz_qemu/fuzzer.py
@@ -35,11 +35,13 @@ def build():
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
+    # FIXME: Share code with afl.fuzz.
     os.environ['WEIZZ_NO_UI'] = '1'
     os.environ['WEIZZ_SKIP_CPUFREQ'] = '1'
     os.environ['WEIZZ_NO_AFFINITY'] = '1'
     os.environ['WEIZZ_I_DONT_CARE_ABOUT_MISSING_CRASHES'] = '1'
     os.environ['WEIZZ_CTX_SENSITIVE'] = '1'
+    os.environ['WEIZZ_SKIP_CRASHES'] = '1'
 
     # Weizz needs at least one non-empty seed to start.
     utils.create_seed_file_for_empty_corpus(input_corpus)


### PR DESCRIPTION
This is needed for benchmarking OSS-Fuzz corpora which can
have corpus items with crashes.