### PR TITLE
Add optional experiment description

### DIFF
--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -157,6 +157,8 @@ def generate_report(experiment_names,
     else:
         experiment_df = queries.get_experiment_data(experiment_names)
 
+    description = queries.get_experiment_description(experiment_names[0])
+
     data_utils.validate_data(experiment_df)
 
     if benchmarks is not None:
@@ -197,7 +199,8 @@ def generate_report(experiment_names,
 
     template = report_type + '.html'
     detailed_report = rendering.render_report(experiment_ctx, template,
-                                              in_progress, coverage_report)
+                                              in_progress, coverage_report,
+                                              description)
 
     filesystem.write(os.path.join(report_directory, 'index.html'),
                      detailed_report)

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -147,7 +147,8 @@ def generate_report(experiment_names,
             queries.add_nonprivate_experiments_for_merge_with_clobber(
                 experiment_names))
 
-    report_name = report_name or experiment_names[0]
+    main_experiment_name = experiment_names[0]
+    report_name = report_name or main_experiment_name
 
     filesystem.create_directory(report_directory)
 
@@ -157,7 +158,7 @@ def generate_report(experiment_names,
     else:
         experiment_df = queries.get_experiment_data(experiment_names)
 
-    description = queries.get_experiment_description(experiment_names[0])
+    description = queries.get_experiment_description(main_experiment_name)
 
     data_utils.validate_data(experiment_df)
 

--- a/analysis/queries.py
+++ b/analysis/queries.py
@@ -42,7 +42,7 @@ def get_experiment_description(experiment_name):
     # results from get_experiment_data.
     return db_utils.query(Experiment.description)\
             .select_from(Experiment)\
-            .filter(Experiment.name.in_(experiment_names)).one()
+            .filter(Experiment.name == experiment_name).one()
 
 
 def add_nonprivate_experiments_for_merge_with_clobber(experiment_names):

--- a/analysis/queries.py
+++ b/analysis/queries.py
@@ -36,6 +36,15 @@ def get_experiment_data(experiment_names):
     return pd.read_sql_query(snapshots_query.statement, db_utils.engine)
 
 
+def get_experiment_description(experiment_name):
+    """Get the description of the experiment named by |experiment_name|."""
+    # Do another query for the description so we don't explode the size of the
+    # results from get_experiment_data.
+    return db_utils.query(Experiment.description)\
+            .select_from(Experiment)\
+            .filter(Experiment.name.in_(experiment_names)).one()
+
+
 def add_nonprivate_experiments_for_merge_with_clobber(experiment_names):
     """Returns a new list containing experiment names preeceeded by a list of
     nonprivate experiments in the order in which they were run, such that

--- a/analysis/rendering.py
+++ b/analysis/rendering.py
@@ -44,4 +44,5 @@ def render_report(experiment_results, template, in_progress, coverage_report,
 
     return template.render(experiment=experiment_results,
                            in_progress=in_progress,
-                           coverage_report=coverage_report)
+                           coverage_report=coverage_report,
+                           description=description)

--- a/analysis/rendering.py
+++ b/analysis/rendering.py
@@ -20,13 +20,17 @@ import jinja2
 from common import utils
 
 
-def render_report(experiment_results, template, in_progress, coverage_report):
+def render_report(experiment_results, template, in_progress, coverage_report,
+                  description):
     """Renders report with |template| using data provided by the
     |experiment_results| context.
 
     Arguments:
       template: filename of the report template. E.g., 'default.html'.
       experiment_results: an ExperimentResults object.
+      in_progress: Whether the experiment is still in progress.
+      coverage_report: Whether to report detailed info about coverage.
+      description: A description of the experiment.
 
     Returns the rendered template.
     """

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -286,7 +286,7 @@
                 </li>
             </ul>
             {% endif %}
-            
+
         </div> <!-- id="{{ benchmark.name }}" -->
         {% endfor %}
 
@@ -302,6 +302,12 @@
             <br><br>
             The experiment was conducted using this FuzzBench commit:
             <a href="https://github.com/google/fuzzbench/commits/{{ experiment.git_hash }}">{{ experiment.git_hash }}</a>
+            {% endif %}
+
+            {% if experiment.description %}
+            <br><br>
+            Experiment Description:<br><br>
+            {{ experiment.description }}
             {% endif %}
         </div>    <!-- id="data" -->
 

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -304,10 +304,10 @@
             <a href="https://github.com/google/fuzzbench/commits/{{ experiment.git_hash }}">{{ experiment.git_hash }}</a>
             {% endif %}
 
-            {% if experiment.description %}
+            {% if description %}
             <br><br>
             Experiment Description:<br><br>
-            {{ experiment.description }}
+            {{ description }}
             {% endif %}
         </div>    <!-- id="data" -->
 

--- a/database/alembic/versions/26dcc0e12872_add_experiment_description.py
+++ b/database/alembic/versions/26dcc0e12872_add_experiment_description.py
@@ -1,0 +1,25 @@
+"""Add experiment description
+
+Revision ID: 26dcc0e12872
+Revises: c83ac04855b4
+Create Date: 2020-10-13 09:04:25.881798
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '26dcc0e12872'
+down_revision = 'c83ac04855b4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('experiment', sa.Column(
+        'description', sa.UnicodeText(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('experiment', 'description')

--- a/database/models.py
+++ b/database/models.py
@@ -14,7 +14,13 @@
 """SQLAlchemy Database Models."""
 import sqlalchemy
 from sqlalchemy.ext import declarative
-from sqlalchemy import Boolean, Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy import Boolean
+from sqlalchemy import Column
+from sqlalchemy import DateTime
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy import UnicodeText
 
 Base = declarative.declarative_base()  # pylint: disable=invalid-name
 
@@ -29,6 +35,7 @@ class Experiment(Base):
     git_hash = Column(String, nullable=True)
     private = Column(Boolean, nullable=False, default=False)
     experiment_filestore = Column(String, nullable=True)
+    description = Column(UnicodeText, nullable=True)
 
 
 class Trial(Base):

--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -66,7 +66,8 @@ def _initialize_experiment_in_db(experiment_config: dict):
             name=experiment_config['experiment'],
             git_hash=experiment_config['git_hash'],
             private=experiment_config.get('private', True),
-            experiment_filestore=experiment_config['experiment_filestore'])
+            experiment_filestore=experiment_config['experiment_filestore'],
+            description=experiment_config['description']),
     ])
 
 

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -205,6 +205,7 @@ def start_experiment(  # pylint: disable=too-many-arguments
         config_filename: str,
         benchmarks: List[str],
         fuzzers: List[str],
+        description: str = None,
         no_seeds=False,
         no_dictionaries=False,
         oss_fuzz_corpus=False):
