### PR TITLE
Update Eclipser to v2.0

### DIFF
--- a/fuzzers/afl/fuzzer.py
+++ b/fuzzers/afl/fuzzer.py
@@ -79,6 +79,15 @@ def prepare_fuzz_environment(input_corpus):
     utils.create_seed_file_for_empty_corpus(input_corpus)
 
 
+def check_skip_det_compatible(additional_flags):
+    """ Checks if additional flags are compatible with '-d' option"""
+    # AFL refuses to take in '-d' with '-M' or '-S' options for parallel mode.
+    # (cf. https://github.com/google/AFL/blob/8da80951/afl-fuzz.c#L7477)
+    if '-M' in additional_flags or '-S' in additional_flags:
+        return False
+    return True
+
+
 def run_afl_fuzz(input_corpus,
                  output_corpus,
                  target_binary,
@@ -93,15 +102,16 @@ def run_afl_fuzz(input_corpus,
         input_corpus,
         '-o',
         output_corpus,
-        # Use deterministic mode as it does best when we don't have
-        # seeds which is often the case.
-        '-d',
         # Use no memory limit as ASAN doesn't play nicely with one.
         '-m',
         'none',
         '-t',
         '1000+',  # Use same default 1 sec timeout, but add '+' to skip hangs.
     ]
+    # Use '-d' to skip deterministic mode, as long as it it compatible with
+    # additional flags.
+    if not additional_flags or check_skip_det_compatible(additional_flags):
+        command.append('-d')
     if additional_flags:
         command.extend(additional_flags)
     dictionary_path = utils.get_dictionary_path(target_binary)

--- a/fuzzers/eclipser/fuzzer.py
+++ b/fuzzers/eclipser/fuzzer.py
@@ -50,10 +50,9 @@ def build():
     new_env['CC'] = 'clang'
     new_env['CXX'] = 'clang++'
     new_env['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
-    # Reset compilation flags only using NO_SANITIZER_COMPAT_* flags. Eclipser
-    # module prefers unoptimized binaries, as hacky binary code can impede its
-    # grey-box concolic technique. Note that we can still use optimized binaries
-    # for AFL module.
+    # Ensure to compile with NO_SANITIZER_COMPAT* flags even for bug benchmarks,
+    # as QEMU is incompatible with sanitizers. Also, Eclipser prefers clean and
+    # unoptimized binaries. We leave fast random fuzzing as AFL's job.
     new_env['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
     cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
     new_env['CXXFLAGS'] = ' '.join(cxxflags)
@@ -107,7 +106,7 @@ def afl_master(input_corpus, output_corpus, target_binary):
 
 def afl_worker(input_corpus, output_corpus, target_binary):
     """Run AFL worker instance."""
-    print('[afl_slave] Run AFL worker')
+    print('[afl_worker] Run AFL worker')
     afl_fuzzer.run_afl_fuzz(input_corpus, output_corpus, target_binary,
                             ['-S', 'afl-worker'], True)
 

--- a/fuzzers/eclipser/fuzzer.py
+++ b/fuzzers/eclipser/fuzzer.py
@@ -100,66 +100,16 @@ def eclipser(input_corpus, output_corpus, target_binary):
 
 def afl_master(input_corpus, output_corpus, target_binary):
     """Run AFL master instance."""
-    command = [
-        './afl-fuzz',
-        '-i',
-        input_corpus,
-        '-o',
-        output_corpus,
-        # Use no memory limit as ASAN doesn't play nicely with one.
-        '-m',
-        'none',
-        # Use same default 1 sec timeout, but add '+' to skip hangs.
-        '-t',
-        '1000+',
-        '-M',
-        'afl-master',
-    ]
-    dictionary_path = utils.get_dictionary_path(target_binary)
-    if dictionary_path:
-        command.extend(['-x', dictionary_path])
-    command += [
-        '--',
-        target_binary,
-        # Pass INT_MAX to afl the maximize the number of persistent loops it
-        # performs.
-        '2147483647'
-    ]
-    print('[afl_master] Run AFL master with command: ' + ' '.join(command))
-    output_stream = subprocess.DEVNULL
-    subprocess.check_call(command, stdout=output_stream, stderr=output_stream)
+    print('[afl_master] Run AFL master')
+    afl_fuzzer.run_afl_fuzz(input_corpus, output_corpus, target_binary,
+                            ['-M', 'afl-master'], True)
 
 
 def afl_worker(input_corpus, output_corpus, target_binary):
     """Run AFL worker instance."""
-    command = [
-        './afl-fuzz',
-        '-i',
-        input_corpus,
-        '-o',
-        output_corpus,
-        # Use no memory limit as ASAN doesn't play nicely with one.
-        '-m',
-        'none',
-        # Use same default 1 sec timeout, but add '+' to skip hangs.
-        '-t',
-        '1000+',
-        '-S',
-        'afl-worker',
-    ]
-    dictionary_path = utils.get_dictionary_path(target_binary)
-    if dictionary_path:
-        command.extend(['-x', dictionary_path])
-    command += [
-        '--',
-        target_binary,
-        # Pass INT_MAX to afl the maximize the number of persistent loops it
-        # performs.
-        '2147483647'
-    ]
-    print('[afl_worker] Run AFL worker with command: ' + ' '.join(command))
-    output_stream = subprocess.DEVNULL
-    subprocess.check_call(command, stdout=output_stream, stderr=output_stream)
+    print('[afl_slave] Run AFL worker')
+    afl_fuzzer.run_afl_fuzz(input_corpus, output_corpus, target_binary,
+                            ['-S', 'afl-worker'], True)
 
 
 def fuzz(input_corpus, output_corpus, target_binary):

--- a/fuzzers/eclipser/fuzzer.py
+++ b/fuzzers/eclipser/fuzzer.py
@@ -11,88 +11,181 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Integration code for Eclipser fuzzer."""
+"""Integration code for Eclipser fuzzer. Note that starting from v2.0, Eclipser
+relies on AFL to perform random-based fuzzing."""
 
-import os
+import shutil
 import subprocess
-import time
-from multiprocessing import Process
+import os
+import threading
 
 from fuzzers import utils
+from fuzzers.afl import fuzzer as afl_fuzzer
+
+
+def get_uninstrumented_outdir(target_directory):
+    """Return path to uninstrumented target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
 
 
 def build():
     """Build benchmark."""
-    # QEMU does not work with sanitizers.
-    # See https://github.com/SoftSec-KAIST/Eclipser/issues/5
 
-    os.environ['CC'] = 'clang'
-    os.environ['CXX'] = 'clang++'
-    os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+    # Backup the environment.
+    new_env = os.environ.copy()
 
-    utils.build_benchmark()
+    # First, build an instrumented binary for AFL.
+    afl_fuzzer.prepare_build_environment()
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+    with utils.restore_directory(src), utils.restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        utils.build_benchmark()
+    print('[build] Copying afl-fuzz to $OUT directory')
+    shutil.copy('/afl/afl-fuzz', os.environ['OUT'])
+
+    # Next, build an uninstrumented binary for Eclipser.
+    new_env['CC'] = 'clang'
+    new_env['CXX'] = 'clang++'
+    new_env['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+    # Reset compilation flags only using NO_SANITIZER_COMPAT_* flags. Eclipser
+    # module prefers unoptimized binaries, as hacky binary code can impede its
+    # grey-box concolic technique. Note that we can still use optimized binaries
+    # for AFL module.
+    new_env['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+    cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
+    new_env['CXXFLAGS'] = ' '.join(cxxflags)
+    uninstrumented_outdir = get_uninstrumented_outdir(os.environ['OUT'])
+    os.mkdir(uninstrumented_outdir)
+    new_env['OUT'] = uninstrumented_outdir
+    fuzz_target = os.getenv('FUZZ_TARGET')
+    if fuzz_target:
+        targ_name = os.path.basename(fuzz_target)
+        new_env['FUZZ_TARGET'] = os.path.join(uninstrumented_outdir, targ_name)
+    print('[build] Re-building benchmark for uninstrumented fuzzing target')
+    utils.build_benchmark(env=new_env)
+
+
+def eclipser(input_corpus, output_corpus, target_binary):
+    """Run Eclipser."""
+    # We will use output_corpus as a directory where AFL and Eclipser sync their
+    # test cases with each other. For Eclipser, we should explicitly specify an
+    # output directory under this sync directory.
+    eclipser_out = os.path.join(output_corpus, "eclipser_output")
+    command = [
+        'dotnet',
+        '/Eclipser/build/Eclipser.dll',
+        '-p',
+        target_binary,
+        '-s',
+        output_corpus,
+        '-o',
+        eclipser_out,
+        '--arg',  # Specifies the command-line of the program.
+        'foo',
+        '-f',  # Specifies the path of file input to fuzz.
+        'foo',
+        '-v',  # Controls the verbosity.
+        '2',
+        '--exectimeout',
+        '4000',
+    ]
+    if os.listdir(input_corpus):  # Specify inputs only if any seed exists.
+        command += ['-i', input_corpus]
+    print('[eclipser] Run Eclipser with command: ' + ' '.join(command))
+    subprocess.Popen(command)
+
+
+def afl_master(input_corpus, output_corpus, target_binary):
+    """Run AFL master instance."""
+    command = [
+        './afl-fuzz',
+        '-i',
+        input_corpus,
+        '-o',
+        output_corpus,
+        # Use no memory limit as ASAN doesn't play nicely with one.
+        '-m',
+        'none',
+        # Use same default 1 sec timeout, but add '+' to skip hangs.
+        '-t',
+        '1000+',
+        '-M',
+        'afl-master',
+    ]
+    dictionary_path = utils.get_dictionary_path(target_binary)
+    if dictionary_path:
+        command.extend(['-x', dictionary_path])
+    command += [
+        '--',
+        target_binary,
+        # Pass INT_MAX to afl the maximize the number of persistent loops it
+        # performs.
+        '2147483647'
+    ]
+    print('[afl_master] Run AFL master with command: ' + ' '.join(command))
+    output_stream = subprocess.DEVNULL
+    subprocess.check_call(command, stdout=output_stream, stderr=output_stream)
+
+
+def afl_worker(input_corpus, output_corpus, target_binary):
+    """Run AFL worker instance."""
+    command = [
+        './afl-fuzz',
+        '-i',
+        input_corpus,
+        '-o',
+        output_corpus,
+        # Use no memory limit as ASAN doesn't play nicely with one.
+        '-m',
+        'none',
+        # Use same default 1 sec timeout, but add '+' to skip hangs.
+        '-t',
+        '1000+',
+        '-S',
+        'afl-worker',
+    ]
+    dictionary_path = utils.get_dictionary_path(target_binary)
+    if dictionary_path:
+        command.extend(['-x', dictionary_path])
+    command += [
+        '--',
+        target_binary,
+        # Pass INT_MAX to afl the maximize the number of persistent loops it
+        # performs.
+        '2147483647'
+    ]
+    print('[afl_worker] Run AFL worker with command: ' + ' '.join(command))
+    output_stream = subprocess.DEVNULL
+    subprocess.check_call(command, stdout=output_stream, stderr=output_stream)
 
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
-    # Create an encoded temp corpus directory.
-    encoded_temp_corpus = os.path.join(os.path.dirname(input_corpus),
-                                       'temp-corpus')
-    if not os.path.exists(encoded_temp_corpus):
-        os.mkdir(encoded_temp_corpus)
 
-    print('[fuzz] Running target with Eclipser')
-    command = [
-        'dotnet',
-        '/Eclipser/build/Eclipser.dll',
-        'fuzz',
-        '-p',
-        target_binary,
-        '-t',
-        '1048576',  # FIXME: Find the max value allowed here.
-        '-o',
-        encoded_temp_corpus,
-        '--src',
-        'file',
-        '--initarg',
-        'foo',  # Specifies how command line argument is passed, just a file.
-        '-f',
-        'foo',
-        '--maxfilelen',
-        # Default is too low (8 bytes), match experiment config at:
-        # https://github.com/SoftSec-KAIST/Eclipser-Artifact/blob/6aadf02eeadb0416bd4c5edeafc8627bc24ebc82/docker-scripts/experiment-scripts/package-exp/run_eclipser.sh#L25
-        '1048576',
-        # Default is low (0.5 sec), recommended to use higher:
-        # https://github.com/google/fuzzbench/issues/70#issuecomment-596060572
-        '--exectimeout',
-        '5000',
-    ]
-    if os.listdir(input_corpus):  # Important, otherwise Eclipser crashes.
-        command += ['-i', input_corpus]
-    print('[fuzz] Running command: ' + ' '.join(command))
-    subprocess.Popen(command)
+    # Calculate uninstrumented binary path from the instrumented target binary.
+    target_binary_directory = os.path.dirname(target_binary)
+    uninstrumented_target_binary_directory = (
+        get_uninstrumented_outdir(target_binary_directory))
+    target_binary_name = os.path.basename(target_binary)
+    uninstrumented_target_binary = os.path.join(
+        uninstrumented_target_binary_directory, target_binary_name)
 
-    process = Process(target=copy_corpus_directory,
-                      args=(
-                          encoded_temp_corpus,
-                          output_corpus,
-                      ))
-    process.start()
-
-
-def copy_corpus_directory(encoded_temp_corpus, output_corpus):
-    """Copies corpus periodically from encoded corpus directory into output
-  directory."""
-    while True:
-        # Wait for initial fuzzer initialization, and after every copy.
-        time.sleep(120)
-
-        subprocess.check_call([
-            'dotnet',
-            '/Eclipser/build/Eclipser.dll',
-            'decode',
-            '-i',
-            os.path.join(encoded_temp_corpus, 'testcase'),
-            '-o',
-            output_corpus,
-        ])
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+    afl_args = (input_corpus, output_corpus, target_binary)
+    eclipser_args = (input_corpus, output_corpus, uninstrumented_target_binary)
+    print('[fuzz] Running AFL master')
+    afl_master_thread = threading.Thread(target=afl_master, args=afl_args)
+    afl_master_thread.start()
+    print('[fuzz] Running AFL worker')
+    afl_worker_thread = threading.Thread(target=afl_worker, args=afl_args)
+    afl_worker_thread.start()
+    print('[fuzz] Running Eclipser')
+    eclipser_thread = threading.Thread(target=eclipser, args=eclipser_args)
+    eclipser_thread.start()
+    print('[fuzz] Now waiting for threads to finish...')
+    afl_master_thread.join()
+    afl_worker_thread.join()
+    eclipser_thread.join()

--- a/fuzzers/eclipser/fuzzer.py
+++ b/fuzzers/eclipser/fuzzer.py
@@ -97,13 +97,6 @@ def eclipser(input_corpus, output_corpus, target_binary):
     subprocess.Popen(command)
 
 
-def afl_master(input_corpus, output_corpus, target_binary):
-    """Run AFL master instance."""
-    print('[afl_master] Run AFL master')
-    afl_fuzzer.run_afl_fuzz(input_corpus, output_corpus, target_binary,
-                            ['-M', 'afl-master'], True)
-
-
 def afl_worker(input_corpus, output_corpus, target_binary):
     """Run AFL worker instance."""
     print('[afl_worker] Run AFL worker')
@@ -125,9 +118,8 @@ def fuzz(input_corpus, output_corpus, target_binary):
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     afl_args = (input_corpus, output_corpus, target_binary)
     eclipser_args = (input_corpus, output_corpus, uninstrumented_target_binary)
-    print('[fuzz] Running AFL master')
-    afl_master_thread = threading.Thread(target=afl_master, args=afl_args)
-    afl_master_thread.start()
+    # Do not launch AFL master instance for now, to reduce memory usage and
+    # align with the vanilla AFL.
     print('[fuzz] Running AFL worker')
     afl_worker_thread = threading.Thread(target=afl_worker, args=afl_args)
     afl_worker_thread.start()
@@ -135,6 +127,5 @@ def fuzz(input_corpus, output_corpus, target_binary):
     eclipser_thread = threading.Thread(target=eclipser, args=eclipser_args)
     eclipser_thread.start()
     print('[fuzz] Now waiting for threads to finish...')
-    afl_master_thread.join()
     afl_worker_thread.join()
     eclipser_thread.join()

--- a/fuzzers/eclipser/fuzzer.py
+++ b/fuzzers/eclipser/fuzzer.py
@@ -90,7 +90,7 @@ def eclipser(input_corpus, output_corpus, target_binary):
         '-v',  # Controls the verbosity.
         '2',
         '--exectimeout',
-        '4000',
+        '5000',
     ]
     if os.listdir(input_corpus):  # Specify inputs only if any seed exists.
         command += ['-i', input_corpus]

--- a/fuzzers/eclipser/runner.Dockerfile
+++ b/fuzzers/eclipser/runner.Dockerfile
@@ -39,7 +39,7 @@ RUN wget -q https://storage.googleapis.com/fuzzbench-files/packages-microsoft-pr
     rm packages-microsoft-prod.deb
 
 # Build Eclipser.
-RUN git clone https://github.com/SoftSec-KAIST/Eclipser /Eclipser && \
+RUN git clone https://github.com/SoftSec-KAIST/Eclipser.git /Eclipser && \
     cd /Eclipser && \
-    git checkout b072f045324869c607d3cdfa8fae0cdfed944492 && \
+    git checkout 310220649a4d790f8bc858ef85873399bba79a8c && \
     make


### PR DESCRIPTION
Eclipser previously had its own simplified random fuzzing module that mimics AFL. This was to support fuzzing multiple input sources (stdin, file, etc.) at once. We recently decided to focus on fuzzing a single input source, as most fuzzers do. This allows us to directly integrate Eclipser with AFL. From v2.0, Eclipser only performs grey-box concolic testing, and relies on AFL for random fuzzing. For the details and context of the update, please refer to https://github.com/SoftSec-KAIST/Eclipser#eclipser-v20.

This PR updates Eclipser to run v2.0 code in parallel with AFL.