### PR TITLE
[CI] Sort benchmarks before building them.

### DIFF
--- a/.github/workflows/build_and_test_run_fuzzer_benchmarks.py
+++ b/.github/workflows/build_and_test_run_fuzzer_benchmarks.py
@@ -94,6 +94,9 @@ def make_builds(benchmarks, fuzzer):
     """Use make to test the fuzzer on each benchmark in |benchmarks|."""
     fuzzer_benchmark_pairs = builder.get_fuzzer_benchmark_pairs([fuzzer],
                                                                 benchmarks)
+    # Sort benchmarks so that they get built in a deterministic order.
+    fuzzer_benchmark_pairs = sorted(fuzzer_benchmark_pairs,
+                                    key=lambda pair: pair[1])
     print('Building fuzzer-benchmark pairs: {}'.format(fuzzer_benchmark_pairs))
     for _, benchmark in fuzzer_benchmark_pairs:
         make_target = get_make_target(fuzzer, benchmark)
@@ -129,8 +132,6 @@ def do_build(build_type, fuzzer, always_build):
     # Otherwise, only build benchmarks that have changed.
     changed_benchmarks = set(change_utils.get_changed_benchmarks(changed_files))
     benchmarks = benchmarks.intersection(changed_benchmarks)
-    # Sort benchmarks so that they get built in a deterministic order.
-    benchmarks = sorted(benchmarks)
     return make_builds(benchmarks, fuzzer)
 
 

--- a/.github/workflows/build_and_test_run_fuzzer_benchmarks.py
+++ b/.github/workflows/build_and_test_run_fuzzer_benchmarks.py
@@ -129,6 +129,8 @@ def do_build(build_type, fuzzer, always_build):
     # Otherwise, only build benchmarks that have changed.
     changed_benchmarks = set(change_utils.get_changed_benchmarks(changed_files))
     benchmarks = benchmarks.intersection(changed_benchmarks)
+    # Sort benchmarks so that they get built in a deterministic order.
+    benchmarks = sorted(benchmarks)
     return make_builds(benchmarks, fuzzer)
 
 


### PR DESCRIPTION
Sort benchmarks before building them to make CI more deterministic.
This change will ensure that benchmarks are built in the same order.