### PR TITLE
Coverage measurement fixes

### DIFF
--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -16,6 +16,7 @@
 
 import collections
 import gc
+import glob
 import multiprocessing
 import os
 import pathlib
@@ -340,7 +341,8 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
                                                   'unchanged-cycles')
 
         # Store the profraw file containing coverage data for each cycle.
-        self.profraw_file = os.path.join(self.coverage_dir, 'data.profraw')
+        self.profraw_file_pattern = os.path.join(self.coverage_dir,
+                                                 'data-%m.profraw')
 
         # Store the profdata file for the current trial.
         self.profdata_file = os.path.join(self.report_dir, 'data.profdata')
@@ -348,6 +350,13 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
         # Store the coverage information in json form.
         self.cov_summary_file = os.path.join(self.report_dir,
                                              'cov_summary.json')
+
+    def get_profraw_files(self):
+        """Return generated profraw files."""
+        return [
+            f for f in glob.glob(self.profraw_file_pattern.replace('%m', '*'))
+            if os.path.getsize(f)
+        ]
 
     def initialize_measurement_dirs(self):
         """Initialize directories that will be needed for measuring
@@ -361,7 +370,7 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
         coverage_binary = coverage_utils.get_coverage_binary(self.benchmark)
         crashing_units = run_coverage.do_coverage_run(coverage_binary,
                                                       self.corpus_dir,
-                                                      self.profraw_file,
+                                                      self.profraw_file_pattern,
                                                       self.crashes_dir)
 
         self.UNIT_BLACKLIST[self.benchmark] = (
@@ -403,12 +412,11 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
 
     def generate_profdata(self, cycle: int):
         """Generate .profdata file from .profraw file."""
+        files_to_merge = self.get_profraw_files()
         if os.path.isfile(self.profdata_file):
             # If coverage profdata exists, then merge it with
             # existing available data.
-            files_to_merge = [self.profraw_file, self.profdata_file]
-        else:
-            files_to_merge = [self.profraw_file]
+            files_to_merge += [self.profdata_file]
 
         result = coverage_utils.merge_profdata_files(files_to_merge,
                                                      self.profdata_file)
@@ -419,11 +427,9 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
     def generate_coverage_information(self, cycle: int):
         """Generate the .profdata file and then transform it into
         json summary."""
-        if not os.path.exists(self.profraw_file):
-            self.logger.error('No profraw file found for cycle: %d.', cycle)
-            return
-        if not os.path.getsize(self.profraw_file):
-            self.logger.error('Empty profraw file found for cycle: %d.', cycle)
+        if not self.get_profraw_files():
+            self.logger.error('No valid profraw files found for cycle: %d.',
+                              cycle)
             return
         self.generate_profdata(cycle)
 

--- a/experiment/run_coverage.py
+++ b/experiment/run_coverage.py
@@ -25,6 +25,18 @@ from common import new_process
 
 logger = logs.Logger('run_coverage')
 
+# Time buffer for libfuzzer merge to gracefully exit.
+EXIT_BUFFER = 15
+
+# Memory limit for libfuzzer merge.
+RSS_LIMIT_MB = 2048
+
+# Per-unit processing timeout for libfuzzer merge.
+UNIT_TIMEOUT = 10
+
+# Max time to spend on libfuzzer merge.
+MAX_TOTAL_TIME = experiment_utils.get_snapshot_seconds()
+
 
 def find_crashing_units(artifacts_dir: str) -> List[str]:
     """Returns the crashing unit in coverage_binary_output."""
@@ -37,27 +49,23 @@ def find_crashing_units(artifacts_dir: str) -> List[str]:
     ]
 
 
-RSS_LIMIT_MB = 2048
-UNIT_TIMEOUT = 10
-MAX_TOTAL_TIME = experiment_utils.get_snapshot_seconds()
-
-
 def do_coverage_run(  # pylint: disable=too-many-locals
-        coverage_binary: str, new_units_dir: List[str], profraw_file: str,
-        crashes_dir: str) -> List[str]:
+        coverage_binary: str, new_units_dir: List[str],
+        profraw_file_pattern: str, crashes_dir: str) -> List[str]:
     """Does a coverage run of |coverage_binary| on |new_units_dir|. Writes
