### PR TITLE
Store crashes for libFuzzer, honggfuzzer in corpus sub-dir.

### DIFF
--- a/fuzzers/afl/fuzzer.py
+++ b/fuzzers/afl/fuzzer.py
@@ -69,9 +69,6 @@ def run_afl_fuzz(input_corpus,
                  hide_output=False):
     """Run afl-fuzz."""
     # Spawn the afl fuzzing process.
-    # FIXME: Currently AFL will exit if it encounters a crashing input in seed
-    # corpus (usually timeouts). Add a way to skip/delete such inputs and
-    # re-run AFL.
     print('[run_afl_fuzz] Running target with afl-fuzz')
     command = [
         './afl-fuzz',

--- a/fuzzers/honggfuzz/fuzzer.py
+++ b/fuzzers/honggfuzz/fuzzer.py
@@ -54,7 +54,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
         output_corpus,
 
         # Store crashes along with corpus for bug based benchmarking.
-        '--workspace',
+        '--crashdir',
         output_corpus,
     ]
     dictionary_path = utils.get_dictionary_path(target_binary)

--- a/fuzzers/honggfuzz/fuzzer.py
+++ b/fuzzers/honggfuzz/fuzzer.py
@@ -37,9 +37,12 @@ def build():
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
-    # Honggfuzz needs the output directory to exist.
-    if not os.path.exists(output_corpus):
-        os.makedirs(output_corpus)
+    # Seperate out corpus and crash directories as sub-directories of
+    # |output_corpus| to avoid conflicts when corpus directory is reloaded.
+    crashes_dir = os.path.join(output_corpus, 'crashes')
+    output_corpus = os.path.join(output_corpus, 'corpus')
+    os.makedirs(crashes_dir)
+    os.makedirs(output_corpus)
 
     print('[fuzz] Running target with honggfuzz')
     command = [
@@ -55,7 +58,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
 
         # Store crashes along with corpus for bug based benchmarking.
         '--crashdir',
-        output_corpus,
+        crashes_dir,
     ]
     dictionary_path = utils.get_dictionary_path(target_binary)
     if dictionary_path:

--- a/fuzzers/honggfuzz/fuzzer.py
+++ b/fuzzers/honggfuzz/fuzzer.py
@@ -52,6 +52,10 @@ def fuzz(input_corpus, output_corpus, target_binary):
         input_corpus,
         '--output',
         output_corpus,
+
+        # Store crashes along with corpus for bug based benchmarking.
+        '--workspace',
+        output_corpus,
     ]
     dictionary_path = utils.get_dictionary_path(target_binary)
     if dictionary_path:

--- a/fuzzers/honggfuzz_qemu/fuzzer.py
+++ b/fuzzers/honggfuzz_qemu/fuzzer.py
@@ -56,7 +56,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
         output_corpus,
 
         # Store crashes along with corpus for bug based benchmarking.
-        '--crashdir',
+        '--workspace',
         output_corpus,
         '-s',
     ]

--- a/fuzzers/honggfuzz_qemu/fuzzer.py
+++ b/fuzzers/honggfuzz_qemu/fuzzer.py
@@ -40,9 +40,12 @@ def build():
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
-    # Honggfuzz needs the output directory to exist.
-    if not os.path.exists(output_corpus):
-        os.makedirs(output_corpus)
+    # Seperate out corpus and crash directories as sub-directories of
+    # |output_corpus| to avoid conflicts when corpus directory is reloaded.
+    crashes_dir = os.path.join(output_corpus, 'crashes')
+    output_corpus = os.path.join(output_corpus, 'corpus')
+    os.makedirs(crashes_dir)
+    os.makedirs(output_corpus)
 
     print('[fuzz] Running target with honggfuzz')
     command = [
@@ -57,7 +60,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
 
         # Store crashes along with corpus for bug based benchmarking.
         '--crashdir',
-        output_corpus,
+        crashes_dir,
         '-s',
     ]
     dictionary_path = utils.get_dictionary_path(target_binary)

--- a/fuzzers/honggfuzz_qemu/fuzzer.py
+++ b/fuzzers/honggfuzz_qemu/fuzzer.py
@@ -56,7 +56,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
         output_corpus,
 
         # Store crashes along with corpus for bug based benchmarking.
-        '--workspace',
+        '--crashdir',
         output_corpus,
         '-s',
     ]

--- a/fuzzers/honggfuzz_qemu/fuzzer.py
+++ b/fuzzers/honggfuzz_qemu/fuzzer.py
@@ -54,6 +54,10 @@ def fuzz(input_corpus, output_corpus, target_binary):
         input_corpus,
         '--output',
         output_corpus,
+
+        # Store crashes along with corpus for bug based benchmarking.
+        '--crashdir',
+        output_corpus,
         '-s',
     ]
     dictionary_path = utils.get_dictionary_path(target_binary)

--- a/fuzzers/libfuzzer/fuzzer.py
+++ b/fuzzers/libfuzzer/fuzzer.py
@@ -49,6 +49,13 @@ def run_fuzzer(input_corpus, output_corpus, target_binary, extra_flags=None):
     if extra_flags is None:
         extra_flags = []
 
+    # Seperate out corpus and crash directories as sub-directories of
+    # |output_corpus| to avoid conflicts when corpus directory is reloaded.
+    crashes_dir = os.path.join(output_corpus, 'crashes')
+    output_corpus = os.path.join(output_corpus, 'corpus')
+    os.makedirs(crashes_dir)
+    os.makedirs(output_corpus)
+
     flags = [
         '-print_final_stats=1',
         # `close_fd_mask` to prevent too much logging output from the target.
@@ -65,7 +72,7 @@ def run_fuzzer(input_corpus, output_corpus, target_binary, extra_flags=None):
         '-detect_leaks=0',
 
         # Store crashes along with corpus for bug based benchmarking.
-        f'-artifact_prefix={output_corpus}/',
+        f'-artifact_prefix={crashes_dir}/',
     ]
     flags += extra_flags
     if 'ADDITIONAL_ARGS' in os.environ:

--- a/fuzzers/libfuzzer/fuzzer.py
+++ b/fuzzers/libfuzzer/fuzzer.py
@@ -63,6 +63,9 @@ def run_fuzzer(input_corpus, output_corpus, target_binary, extra_flags=None):
         # Don't use LSAN's leak detection. Other fuzzers won't be using it and
         # using it will cause libFuzzer to find "crashes" no one cares about.
         '-detect_leaks=0',
+
+        # Store crashes along with corpus for bug based benchmarking.
+        f'-artifact_prefix={output_corpus}/',
     ]
     flags += extra_flags
     if 'ADDITIONAL_ARGS' in os.environ:


### PR DESCRIPTION
This is needed for bug based benchmarking, as we archive corpus
dir and re-run it in measurer.