### PR TITLE
[build][make] Add dependency on base-image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ${VENV_ACTIVATE}: requirements.txt
 
 install-dependencies: ${VENV_ACTIVATE}
 
-docker/generated.mk: docker/generate_makefile.py fuzzers benchmarks ${VENV_ACTIVATE}
+docker/generated.mk: docker/generate_makefile.py docker/image_types.yaml fuzzers benchmarks ${VENV_ACTIVATE}
 	source ${VENV_ACTIVATE} && PYTHONPATH=. python3 $< > $@
 
 presubmit: install-dependencies

--- a/docker/image_types.yaml
+++ b/docker/image_types.yaml
@@ -41,6 +41,7 @@
     - 'parent_image=gcr.io/fuzzbench/builders/coverage/{benchmark}-intermediate'
   depends_on:
     - 'coverage-{benchmark}-builder-intermediate'
+    - 'base-image'
   dockerfile: 'docker/benchmark-builder/Dockerfile'
   context: '.'
   tag: 'builders/coverage/{benchmark}'
@@ -63,6 +64,7 @@
     - 'parent_image=gcr.io/fuzzbench/builders/{fuzzer}/{benchmark}-intermediate'
   depends_on:
     - '{fuzzer}-{benchmark}-builder-intermediate'
+    - 'base-image'
   dockerfile: 'docker/benchmark-builder/Dockerfile'
   context: '.'
   tag: 'builders/{fuzzer}/{benchmark}'
@@ -71,6 +73,7 @@
 '{fuzzer}-{benchmark}-intermediate-runner':
   depends_on:
     - '{fuzzer}-{benchmark}-builder'
+    - 'base-image'
   dockerfile: 'fuzzers/{fuzzer}/runner.Dockerfile'
   context: 'fuzzers/{fuzzer}'
   tag: 'runners/{fuzzer}/{benchmark}-intermediate'


### PR DESCRIPTION
base-image was not listed as a dependency of images that depended
on it in image_types.yaml. This problem was hidden by buildkit.
Also, regenerate makefile when image_types is modified.

Fixes #863
Fixes #862 