### PR TITLE
[CI] Upgrade python environment action to silence warnings

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -60,10 +60,6 @@ jobs:
           - oss-fuzz
           - standard
 
-    env:
-      FUZZER: ${{ matrix.fuzzer }}
-      BENCHMARK_TYPE: ${{ matrix.benchmark_type }}
-
     steps:
     - uses: actions/checkout@v2
     - run: |  # Needed for git diff to work.

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -99,4 +99,4 @@ jobs:
 
     - name: Build Benchmarks
       run: |
-        PATH=.venv/bin/:$PATH PYTHONPATH=. python3 .github/workflows/build_and_test_run_fuzzer_benchmarks.py $BENCHMARK_TYPE $FUZZER
+        PATH=.venv/bin/:$PATH PYTHONPATH=. python3 .github/workflows/build_and_test_run_fuzzer_benchmarks.py ${{ matrix.benchmark_type }} ${{ matrix.fuzzer }}

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -75,7 +75,7 @@ jobs:
         df -h
 
     - name: Setup Python environment
-      uses: actions/setup-python@v1.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -11,11 +11,6 @@ jobs:
         git fetch origin master --unshallow
         git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
-    - name: Setup Python environment
-      uses: actions/setup-python@v1.1.1
-      with:
-        python-version: 3.7
-
     # Copied from:
     # https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions
     - name: Cache pip

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -11,6 +11,11 @@ jobs:
         git fetch origin master --unshallow
         git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
 
+    - name: Setup Python environment
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
     # Copied from:
     # https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions
     - name: Cache pip

--- a/fuzzers/afl/fuzzer.py
+++ b/fuzzers/afl/fuzzer.py
@@ -109,5 +109,4 @@ def fuzz(input_corpus, output_corpus, target_binary):
     """Run afl-fuzz on target."""
     prepare_fuzz_environment(input_corpus)
 
-    # test
     run_afl_fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl/fuzzer.py
+++ b/fuzzers/afl/fuzzer.py
@@ -109,4 +109,5 @@ def fuzz(input_corpus, output_corpus, target_binary):
     """Run afl-fuzz on target."""
     prepare_fuzz_environment(input_corpus)
 
+    # test
     run_afl_fuzz(input_corpus, output_corpus, target_binary)


### PR DESCRIPTION
This upgrades the versions of github actions we use to setup the python environment.
Using the old action results in these warnings: https://github.com/google/fuzzbench/actions/runs/304779767
More details here: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/