### PR TITLE
Hack around container-optimized-os issues

### DIFF
--- a/experiment/resources/dispatcher-startup-script-template.sh
+++ b/experiment/resources/dispatcher-startup-script-template.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Hack because container-optmized-os doesn't support writing to /home/root
+export HOME=/home/chronos
+mkdir HOME || true
 docker-credential-gcr configure-docker -include-artifact-registry
 echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
 docker run --rm \

--- a/experiment/resources/dispatcher-startup-script-template.sh
+++ b/experiment/resources/dispatcher-startup-script-template.sh
@@ -15,7 +15,7 @@
 
 # Hack because container-optmized-os doesn't support writing to /home/root
 export HOME=/home/chronos
-mkdir HOME || true
+mkdir -p $HOME
 docker-credential-gcr configure-docker -include-artifact-registry
 echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
 docker run --rm \

--- a/experiment/resources/dispatcher-startup-script-template.sh
+++ b/experiment/resources/dispatcher-startup-script-template.sh
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Hack because container-optmized-os doesn't support writing to /home/root
+# Hack because container-optmized-os doesn't support writing to /home/root.
+# docker-credential-gcr needs to write to a dotfile in $HOME.
 export HOME=/home/chronos
 mkdir -p $HOME
 docker-credential-gcr configure-docker -include-artifact-registry

--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -23,9 +23,10 @@ echo core >/proc/sys/kernel/core_pattern
 
 # Start docker.
 {% if not local_experiment %}
-# Hack because container-optmized-os doesn't support writing to /home/root
+# Hack because container-optmized-os doesn't support writing to /home/root.
+# docker-credential-gcr needs to write to a dotfile in $HOME.
 export HOME=/home/chronos
-mkdir HOME || true
+mkdir -p $HOME
 docker-credential-gcr configure-docker -include-artifact-registry
 
 while ! docker pull {{docker_image_url}}

--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -23,7 +23,11 @@ echo core >/proc/sys/kernel/core_pattern
 
 # Start docker.
 {% if not local_experiment %}
+# Hack because container-optmized-os doesn't support writing to /home/root
+export HOME=/home/chronos
+mkdir HOME || true
 docker-credential-gcr configure-docker -include-artifact-registry
+
 while ! docker pull {{docker_image_url}}
 do
   echo 'Error pulling image, retrying...'

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -94,7 +94,12 @@ def test_create_trial_instance(benchmark, expected_image, expected_target,
     and creates a startup script for the instance, as we expect it to."""
     expected_startup_script = '''# Start docker.
 
+# Hack because container-optmized-os doesn't support writing to /home/root.
+# docker-credential-gcr needs to write to a dotfile in $HOME.
+export HOME=/home/chronos
+mkdir -p $HOME
 docker-credential-gcr configure-docker -include-artifact-registry
+
 while ! docker pull {docker_image_url}
 do
   echo 'Error pulling image, retrying...'


### PR DESCRIPTION
Container-optimized-os doesn't allow writing to HOME.
Allowing docker to authenticate to the artifact registry requires
writing to the HOME directory of root.
To support this, use the HOME directory of another user on the
instance: chronos.

Also, create /home/chronos if it doesn't already exist. This will
allow use of these scripts on instances that aren't using COS.