### PR TITLE
[GCB] Fix builds in other cloud projects and fix caching

### DIFF
--- a/experiment/build/generate_cloudbuild.py
+++ b/experiment/build/generate_cloudbuild.py
@@ -23,14 +23,62 @@ from common.utils import ROOT_DIR
 from experiment.build import build_utils
 
 DOCKER_IMAGE = 'docker:19.03.12'
+STANDARD_DOCKER_REGISTRY = 'gcr.io/fuzzbench'
 
 
-def get_experiment_tag_for_image(image_specs, tag_by_experiment=True):
-    """Returns the registry with the experiment tag for given image."""
-    tag = posixpath.join(get_docker_registry(), image_specs['tag'])
+def _get_image_tag(image_specs,
+                   tag_by_experiment=False,
+                   use_standard_registry=False):
+    """Returns an image tag for |image_specs|. Uses an experiment-specific tag
+    if |tag_by_experiment|. The registry is determined by the env var
+    DOCKER_REGISTRY or is |STANDARD_DOCKER_REGISTRY| if |use_standard_registry|
+    is True. Note that "tag" in this file generally refers to "name:tag".
+    """
+    if use_standard_registry:
+        registry = STANDARD_DOCKER_REGISTRY
+    else:
+        registry = get_docker_registry()
+
+    tag = posixpath.join(registry, image_specs['tag'])
     if tag_by_experiment:
         tag += ':' + experiment_utils.get_experiment_name()
     return tag
+
+
+def _get_gcb_image_tag(image_specs):
+    """Returns an image tag for |image_specs| that can be used by other steps in
+    GCB. This tag is needed because the docker images in FuzzBench inherit from
+    "gcr.io/fuzzbench/$PARENT" but the other tags for an image can't include
+    gcr.io/fuzzbench because they are used to name images that are actually
+    pushed to a registry, and not everyone can push to gcr.io/fuzzbench.
+    This tag should not actually be pushed since again not everyone can push to
+    gcr.io/fuzzbench.
+    """
+    return _get_image_tag(image_specs, use_standard_registry=True)
+
+
+def _get_experiment_image_tag(image_specs):
+    """Returns an image tag for |image_specs| that is experiment-specific and
+    can be used to get images built for a specific experiment. This is needed by
+    the runners which need to pull images built for a specific experiment.
+    Otherwise, if multiple experiments are running concurrently, the runners can
+    pull images built for another experiment.
+    """
+    # This tag will be used by images other than runner. However, it is only
+    # actually needed for the runner images. Doing it for the other images may
+    # help with debugging, but is primarily done to avoid compilcating the build
+    # code.
+    return _get_image_tag(image_specs, tag_by_experiment=True)
+
+
+def _get_cachable_image_tag(image_specs):
+    """Returns an image tag for |image_specs| that is cachable. By cachable, we
+    mean the images can both be pushed to the registry and be pulled from the
+    registry in a subsequent build. This means that the tag will use the
+    registry specified by this experiment and will not use an experiment
+    specific-tag (so that builds in other experiments can cache from this tag).
+    """
+    return _get_image_tag(image_specs)
 
 
 def coverage_steps(benchmark):
@@ -41,10 +89,16 @@ def coverage_steps(benchmark):
         'name':
             DOCKER_IMAGE,
         'args': [
-            'run', '-v', '/workspace/out:/host-out',
+            'run',
+            '-v',
+            '/workspace/out:/host-out',
+            # TODO(metzman): Get rid of this and use one source of truth
+            # for tags.
             posixpath.join(get_docker_registry(), 'builders', 'coverage',
                            benchmark) + ':' +
-            experiment_utils.get_experiment_name(), '/bin/bash', '-c',
+            experiment_utils.get_experiment_name(),
+            '/bin/bash',
+            '-c',
             'cd /out; tar -czvf /host-out/coverage-build-' + benchmark +
             '.tar.gz * /src /work'
         ]
@@ -88,8 +142,6 @@ def create_cloudbuild_spec(image_templates,
             'args': ['pull', 'ubuntu:xenial'],
         })
 
