### PR TITLE
Fix runner exception in stats calc due to virtualenv.

### DIFF
--- a/docker/benchmark-runner/Dockerfile
+++ b/docker/benchmark-runner/Dockerfile
@@ -81,13 +81,5 @@ COPY experiment/runner.py $ROOT_DIR/experiment/runner.py
 COPY docker/benchmark-runner $ROOT_DIR/docker/benchmark-runner
 
 ENV PYTHONPATH=$ROOT_DIR
-
-# |VIRTUALENV_DIR| is set so that python code can know the location of current
-# virtualenv directory and strip it if needed to execute in system python
-# environment.
-ENV VIRTUALENV_DIR=$ROOT_DIR/.venv
-RUN virtualenv --python=$(which python3) $VIRTUALENV_DIR
-RUN /bin/bash -c "source $VIRTUALENV_DIR/bin/activate && \
-    pip3 install -r $ROOT_DIR/docker/benchmark-runner/requirements.txt"
 RUN chmod +x $ROOT_DIR/docker/benchmark-runner/startup-runner.sh
 ENTRYPOINT $ROOT_DIR/docker/benchmark-runner/startup-runner.sh

--- a/docker/benchmark-runner/requirements.txt
+++ b/docker/benchmark-runner/requirements.txt
@@ -1,3 +1,0 @@
-# Keep these small, so the runner is more likely to work on diverse images.
-google-cloud-error-reporting==0.32.1
-google-cloud-logging==1.12.1

--- a/docker/benchmark-runner/startup-runner.sh
+++ b/docker/benchmark-runner/startup-runner.sh
@@ -13,10 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Script to run on creation of the runner container.
-# Loads the virtualenv before executing the runner script.
-source $VIRTUALENV_DIR/bin/activate
-
 # The runner runs at a higher priority than other processes to ensure that it's
 # able to finish infrastructure tasks regardless of the fuzzing workload.
 export RUNNER_NICENESS="-5"


### PR DESCRIPTION
Fixes exception. This yaml module is not inside runner virtualenv.
virtualenv is not needed in first place now since all those deps
in base-image. so simplify.

```
Traceback (most recent call last):
  File "/src/experiment/runner.py", line 368, in do_sync
    self.record_stats()
  File "/src/experiment/runner.py", line 380, in record_stats
    fuzzer_module = get_fuzzer_module(self.fuzzer)
  File "/src/experiment/runner.py", line 465, in get_fuzzer_module
    fuzzer_module = importlib.import_module(fuzzer_module_name)
  File "/src/.venv/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/src/fuzzers/afl_fast_agg/fuzzer.py", line 23, in <module>
    from fuzzers.afl import fuzzer as afl_fuzzer
  File "/src/fuzzers/afl/fuzzer.py", line 21, in <module>
    from fuzzers import utils
  File "/src/fuzzers/utils.py", line 24, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```