@@ -222,6 +223,7 @@ def start_experiment(  # pylint: disable=too-many-arguments
     config['no_seeds'] = no_seeds
     config['no_dictionaries'] = no_dictionaries
     config['oss_fuzz_corpus'] = oss_fuzz_corpus
+    config['description'] = description
 
     set_up_experiment_config_file(config)
 
@@ -476,6 +478,10 @@ def main():
                         '--experiment-name',
                         help='Experiment name.',
                         required=True)
+    parser.add_argument('-d',
+                        '--description',
+                        help='Description of the experiment.',
+                        required=False)
     parser.add_argument('-f',
                         '--fuzzers',
                         help='Fuzzers to use.',
@@ -509,6 +515,7 @@ def main():
                      args.experiment_config,
                      args.benchmarks,
                      fuzzers,
+                     description=args.description,
                      no_seeds=args.no_seeds,
                      no_dictionaries=args.no_dictionaries,
                      oss_fuzz_corpus=args.oss_fuzz_corpus)

--- a/experiment/test_data/experiment-config.yaml
+++ b/experiment/test_data/experiment-config.yaml
@@ -31,3 +31,4 @@ git_hash: "git-hash"
 no_seeds: false
 no_dictionaries: false
 oss_fuzz_corpus: false
+description: "Test experiment"

