### PR TITLE
[New] Generate data recording segment and function coverage over time.

### DIFF
--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -160,12 +160,42 @@ class DataFrameContainer:
             self.segment_df = self.segment_df.drop_duplicates(
                 subset=self.segment_df.columns.difference(['time_stamp']),
                 keep="first")
-            # Converting all values to integer
-            self.segment_df = self.segment_df.astype(int)
-            self.function_df = self.function_df.astype(int)
 
         except (ValueError, KeyError, IndexError):
             logger.error('Error occurred when removing duplicates.')
+
+    def change_all_numeric_columns_to_int(self):
+        """Casts all the columns in segment_df and function_df to integer
+        type to avoid float/numeric types with decimal values"""
+        try:
+            # Cast all columns in segment_df and function_df to integer.
+            self.segment_df = self.segment_df.astype(int)
+            self.function_df = self.function_df.astype(int)
+        except TypeError:
+            logger.error('Error occurred when casting all columns in DataFrame'
+                         ' to integer type.')
+
+    def reorder_columns_in_segment_and_function_df(self):
+        """Re-orders the columns of segment_df and fucntion_df to the desired
+        order"""
+        try:
+            # Re-order columns in segment_df.
+            segmentdf_col_names = [
+                "benchmark_id", "fuzzer_id", "trial_id", "time_stamp",
+                "file_id", "line", "col"
+            ]
+            self.segment_df = self.segment_df.reindex(
+                columns=segmentdf_col_names)
+            # Re-order columns in function_df.
+            functiondf_col_names = [
+                "benchmark_id", "fuzzer_id", "trial_id", "time_stamp",
+                "function_id", "hits"
+            ]
+            self.function_df = self.function_df.reindex(
+                columns=functiondf_col_names)
+        except (IndexError, ValueError, KeyError):
+            logger.error('Error occurred when reordering columns in '
+                         'DataFrames.')
 
     def generate_csv_files(self):
         """Generates three compressed CSV files containing coverage information
@@ -176,6 +206,8 @@ class DataFrameContainer:
         # Clean and prune experiment-specific data frames.
         self.prepare_name_dataframe()
         self.remove_redundant_duplicates()
+        self.change_all_numeric_columns_to_int()
+        self.reorder_columns_in_segment_and_function_df()
 
         # Write CSV files to file store.
         def csv_filestore_helper(file_name, df):

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -160,6 +160,10 @@ class DataFrameContainer:
             self.segment_df = self.segment_df.drop_duplicates(
                 subset=self.segment_df.columns.difference(['time_stamp']),
                 keep="first")
+            # Converting all values to integer
+            self.segment_df = self.segment_df.astype(int)
+            self.function_df = self.function_df.astype(int)
+
         except (ValueError, KeyError, IndexError):
             logger.error('Error occurred when removing duplicates.')
 

--- a/experiment/coverage_utils.py
+++ b/experiment/coverage_utils.py
@@ -15,6 +15,8 @@
 
 import os
 import json
+import pandas as pd
+import numpy as np
 
 from common import experiment_path as exp_path
 from common import experiment_utils as exp_utils
@@ -34,8 +36,8 @@ COV_DIFF_QUEUE_GET_TIMEOUT = 1
 
 
 def get_coverage_info_dir():
-    """Returns the directory to store coverage information including
-    coverage report and json summary file."""
+    """Returns the directory to store coverage information including coverage
+    report and json summary file."""
     work_dir = exp_utils.get_work_dir()
     return os.path.join(work_dir, 'coverage')
 
@@ -54,6 +56,134 @@ def generate_coverage_reports(experiment_config: dict):
             generate_coverage_report(experiment, benchmark, fuzzer)
 
     logger.info('Finished generating coverage reports.')
+
+
+class DataFrameContainer:
+    """Maintains segment and function coverage information, and writes this
+    information to CSV files."""
+
+    def __init__(self):
+        """Construct data frames."""
+        self.segment_df = pd.DataFrame(columns=[
+            "benchmark", "fuzzer", "trial_id", "file_name", "line", "col",
+            "time_stamp"
+        ])
+        self.function_df = pd.DataFrame(columns=[
+            "benchmark", "fuzzer", "trial_id", "function_name", "hits",
+            "time_stamp"
+        ])
+        self.name_df = pd.DataFrame(columns=['id', 'name', 'type'])
+
+    def prepare_name_dataframe(self):
+        """Populates name data frame with experiment specific benchmark names,
+        fuzzer names, file names and function names and also replaces names with
+        ids in segment and function data frames."""
+        try:
+            # Stack all names into a single numpy array.
+            names = np.hstack([
+                self.segment_df['benchmark'].unique(),
+                self.segment_df['fuzzer'].unique(),
+                self.function_df['function_name'].unique(),
+                self.segment_df['file_name'].unique()
+            ])
+
+            # Create a list with "type" of names to match the stack above.
+            types = ['benchmark'] * len(self.segment_df['benchmark'].unique())
+            types.extend(['fuzzer'] * len(self.segment_df['fuzzer'].unique()))
+            types.extend(['function'] *
+                         len(self.function_df['function_name'].unique()))
+            types.extend(['file'] * len(self.segment_df['file_name'].unique()))
+
+            # Populate name DataFrame.
+            self.name_df['name'] = names
+            self.name_df['type'] = types
+            self.name_df.reset_index()
+            self.name_df['id'] = self.name_df.index + 1
+
+            # Reshape data frames for joins.
+            reshaped_name_df = self.name_df.pivot(index='name',
+                                                  columns='type',
+                                                  values='id')
+            # Make "name" a column again.
+            reshaped_name_df['name'] = reshaped_name_df.index
+
+            # Helper function to rename, drop, and leftjoin in bulk.
+            def rename_drop_columns_and_leftjoin(df1, df2, name_list):
+                column_name = name_list[0]
+                df2.columns = [
+                    'benchmark_id', 'file_id', 'function_id', 'fuzzer_id',
+                    column_name
+                ]
+                cols = [col for col in df2.columns if col not in name_list]
+                df = pd.merge(df1,
+                              df2.drop(columns=cols),
+                              on=column_name,
+                              how='outer')
+                df = df.drop(columns=[column_name])
+                return df.dropna()
+
+            # Replace names with ids by joining data frames.
+            self.segment_df = rename_drop_columns_and_leftjoin(
+                self.segment_df, reshaped_name_df, ['fuzzer', 'fuzzer_id'])
+
+            self.function_df = rename_drop_columns_and_leftjoin(
+                self.function_df, reshaped_name_df, ['fuzzer', 'fuzzer_id'])
+
+            self.segment_df = rename_drop_columns_and_leftjoin(
+                self.segment_df, reshaped_name_df,
+                ['benchmark', 'benchmark_id'])
+
+            self.function_df = rename_drop_columns_and_leftjoin(
+                self.function_df, reshaped_name_df,
+                ['benchmark', 'benchmark_id'])
+
+            self.segment_df = rename_drop_columns_and_leftjoin(
+                self.segment_df, reshaped_name_df, ['file_name', 'file_id'])
+
+            self.function_df = rename_drop_columns_and_leftjoin(
+                self.function_df, reshaped_name_df,
+                ['function_name', 'function_id'])
+
+        except (ValueError, KeyError, IndexError):
+            logger.error('Error occurred when preparing name DataFrame.')
+
+    def remove_redundant_duplicates(self):
+        """Removes redundant entries in segment_df. Before calling this
+        function, for each time stamp, segment_df contains all segments that are
+        covered in this time stamp. After calling this function, for each time
+        stamp, segment_df only contains segments that have been covered since
+        the previous time stamp. This significantly reduces the size of the
+        resulting CSV file."""
+        try:
+            # Drop duplicates but with different timestamps in segment data.
+            self.segment_df = self.segment_df.sort_values(by=['time_stamp'])
+            self.segment_df = self.segment_df.drop_duplicates(
+                subset=self.segment_df.columns.difference(['time_stamp']),
+                keep="first")
+        except (ValueError, KeyError, IndexError):
+            logger.error('Error occurred when removing duplicates.')
+
+    def generate_csv_files(self):
+        """Generates three compressed CSV files containing coverage information
+        for all fuzzers, benchmarks, and trials. To maintain a small file size,
+        all strings, such as file and function names, are referenced by id and
+        resolved in 'names.csv'."""
+
+        # Clean and prune experiment-specific data frames.
+        self.prepare_name_dataframe()
+        self.remove_redundant_duplicates()
+
+        # Write CSV files to file store.
+        def csv_filestore_helper(file_name, df):
+            """Helper function for storing csv files in filestore."""
+            src = os.path.join(get_coverage_info_dir(), 'data', file_name)
+            dst = exp_path.filestore(src)
+            df.to_csv(src, index=False, compression='infer')
+            filestore_utils.cp(src, dst)
+
+        csv_filestore_helper('functions.csv.gz', self.function_df)
+        csv_filestore_helper('segments.csv.gz', self.segment_df)
+        csv_filestore_helper('names.csv.gz', self.name_df)
 
 
 def generate_coverage_report(experiment, benchmark, fuzzer):
@@ -84,8 +214,8 @@ def generate_coverage_report(experiment, benchmark, fuzzer):
 
 
 class CoverageReporter:  # pylint: disable=too-many-instance-attributes
-    """Class used to generate coverage report for a pair of
-    fuzzer and benchmark."""
+    """Class used to generate coverage report for a pair of fuzzer and
+    benchmark."""
 
     # pylint: disable=too-many-arguments
     def __init__(self, experiment, fuzzer, benchmark):
@@ -267,6 +397,53 @@ def generate_json_summary(coverage_binary,
                                      output_file=dst_file,
                                      expect_zero=False)
     return result
+
+
+def extract_segments_and_functions_from_summary_json(  # pylint: disable=too-many-locals
+        summary_json_file, benchmark, fuzzer, trial_id, time_stamp):
+    """Return a trial-specific data frame container with segment and function
+     coverage information given a trial-specific coverage summary json file."""
+
+    process_specific_df_container = DataFrameContainer()
+
+    try:
+        coverage_info = get_coverage_infomation(summary_json_file)
+        # Extract coverage information for functions.
+        for function_data in coverage_info['data'][0]['functions']:
+            to_append = [
+                benchmark, fuzzer, trial_id, function_data['name'],
+                function_data['count'], time_stamp
+            ]
+            series = pd.Series(
+                to_append,
+                index=process_specific_df_container.function_df.columns)
+            process_specific_df_container.function_df = (
+                process_specific_df_container.function_df.append(
+                    series, ignore_index=True))
+
+        # Extract coverage information for segments.
+        line_index = 0
+        col_index = 1
+        hits_index = 2
+        for file in coverage_info['data'][0]['files']:
+            filename = file['filename']
+            for segment in file['segments']:
+                if segment[hits_index] != 0:
+                    to_append = [
+                        benchmark, fuzzer, trial_id, filename,
+                        segment[line_index], segment[col_index], time_stamp
+                    ]
+                    series = pd.Series(
+                        to_append,
+                        index=process_specific_df_container.segment_df.columns)
+                    process_specific_df_container.segment_df = (
+                        process_specific_df_container.segment_df.append(
+                            series, ignore_index=True))
+
+    except (ValueError, KeyError, IndexError):
+        logger.error('Failed when extracting trial-specific segment and'
+                     'function information from coverage summary')
+    return process_specific_df_container
 
 
 def extract_covered_regions_from_summary_json(summary_json_file):

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -576,8 +576,9 @@ def measure_trial_coverage(  # pylint: disable=invalid-name
                 measure_req.fuzzer, measure_req.benchmark, measure_req.trial_id,
                 cycle)
 
-            segment_list.append(process_specific_df_container.segment_df)
-            function_list.append(process_specific_df_container.function_df)
+            if process_specific_df_container is not None:
+                segment_list.append(process_specific_df_container.segment_df)
+                function_list.append(process_specific_df_container.function_df)
 
             if not snapshot:
                 break

--- a/experiment/measurer.py
+++ b/experiment/measurer.py
@@ -24,8 +24,9 @@ import posixpath
 import sys
 import tarfile
 import time
-from typing import List, Set
+from typing import List, Set, Tuple
 import queue
+import pandas as pd
 
 from sqlalchemy import func
 from sqlalchemy import orm
@@ -66,10 +67,13 @@ def measure_main(experiment_config):
     initialize_logs()
     logger.info('Start measuring.')
 
+    # Create data frame container for segment and function coverage info.
+    experiment_specific_df_container = coverage_utils.DataFrameContainer()
+
     # Start the measure loop first.
     experiment = experiment_config['experiment']
     max_total_time = experiment_config['max_total_time']
-    measure_loop(experiment, max_total_time)
+    measure_loop(experiment, max_total_time, experiment_specific_df_container)
 
     # Clean up resources.
     gc.collect()
@@ -77,10 +81,14 @@ def measure_main(experiment_config):
     # Do the final measuring and store the coverage data.
     coverage_utils.generate_coverage_reports(experiment_config)
 
+    # Generate segment and function coverage CSV files.
+    experiment_specific_df_container.generate_csv_files()
+
     logger.info('Finished measuring.')
 
 
-def measure_loop(experiment: str, max_total_time: int):
+def measure_loop(experiment: str, max_total_time: int,
+                 experiment_specific_df_container):
     """Continuously measure trials for |experiment|."""
     logger.info('Start measure_loop.')
 
@@ -89,15 +97,30 @@ def measure_loop(experiment: str, max_total_time: int):
         # Using Multiprocessing.Queue will fail with a complaint about
         # inheriting queue.
         q = manager.Queue()  # pytype: disable=attribute-error
+
+        segment_list = manager.list(  # pytype: disable=attribute-error
+            [experiment_specific_df_container.segment_df])
+
+        function_list = manager.list(  # pytype: disable=attribute-error
+            [experiment_specific_df_container.function_df])
+
         while True:
             try:
                 # Get whether all trials have ended before we measure to prevent
                 # races.
                 all_trials_ended = scheduler.all_trials_ended(experiment)
 
-                if not measure_all_trials(experiment, max_total_time, pool, q):
+                if not measure_all_trials(experiment, max_total_time, pool, q,
+                                          segment_list, function_list):
                     # We didn't measure any trials.
                     if all_trials_ended:
+                        # Concatenate all data frames in the segment and
+                        # function multiprocessing list.
+                        experiment_specific_df_container.segment_df = (
+                            pd.concat(segment_list, ignore_index=True))
+
+                        experiment_specific_df_container.function_df = (
+                            pd.concat(function_list, ignore_index=True))
                         # There are no trials producing snapshots to measure.
                         # Given that we couldn't measure any snapshots, we won't
                         # be able to measure any the future, so stop now.
@@ -110,7 +133,9 @@ def measure_loop(experiment: str, max_total_time: int):
     logger.info('Finished measure loop.')
 
 
-def measure_all_trials(experiment: str, max_total_time: int, pool, q) -> bool:  # pylint: disable=invalid-name
+def measure_all_trials(  # pylint: disable=too-many-arguments
+        experiment: str, max_total_time: int, pool, q, segment_list,
+        function_list) -> bool:  # pylint: disable=invalid-name
     """Get coverage data (with coverage runs) for all active trials. Note that
     this should not be called unless multiprocessing.set_start_method('spawn')
     was called first. Otherwise it will use fork which breaks logging."""
@@ -127,7 +152,7 @@ def measure_all_trials(experiment: str, max_total_time: int, pool, q) -> bool:  
         return False
 
     measure_trial_coverage_args = [
-        (unmeasured_snapshot, max_cycle, q)
+        (unmeasured_snapshot, max_cycle, q, segment_list, function_list)
         for unmeasured_snapshot in unmeasured_snapshots
     ]
 
@@ -155,6 +180,7 @@ def measure_all_trials(experiment: str, max_total_time: int, pool, q) -> bool:  
         try:
             snapshot = q.get(timeout=SNAPSHOT_QUEUE_GET_TIMEOUT)
             snapshots.append(snapshot)
+
         except queue.Empty:
             if result.ready():
                 # If "ready" that means pool has finished calling on each
@@ -376,7 +402,7 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
         self.UNIT_BLACKLIST[self.benchmark] = (
             self.UNIT_BLACKLIST[self.benchmark].union(set(crashing_units)))
 
-    def generate_summary(self, cycle: int, summary_only=True):
+    def generate_summary(self, cycle: int, summary_only=False):
         """Transforms the .profdata file into json form."""
         coverage_binary = coverage_utils.get_coverage_binary(self.benchmark)
         result = coverage_utils.generate_json_summary(coverage_binary,
@@ -409,6 +435,16 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
             self.logger.error(
                 'Coverage summary json file defective or missing.')
             return 0
+
+    def get_current_segment_and_function_coverage(self, time_stamp):
+        """Returns a process specific data frame with current segment and
+        function coverage"""
+        return coverage_utils.extract_segments_and_functions_from_summary_json(
+            self.cov_summary_file,
+            benchmark=self.benchmark,
+            fuzzer=self.fuzzer,
+            trial_id=self.trial_num,
+            time_stamp=time_stamp)
 
     def generate_profdata(self, cycle: int):
         """Generate .profdata file from .profraw file."""
@@ -526,8 +562,8 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
 
 
 def measure_trial_coverage(  # pylint: disable=invalid-name
-        measure_req, max_cycle: int,
-        q: multiprocessing.Queue) -> models.Snapshot:
+        measure_req, max_cycle: int, q: multiprocessing.Queue, segment_list,
+        function_list):
     """Measure the coverage obtained by |trial_num| on |benchmark| using
     |fuzzer|."""
     initialize_logs()
@@ -536,9 +572,13 @@ def measure_trial_coverage(  # pylint: disable=invalid-name
     # Add 1 to ensure we measure the last cycle.
     for cycle in range(min_cycle, max_cycle + 1):
         try:
-            snapshot = measure_snapshot_coverage(measure_req.fuzzer,
-                                                 measure_req.benchmark,
-                                                 measure_req.trial_id, cycle)
+            snapshot, process_specific_df_container = measure_snapshot_coverage(
+                measure_req.fuzzer, measure_req.benchmark, measure_req.trial_id,
+                cycle)
+
+            segment_list.append(process_specific_df_container.segment_df)
+            function_list.append(process_specific_df_container.function_df)
+
             if not snapshot:
                 break
             q.put(snapshot)
@@ -553,8 +593,9 @@ def measure_trial_coverage(  # pylint: disable=invalid-name
     logger.debug('Done measuring trial: %d.', measure_req.trial_id)
 
 
-def measure_snapshot_coverage(fuzzer: str, benchmark: str, trial_num: int,
-                              cycle: int) -> models.Snapshot:
+def measure_snapshot_coverage(  # pylint: disable=too-many-locals
+        fuzzer: str, benchmark: str, trial_num: int, cycle: int
+) -> Tuple[models.Snapshot, coverage_utils.DataFrameContainer]:
     """Measure coverage of the snapshot for |cycle| for |trial_num| of |fuzzer|
     and |benchmark|."""
     snapshot_logger = logs.Logger('measurer',
@@ -573,9 +614,13 @@ def measure_snapshot_coverage(fuzzer: str, benchmark: str, trial_num: int,
     if snapshot_measurer.is_cycle_unchanged(cycle):
         snapshot_logger.info('Cycle: %d is unchanged.', cycle)
         regions_covered = snapshot_measurer.get_current_coverage()
-        return models.Snapshot(time=this_time,
-                               trial_id=trial_num,
-                               edges_covered=regions_covered)
+        process_specific_df_container = (
+            snapshot_measurer.get_current_segment_and_function_coverage(
+                this_time))
+        snapshot = models.Snapshot(time=this_time,
+                                   trial_id=trial_num,
+                                   edges_covered=regions_covered)
+        return snapshot, process_specific_df_container
 
     corpus_archive_dst = os.path.join(
         snapshot_measurer.trial_dir, 'corpus',
@@ -590,7 +635,7 @@ def measure_snapshot_coverage(fuzzer: str, benchmark: str, trial_num: int,
                           corpus_archive_dst,
                           expect_zero=False).retcode:
         snapshot_logger.warning('Corpus not found for cycle: %d.', cycle)
-        return None
+        return None, None
 
     snapshot_measurer.initialize_measurement_dirs()
     snapshot_measurer.extract_corpus(corpus_archive_dst)
@@ -605,6 +650,8 @@ def measure_snapshot_coverage(fuzzer: str, benchmark: str, trial_num: int,
 
     # Get the coverage of the new corpus units.
     regions_covered = snapshot_measurer.get_current_coverage()
+    process_specific_df_container = (
+        snapshot_measurer.get_current_segment_and_function_coverage(this_time))
     snapshot = models.Snapshot(time=this_time,
                                trial_id=trial_num,
                                edges_covered=regions_covered)
@@ -617,7 +664,7 @@ def measure_snapshot_coverage(fuzzer: str, benchmark: str, trial_num: int,
     measuring_time = round(time.time() - measuring_start_time, 2)
     snapshot_logger.info('Measured cycle: %d in %f seconds.', cycle,
                          measuring_time)
-    return snapshot
+    return snapshot, process_specific_df_container
 
 
 def set_up_coverage_binaries(pool, experiment):
@@ -667,7 +714,8 @@ def main():
     experiment_name = experiment_utils.get_experiment_name()
 
     try:
-        measure_loop(experiment_name, int(sys.argv[1]))
+        measure_loop(experiment_name, int(sys.argv[1]),
+                     coverage_utils.DataFrameContainer())
     except Exception as error:
         logs.error('Error conducting experiment.')
         raise error


### PR DESCRIPTION
Sorry about the new PR. Reviewing would be easier this way :)

PR is about generating 3 compressed CSV files recording the segment and function coverage over time. The CSV files (headers mentioned alongside) being generated are:

 ```
         1. segments.csv (only covered segments) - (benchmark_id, fuzzer_id, trial_id, time_stamp, file_id, line, col)
         2. functions.csv - (benchmark_id, fuzzer_id, trial_id, time_stamp, function_id, hits)
         3. names.csv  - (id, name, type)
```

The segment and function coverage is being recorded while measuring snapshots (every 900 secs), hence the time_stamp column. The generated data captures the concrete code elements that are covered over time. For functions, we also maintain hit counts. For segments, we only record those that have been covered and add the newly covered segments for later time stamps. This makes it space efficient alongside compression.

This data is generated over the entire campaign at every snapshot point when coverage is measured but the CSV files are only available after the experiment ends.

Filestore path for these files:  **`experiment_data/$(EXPERIMENT_NAME)/coverage/data/{files above}.csv`** 
Since the files contain information specific to an experiment for all benchmark, fuzzer, trial combinations I chose the path above as the destination to copy these files.

This data is being generated for issue #686
@mboehme : "We are interested in (unique) coverage over time. We would use this data for empirical studies of the utility of various coverage criteria as measures of fuzzer performance and to study how we can visualise the progress of a fuzzer's coverage frontier in a subject over time, or visualise fuzzer roadblocks (potentially viz-a-viz other fuzzers)."

```
Experiment config:
        benchmark: libjpeg-turbo-07-2017
        fuzzers: libfuzzer, honggfuzz
        trials: 3 (each)
        max_total_time: 1860 (2 cycles)

Output files size:
        segment.csv.gz:  104.1 kB
        functions.csv.gz: 22.9 kB
        names.csv.gz:  5.3 kB
```

Based on the experiment results shown above, if we have to estimate the sizes on a full experiment, it can be calculated as:
```((size_of_segment.csv.gz + (size_of_function.csv.gz * measure_cycles * trials)) * fuzzers + size_of_name.csv.gz) * benchmarks ```

So for a 24-hour experiment (96 cycles), 20 benchmarks and 15 fuzzers and 10 trials the estimated size is ~ 552 mB. Due to certain repetitive patterns in the data, the final compressed sized may even result to lower than 552 mB as compression engines give a better compression rate if all the records are similar in a way.