### PR TITLE
[build] Fix use of docker registries.

### DIFF
--- a/common/experiment_utils.py
+++ b/common/experiment_utils.py
@@ -81,16 +81,6 @@ def get_crashes_archive_name(cycle: int) -> str:
     return 'crashes-%04d.tar.gz' % cycle
 
 
-def get_base_docker_tag(cloud_project=None):
-    """Returns the base docker tag (i.e. Docker repo URL) given cloud_project.
-    If cloud is not provided, then the value of the environment variable
-    CLOUD_PROJECT is used."""
-    # Google Cloud Docker repos use the form "gcr.io/$CLOUD_PROJECT"
-    if cloud_project is None:
-        cloud_project = get_cloud_project()
-    return posixpath.join('gcr.io', cloud_project)
-
-
 def is_local_experiment():
     """Returns True if running a local experiment."""
     return bool(environment.get('LOCAL_EXPERIMENT'))

--- a/experiment/build/generate_cloudbuild.py
+++ b/experiment/build/generate_cloudbuild.py
@@ -27,8 +27,7 @@ DOCKER_IMAGE = 'docker:19.03.12'
 
 def get_experiment_tag_for_image(image_specs, tag_by_experiment=True):
     """Returns the registry with the experiment tag for given image."""
-    tag = posixpath.join(experiment_utils.get_base_docker_tag(),
-                         image_specs['tag'])
+    tag = posixpath.join(get_docker_registry(), image_specs['tag'])
     if tag_by_experiment:
         tag += ':' + experiment_utils.get_experiment_name()
     return tag
@@ -43,8 +42,8 @@ def coverage_steps(benchmark):
             DOCKER_IMAGE,
         'args': [
             'run', '-v', '/workspace/out:/host-out',
-            posixpath.join(experiment_utils.get_base_docker_tag(), 'builders',
-                           'coverage', benchmark) + ':' +
+            posixpath.join(get_docker_registry(), 'builders', 'coverage',
+                           benchmark) + ':' +
             experiment_utils.get_experiment_name(), '/bin/bash', '-c',
             'cd /out; tar -czvf /host-out/coverage-build-' + benchmark +
             '.tar.gz * /src /work'


### PR DESCRIPTION
Use docker registry from config to set the docker URLs instead
of using CLOUD_PROJECT.