--- a/service/automatic_run_experiment.py
+++ b/service/automatic_run_experiment.py
@@ -77,11 +77,17 @@ BENCHMARKS = [
 
 
 def _get_experiment_name(experiment_config: dict) -> str:
-    """Returns the name of the experiment described by experiment_config as a
+    """Returns the name of the experiment described by |experiment_config| as a
     string."""
     # Use str because the yaml parser will parse things like `2020-05-06` as
     # a datetime if not included in quotes.
     return str(experiment_config['experiment'])
+
+
+def _get_description(experiment_config: dict) -> str:
+    """Returns the description of the experiment described by
+    |experiment_config| as a string."""
+    return experiment_config.get('description')
 
 
 def _get_requested_experiments():
@@ -203,10 +209,11 @@ def run_requested_experiment(dry_run):
 
     logs.info('Running experiment: %s with fuzzers: %s.', experiment_name,
               ' '.join(fuzzers))
-    return _run_experiment(experiment_name, fuzzers, dry_run)
+    description = _get_description(requested_experiment)
+    return _run_experiment(experiment_name, fuzzers, description, dry_run)
 
 
-def _run_experiment(experiment_name, fuzzers, dry_run=False):
+def _run_experiment(experiment_name, fuzzers, description, dry_run=False):
     """Run an experiment named |experiment_name| on |fuzzer_configs| and shut it
     down once it terminates."""
     logs.info('Starting experiment: %s.', experiment_name)
@@ -214,7 +221,7 @@ def _run_experiment(experiment_name, fuzzers, dry_run=False):
         logs.info('Dry run. Not actually running experiment.')
         return
     run_experiment.start_experiment(experiment_name, EXPERIMENT_CONFIG_FILE,
-                                    BENCHMARKS, fuzzers)
+                                    BENCHMARKS, fuzzers, description)
 
 
 def main():

--- a/service/automatic_run_experiment.py
+++ b/service/automatic_run_experiment.py
@@ -21,6 +21,7 @@ import collections
 import os
 import re
 import sys
+from typing import Optional
 
 from common import logs
 from common import fuzzer_utils
@@ -84,7 +85,7 @@ def _get_experiment_name(experiment_config: dict) -> str:
     return str(experiment_config['experiment'])
 
 
-def _get_description(experiment_config: dict) -> str:
+def _get_description(experiment_config: dict) -> Optional[str]:
     """Returns the description of the experiment described by
     |experiment_config| as a string."""
     return experiment_config.get('description')

--- a/service/test_automatic_run_experiment.py
+++ b/service/test_automatic_run_experiment.py
@@ -94,7 +94,7 @@ def test_run_requested_experiment(mocked_get_requested_experiments,
     ]
     expected_calls = [
         mock.call(expected_experiment_name, expected_config_file,
-                  expected_benchmarks, expected_fuzzers)
+                  expected_benchmarks, expected_fuzzers, None)
     ]
     start_experiment_call_args = mocked_start_experiment.call_args_list
     assert len(start_experiment_call_args) == 1

--- a/service/test_automatic_run_experiment.py
+++ b/service/test_automatic_run_experiment.py
@@ -28,7 +28,8 @@ EXPERIMENT = '2020-01-01'
 
 EXPERIMENT_REQUESTS = [{
     'experiment': datetime.date(2020, 6, 8),
-    'fuzzers': ['aflplusplus', 'libfuzzer']
+    'fuzzers': ['aflplusplus', 'libfuzzer'],
+    'description': 'Test experiment'
 }, {
     'experiment': datetime.date(2020, 6, 5),
     'fuzzers': ['honggfuzz', 'afl']
@@ -94,7 +95,7 @@ def test_run_requested_experiment(mocked_get_requested_experiments,
     ]
     expected_calls = [
         mock.call(expected_experiment_name, expected_config_file,
-                  expected_benchmarks, expected_fuzzers, None)
+                  expected_benchmarks, expected_fuzzers, 'Test experiment')
     ]
     start_experiment_call_args = mocked_start_experiment.call_args_list
     assert len(start_experiment_call_args) == 1

--- a/service/test_automatic_run_experiment.py
+++ b/service/test_automatic_run_experiment.py
@@ -29,10 +29,10 @@ EXPERIMENT = '2020-01-01'
 EXPERIMENT_REQUESTS = [{
     'experiment': datetime.date(2020, 6, 8),
     'fuzzers': ['aflplusplus', 'libfuzzer'],
-    'description': 'Test experiment'
 }, {
     'experiment': datetime.date(2020, 6, 5),
-    'fuzzers': ['honggfuzz', 'afl']
+    'fuzzers': ['honggfuzz', 'afl'],
+    'description': 'Test experiment',
 }]
 
 


### PR DESCRIPTION
This can be specified using the service or manually.
When specified, Fuzzbench will include the description in the experiment report.
Fixes #805.