### PR TITLE
[CI][GCB] Fix commit build trigger

### DIFF
--- a/docker/gcb/base-images.yaml
+++ b/docker/gcb/base-images.yaml
@@ -19,6 +19,13 @@ images:
 - gcr.io/fuzzbench/base-image
 steps:
 - args:
+  - pull
+  - ubuntu:xenial
+  env:
+    - DOCKER_BUILDKIT=1
+  id: pull-ubuntu-xenial
+  name: docker:19.03.12
+- args:
   - build
   - --tag
   - gcr.io/fuzzbench/base-image
@@ -31,6 +38,8 @@ steps:
   - --file
   - docker/base-image/Dockerfile
   - docker/base-image
-  env: DOCKER_BUILDKIT=1
+  env:
+    - DOCKER_BUILDKIT=1
   id: base-image
   name: docker:19.03.12
+  wait_for: []

--- a/experiment/build/generate_cloudbuild.py
+++ b/experiment/build/generate_cloudbuild.py
@@ -80,7 +80,7 @@ def create_cloud_build_spec(image_templates,
     if build_base_images:
         cloud_build_spec['steps'].append({
             'id': 'pull-ubuntu-xenial',
-            'env': 'DOCKER_BUILDKIT=1',
+            'env': ['DOCKER_BUILDKIT=1'],
             'name': DOCKER_IMAGE,
             'args': ['pull', 'ubuntu:xenial'],
         })
@@ -88,7 +88,7 @@ def create_cloud_build_spec(image_templates,
     for image_name, image_specs in image_templates.items():
         step = {
             'id': image_name,
-            'env': 'DOCKER_BUILDKIT=1',
+            'env': ['DOCKER_BUILDKIT=1'],
             'name': DOCKER_IMAGE,
         }
         step['args'] = [

--- a/experiment/build/test_generate_cloudbuild.py
+++ b/experiment/build/test_generate_cloudbuild.py
@@ -40,12 +40,12 @@ def test_generate_cloud_build_spec_build_base_image():
     expected_spec = {
         'steps': [{
             'id': 'pull-ubuntu-xenial',
-            'env': 'DOCKER_BUILDKIT=1',
+            'env': ['DOCKER_BUILDKIT=1'],
             'name': 'docker:19.03.12',
             'args': ['pull', 'ubuntu:xenial']
         }, {
             'id': 'base-image',
-            'env': 'DOCKER_BUILDKIT=1',
+            'env': ['DOCKER_BUILDKIT=1'],
             'name': 'docker:19.03.12',
             'args': [
                 'build', '--tag', 'gcr.io/fuzzbench/base-image', '--tag',
@@ -90,7 +90,7 @@ def test_generate_cloud_build_spec_build_fuzzer_benchmark():
     expected_spec = {
         'steps': [{
             'id': 'afl-zlib-builder-intermediate',
-            'env': 'DOCKER_BUILDKIT=1',
+            'env': ['DOCKER_BUILDKIT=1'],
             'name': 'docker:19.03.12',
             'args': [
                 'build', '--tag',
@@ -159,7 +159,7 @@ def test_generate_cloud_build_spec_build_benchmark_coverage():
     expected_spec = {
         'steps': [{
             'id': 'zlib-project-builder',
-            'env': 'DOCKER_BUILDKIT=1',
+            'env': ['DOCKER_BUILDKIT=1'],
             'name': 'docker:19.03.12',
             'args': [
                 'build', '--tag', 'gcr.io/fuzzbench/builders/benchmark/zlib',
@@ -172,7 +172,7 @@ def test_generate_cloud_build_spec_build_benchmark_coverage():
             'wait_for': []
         }, {
             'id': 'coverage-zlib-builder-intermediate',
-            'env': 'DOCKER_BUILDKIT=1',
+            'env': ['DOCKER_BUILDKIT=1'],
             'name': 'docker:19.03.12',
             'args': [
                 'build', '--tag',
@@ -188,7 +188,7 @@ def test_generate_cloud_build_spec_build_benchmark_coverage():
             'wait_for': ['zlib-project-builder']
         }, {
             'id': 'coverage-zlib-builder',
-            'env': 'DOCKER_BUILDKIT=1',
+            'env': ['DOCKER_BUILDKIT=1'],
             'name': 'docker:19.03.12',
             'args': [
                 'build', '--tag', 'gcr.io/fuzzbench/builders/coverage/zlib',


### PR DESCRIPTION
This fixes the commit build trigger we use to build base-images
on every commit to master. While this trigger is not mandatory,
using it speeds up builds in CI by ensuring they never have to build
base-images (including python).