### PR TITLE
[queue]Use one source of truth for cycle filenames.

### DIFF
--- a/common/experiment_utils.py
+++ b/common/experiment_utils.py
@@ -71,19 +71,26 @@ def get_trial_instance_name(experiment: str, trial_id: int) -> str:
     return 'r-%s-%d' % (experiment, trial_id)
 
 
+def get_cycle_filename(basename: str, cycle: int) -> str:
+    """Returns a filename for a file that is relevant to a particular snapshot
+    cycle."""
+    filename = basename + '-' + ('%04d' % cycle)
+    return filename
+
+
 def get_corpus_archive_name(cycle: int) -> str:
     """Returns a corpus archive name given a cycle."""
-    return 'corpus-archive-%04d.tar.gz' % cycle
+    return get_cycle_filename('corpus-archive', cycle) + '.tar.gz'
 
 
 def get_stats_filename(cycle: int) -> str:
     """Returns a corpus archive name given a cycle."""
-    return 'stats-%04d.json' % cycle
+    return get_cycle_filename('stats', cycle) + '.json'
 
 
 def get_crashes_archive_name(cycle: int) -> str:
     """Return as crashes archive name given a cycle."""
-    return 'crashes-%04d.tar.gz' % cycle
+    return get_cycle_filename('crashes', cycle) + '.tar.gz'
 
 
 def is_local_experiment():


### PR DESCRIPTION
Use one source of truth for naming of cycle files (e.g. corpus-archive-0001).

Part of queue based measurer (#895).