### PR TITLE
Store filtered data in csv.

### DIFF
--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -156,8 +156,6 @@ def generate_report(experiment_names,
         experiment_df = pd.read_csv(data_path)
     else:
         experiment_df = queries.get_experiment_data(experiment_names)
-        # Save the raw data along with the report.
-        experiment_df.to_csv(data_path)
 
     data_utils.validate_data(experiment_df)
 
@@ -176,6 +174,11 @@ def generate_report(experiment_names,
     if merge_with_clobber or merge_with_clobber_nonprivate:
         experiment_df = data_utils.clobber_experiments_data(
             experiment_df, experiment_names)
+
+    # Save the filtered raw data along with the report if not using cached data
+    # or if the data does not exist.
+    if not from_cached_data or not os.path.exists(data_path):
+        experiment_df.to_csv(data_path)
 
     # Load the coverage json summary file.
     coverage_dict = {}


### PR DESCRIPTION
Since we merge data across earlier experiments and do lot of filters,
it can be very confusing to add data from all experiments. Only keep
the filtered data in csv that was used to generate the report.

Fixes https://github.com/google/fuzzbench/issues/812