### PR TITLE
Set DOCKER_REGISTRY env in dispatcher.

### DIFF
--- a/experiment/resources/dispatcher-startup-script-template.sh
+++ b/experiment/resources/dispatcher-startup-script-template.sh
@@ -21,6 +21,7 @@ docker run --rm \
   -e EXPERIMENT_FILESTORE={{experiment_filestore}} \
   -e POSTGRES_PASSWORD={{postgres_password}} \
   -e CLOUD_SQL_INSTANCE_CONNECTION_NAME={{cloud_sql_instance_connection_name}} \
+  -e DOCKER_REGISTRY={{docker_registry}} \
   --cap-add=SYS_PTRACE --cap-add=SYS_NICE \
   -v /var/run/docker.sock:/var/run/docker.sock --name=dispatcher-container \
   {{docker_registry}}/dispatcher-image /work/startup-dispatcher.sh


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "/work/src/experiment/dispatcher.py", line 192, in main
    dispatcher_main()
  File "/work/src/experiment/dispatcher.py", line 148, in dispatcher_main
    experiment.preemptible)
  File "/work/src/experiment/dispatcher.py", line 111, in build_images_for_trials
    builder.build_base_images()
  File "/work/src/experiment/build/builder.py", line 77, in build_base_images
    return buildlib.build_base_images()
  File "/work/src/experiment/build/gcb_build.py", line 51, in build_base_images
    build_base_images=True)
  File "/work/src/experiment/build/generate_cloudbuild.py", line 91, in create_cloudbuild_spec
    docker_registry = get_docker_registry()
  File "/work/src/experiment/build/generate_cloudbuild.py", line 63, in get_docker_registry
    return os.environ['DOCKER_REGISTRY']
  File "/work/.venv/lib/python3.7/os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'DOCKER_REGISTRY'
"
```