-    docker_registry = get_docker_registry()
-
     for image_name, image_specs in image_templates.items():
         step = {
             'id': image_name,
@@ -98,10 +150,11 @@ def create_cloudbuild_spec(image_templates,
         }
         step['args'] = [
             'build', '--tag',
-            posixpath.join(docker_registry, image_specs['tag']), '--tag',
-            get_experiment_tag_for_image(image_specs), '--cache-from',
-            get_experiment_tag_for_image(image_specs, tag_by_experiment=False),
-            '--build-arg', 'BUILDKIT_INLINE_CACHE=1'
+            _get_experiment_image_tag(image_specs), '--tag',
+            _get_gcb_image_tag(image_specs), '--tag',
+            _get_cachable_image_tag(image_specs), '--cache-from',
+            _get_cachable_image_tag(image_specs), '--build-arg',
+            'BUILDKIT_INLINE_CACHE=1'
         ]
         for build_arg in image_specs.get('build_arg', []):
             step['args'] += ['--build-arg', build_arg]
@@ -118,10 +171,8 @@ def create_cloudbuild_spec(image_templates,
             step['wait_for'] += [dependency]
 
         cloudbuild_spec['steps'].append(step)
-        cloudbuild_spec['images'].append(
-            get_experiment_tag_for_image(image_specs))
-        cloudbuild_spec['images'].append(
-            get_experiment_tag_for_image(image_specs, tag_by_experiment=False))
+        cloudbuild_spec['images'].append(_get_experiment_image_tag(image_specs))
+        cloudbuild_spec['images'].append(_get_cachable_image_tag(image_specs))
 
     if any(image_specs['type'] in 'coverage'
            for _, image_specs in image_templates.items()):

--- a/experiment/build/test_generate_cloudbuild.py
+++ b/experiment/build/test_generate_cloudbuild.py
@@ -89,9 +89,8 @@ def test_generate_cloudbuild_spec_other_registry(experiment):
             'name': 'docker:19.03.12',
             'args': [
                 'build', '--tag', 'gcr.io/not-fuzzbench/base-image'
-                ':test-experiment',
-                '--tag', 'gcr.io/fuzzbench/base-image', '--tag',
-                'gcr.io/not-fuzzbench/base-image', '--cache-from',
+                ':test-experiment', '--tag', 'gcr.io/fuzzbench/base-image',
+                '--tag', 'gcr.io/not-fuzzbench/base-image', '--cache-from',
                 'gcr.io/not-fuzzbench/base-image', '--build-arg',
                 'BUILDKIT_INLINE_CACHE=1', '--file',
                 'docker/base-image/Dockerfile', 'docker/base-image'

--- a/experiment/build/test_generate_cloudbuild.py
+++ b/experiment/build/test_generate_cloudbuild.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for generate_cloudbuild.py."""
+import os
 
 from experiment.build import generate_cloudbuild
 
@@ -19,7 +20,7 @@ from experiment.build import generate_cloudbuild
 
 
 def test_generate_cloudbuild_spec_build_base_image(experiment):
-    """Tests cloud build configuration yaml for the base image."""
+    """Tests generation of cloud build configuration yaml for the base image."""
     image_templates = {
         'base-image': {
             'dockerfile': 'docker/base-image/Dockerfile',
@@ -42,8 +43,9 @@ def test_generate_cloudbuild_spec_build_base_image(experiment):
             'env': ['DOCKER_BUILDKIT=1'],
             'name': 'docker:19.03.12',
             'args': [
-                'build', '--tag', 'gcr.io/fuzzbench/base-image', '--tag',
-                'gcr.io/fuzzbench/base-image:test-experiment', '--cache-from',
+                'build', '--tag', 'gcr.io/fuzzbench/base-image:test-experiment',
+                '--tag', 'gcr.io/fuzzbench/base-image', '--tag',
+                'gcr.io/fuzzbench/base-image', '--cache-from',
                 'gcr.io/fuzzbench/base-image', '--build-arg',
                 'BUILDKIT_INLINE_CACHE=1', '--file',
                 'docker/base-image/Dockerfile', 'docker/base-image'
@@ -59,8 +61,55 @@ def test_generate_cloudbuild_spec_build_base_image(experiment):
     assert generated_spec == expected_spec
 
 
+def test_generate_cloudbuild_spec_other_registry(experiment):
+    """Tests generation of cloud build configuration yaml for the base image
+    when a registry other than gcr.io/fuzzbench is specified.
+    """
+    os.environ['DOCKER_REGISTRY'] = 'gcr.io/not-fuzzbench'
+    image_templates = {
+        'base-image': {
+            'dockerfile': 'docker/base-image/Dockerfile',
+            'context': 'docker/base-image',
+            'tag': 'base-image',
+            'type': 'base'
+        }
+    }
+    generated_spec = generate_cloudbuild.create_cloudbuild_spec(
+        image_templates, build_base_images=True)
+
+    expected_spec = {
+        'steps': [{
+            'id': 'pull-ubuntu-xenial',
+            'env': ['DOCKER_BUILDKIT=1'],
+            'name': 'docker:19.03.12',
+            'args': ['pull', 'ubuntu:xenial']
+        }, {
+            'id': 'base-image',
+            'env': ['DOCKER_BUILDKIT=1'],
+            'name': 'docker:19.03.12',
+            'args': [
+                'build', '--tag', 'gcr.io/not-fuzzbench/base-image'
+                ':test-experiment',
+                '--tag', 'gcr.io/fuzzbench/base-image', '--tag',
+                'gcr.io/not-fuzzbench/base-image', '--cache-from',
+                'gcr.io/not-fuzzbench/base-image', '--build-arg',
+                'BUILDKIT_INLINE_CACHE=1', '--file',
+                'docker/base-image/Dockerfile', 'docker/base-image'
+            ],
+            'wait_for': []
+        }],
+        'images': [
+            'gcr.io/not-fuzzbench/base-image:test-experiment',
+            'gcr.io/not-fuzzbench/base-image'
+        ]
+    }
+
+    assert generated_spec == expected_spec
+
+
 def test_generate_cloudbuild_spec_build_fuzzer_benchmark(experiment):
-    """Tests cloud build configuration yaml for a fuzzer-benchmark build."""
+    """Tests generation of cloud build configuration yaml for a fuzzer-benchmark
+    build."""
     image_templates = {
         'afl-zlib-builder-intermediate': {
             'build_arg': [
@@ -83,9 +132,11 @@ def test_generate_cloudbuild_spec_build_fuzzer_benchmark(experiment):
             'name': 'docker:19.03.12',
             'args': [
                 'build', '--tag',
-                'gcr.io/fuzzbench/builders/afl/zlib-intermediate', '--tag',
                 'gcr.io/fuzzbench/builders/afl/zlib-intermediate'
-                ':test-experiment', '--cache-from',
+                ':test-experiment', '--tag',
+                'gcr.io/fuzzbench/builders/afl/zlib-intermediate', '--tag',
+                'gcr.io/fuzzbench/builders/afl/zlib-intermediate',
+                '--cache-from',
                 'gcr.io/fuzzbench/builders/afl/zlib-intermediate',
                 '--build-arg', 'BUILDKIT_INLINE_CACHE=1', '--build-arg',
                 'parent_image=gcr.io/fuzzbench/builders/benchmark/zlib',
@@ -98,12 +149,12 @@ def test_generate_cloudbuild_spec_build_fuzzer_benchmark(experiment):
             'gcr.io/fuzzbench/builders/afl/zlib-intermediate'
         ]
     }
-
     assert generated_spec == expected_spec
 
 
 def test_generate_cloudbuild_spec_build_benchmark_coverage(experiment):
-    """Tests cloud build configuration yaml for a benchmark coverage build."""
+    """Tests generation of cloud build configuration yaml for a benchmark
+    coverage build."""
     image_templates = {
         'zlib-project-builder': {
             'dockerfile': 'benchmarks/zlib/Dockerfile',
@@ -144,11 +195,12 @@ def test_generate_cloudbuild_spec_build_benchmark_coverage(experiment):
             'env': ['DOCKER_BUILDKIT=1'],
             'name': 'docker:19.03.12',
             'args': [
-                'build', '--tag', 'gcr.io/fuzzbench/builders/benchmark/zlib',
-                '--tag',
+                'build', '--tag',
                 'gcr.io/fuzzbench/builders/benchmark/zlib:test-experiment',
-                '--cache-from', 'gcr.io/fuzzbench/builders/benchmark/zlib',
-                '--build-arg', 'BUILDKIT_INLINE_CACHE=1', '--file',
+                '--tag', 'gcr.io/fuzzbench/builders/benchmark/zlib', '--tag',
+                'gcr.io/fuzzbench/builders/benchmark/zlib', '--cache-from',
+                'gcr.io/fuzzbench/builders/benchmark/zlib', '--build-arg',
+                'BUILDKIT_INLINE_CACHE=1', '--file',
                 'benchmarks/zlib/Dockerfile', 'benchmarks/zlib'
             ],
             'wait_for': []
@@ -158,9 +210,11 @@ def test_generate_cloudbuild_spec_build_benchmark_coverage(experiment):
             'name': 'docker:19.03.12',
             'args': [
                 'build', '--tag',
+                'gcr.io/fuzzbench/builders/coverage/zlib-intermediate:'
+                'test-experiment', '--tag',
                 'gcr.io/fuzzbench/builders/coverage/zlib-intermediate', '--tag',
-                'gcr.io/fuzzbench/builders/coverage/zlib-intermediate'
-                ':test-experiment', '--cache-from',
+                'gcr.io/fuzzbench/builders/coverage/zlib-intermediate',
+                '--cache-from',
                 'gcr.io/fuzzbench/builders/coverage/zlib-intermediate',
                 '--build-arg', 'BUILDKIT_INLINE_CACHE=1', '--build-arg',
                 'parent_image=gcr.io/fuzzbench/builders/benchmark/zlib',
@@ -173,13 +227,13 @@ def test_generate_cloudbuild_spec_build_benchmark_coverage(experiment):
             'env': ['DOCKER_BUILDKIT=1'],
             'name': 'docker:19.03.12',
             'args': [
-                'build', '--tag', 'gcr.io/fuzzbench/builders/coverage/zlib',
-                '--tag',
+                'build', '--tag',
                 'gcr.io/fuzzbench/builders/coverage/zlib:test-experiment',
-                '--cache-from', 'gcr.io/fuzzbench/builders/coverage/zlib',
-                '--build-arg', 'BUILDKIT_INLINE_CACHE=1', '--build-arg',
-                'benchmark=zlib', '--build-arg', 'fuzzer=coverage',
-                '--build-arg',
+                '--tag', 'gcr.io/fuzzbench/builders/coverage/zlib', '--tag',
+                'gcr.io/fuzzbench/builders/coverage/zlib', '--cache-from',
+                'gcr.io/fuzzbench/builders/coverage/zlib', '--build-arg',
+                'BUILDKIT_INLINE_CACHE=1', '--build-arg', 'benchmark=zlib',
+                '--build-arg', 'fuzzer=coverage', '--build-arg',
                 'parent_image=gcr.io/fuzzbench/builders/coverage/'
                 'zlib-intermediate', '--file',
                 'docker/benchmark-builder/Dockerfile', '.'
@@ -213,5 +267,4 @@ def test_generate_cloudbuild_spec_build_benchmark_coverage(experiment):
             'gcr.io/fuzzbench/builders/coverage/zlib'
         ]
     }
-
     assert generated_spec == expected_spec

--- a/experiment/build/test_generate_cloudbuild.py
+++ b/experiment/build/test_generate_cloudbuild.py
@@ -267,4 +267,5 @@ def test_generate_cloudbuild_spec_build_benchmark_coverage(experiment):
             'gcr.io/fuzzbench/builders/coverage/zlib'
         ]
     }
+
     assert generated_spec == expected_spec


### PR DESCRIPTION
Fix builds: Make sure we tag every image using the
gcr.io/fuzzbench style to ensure subsequent build steps can
use them.

Caching:
Previously when GCB builds tried to build a specific image they
used the last build of that image pushed to gcr.io/fuzzbench as
a cache. This broke caching when doing a build in another project
of an image that was never pushed to gcr.io/fuzzbench.

Also fix tests for both features and add a test to ensure other
docker registries are handled properly.