-    the result to |profraw_file|. Returns a list of crashing units."""
+    the result to |profraw_file_pattern|. Returns a list of crashing units."""
     with tempfile.TemporaryDirectory() as merge_dir:
         command = [
             coverage_binary, '-merge=1', '-dump_coverage=1',
             '-artifact_prefix=%s/' % crashes_dir,
             '-timeout=%d' % UNIT_TIMEOUT,
             '-rss_limit_mb=%d' % RSS_LIMIT_MB,
-            '-max_total_time=%d' % MAX_TOTAL_TIME, merge_dir, new_units_dir
+            '-max_total_time=%d' % (MAX_TOTAL_TIME - EXIT_BUFFER), merge_dir,
+            new_units_dir
         ]
         coverage_binary_dir = os.path.dirname(coverage_binary)
         env = os.environ.copy()
-        env['LLVM_PROFILE_FILE'] = profraw_file
+        env['LLVM_PROFILE_FILE'] = profraw_file_pattern
         result = new_process.execute(command,
                                      env=env,
                                      cwd=coverage_binary_dir,

--- a/experiment/test_measurer.py
+++ b/experiment/test_measurer.py
@@ -96,13 +96,14 @@ def test_generate_profdata_create(mocked_execute, experiment, fs):
     snapshot_measurer = measurer.SnapshotMeasurer(FUZZER, BENCHMARK, TRIAL_NUM,
                                                   SNAPSHOT_LOGGER)
     snapshot_measurer.profdata_file = '/work/reports/data.profdata'
-    snapshot_measurer.profraw_file = '/work/reports/data.profraw'
-    fs.create_file(snapshot_measurer.profraw_file, contents='fake_contents')
+    snapshot_measurer.profraw_file_pattern = '/work/reports/data-%m.profraw'
+    profraw_file = '/work/reports/data-123.profraw'
+    fs.create_file(profraw_file, contents='fake_contents')
     snapshot_measurer.generate_profdata(CYCLE)
 
     expected = [
-        'llvm-profdata', 'merge', '-sparse', '/work/reports/data.profraw', '-o',
-        '/work/reports/data.profdata'
+        'llvm-profdata', 'merge', '-sparse', '/work/reports/data-123.profraw',
+        '-o', '/work/reports/data.profdata'
     ]
 
     assert (len(mocked_execute.call_args_list)) == 1
@@ -117,13 +118,14 @@ def test_generate_profdata_merge(mocked_execute, experiment, fs):
     snapshot_measurer = measurer.SnapshotMeasurer(FUZZER, BENCHMARK, TRIAL_NUM,
                                                   SNAPSHOT_LOGGER)
     snapshot_measurer.profdata_file = '/work/reports/data.profdata'
-    snapshot_measurer.profraw_file = '/work/reports/data.profraw'
-    fs.create_file(snapshot_measurer.profraw_file, contents='fake_contents')
+    snapshot_measurer.profraw_file_pattern = '/work/reports/data-%m.profraw'
+    profraw_file = '/work/reports/data-123.profraw'
+    fs.create_file(profraw_file, contents='fake_contents')
     fs.create_file(snapshot_measurer.profdata_file, contents='fake_contents')
     snapshot_measurer.generate_profdata(CYCLE)
 
     expected = [
-        'llvm-profdata', 'merge', '-sparse', '/work/reports/data.profraw',
+        'llvm-profdata', 'merge', '-sparse', '/work/reports/data-123.profraw',
         '/work/reports/data.profdata', '-o', '/work/reports/data.profdata'
     ]
 
@@ -320,7 +322,9 @@ def test_run_cov_new_units(_, mocked_execute, fs, environ):
     expected = {
         'cwd': '/work/coverage-binaries/benchmark-a',
         'env': {
-            'LLVM_PROFILE_FILE': profraw_file_path,
+            'LLVM_PROFILE_FILE':
+                ('/work/measurement-folders/'
+                 'benchmark-a-fuzzer-a/trial-12/coverage/data-%m.profraw'),
             'WORK': '/work',
             'EXPERIMENT_FILESTORE': 'gs://bucket',
             'EXPERIMENT': 'experiment',


### PR DESCRIPTION
- Don't overwrite profraw after a crash is encountered, use unique
  one with %m in profraw pattern. This also fixes the warning -
  "Later invocation of __llvm_profile_dump can
  lead to clobbering  of previously dumped profile data : online
  profile merging is not on. Either use %m in profile name or change
  profile name before dumping."
- Leave some grace period so that libfuzzer merge can exit properly
  and coverage is always dumped. Keep -max_total_time 15 sec less
  than the command timeout.
- Add get_profraw_files helper to get non-zero/valid profraw files,
  fix tests

Fixes https://github.com/google/fuzzbench/issues/809