### PR TITLE
Use sanitizers when compiling matio

### DIFF
--- a/benchmarks/matio_matio_fuzzer/build.sh
+++ b/benchmarks/matio_matio_fuzzer/build.sh
@@ -20,7 +20,7 @@
 ./configure
 make -j$(nproc)
 make install
-
+CXXFLAGS="$CXXFLAGS -fsanitize=undefined,address" 
 # build fuzzers
 for fuzzers in $(find $SRC -name '*_fuzzer.cc'); do
   base=$(basename -s .cc $fuzzers)


### PR DESCRIPTION
In PR #666 I forgot to add the flags to compile matio with ASAN and UBSAN, which are needed since the bugs we have for it have been found by OSS-Fuzz using those sanitizers.