### PR TITLE
[queue][retry] Allow opting-out of logging retries

### DIFF
--- a/common/logs.py
+++ b/common/logs.py
@@ -150,7 +150,7 @@ class LogSeverity(Enum):
     DEBUG = logging.DEBUG
 
 
-@retry.wrap(NUM_RETRIES, RETRY_DELAY, 'common.logs.log')
+@retry.wrap(NUM_RETRIES, RETRY_DELAY, 'common.logs.log', log_retries=False)
 def log(logger, severity, message, *args, extras=None):
     """Log a message with severity |severity|. If using stack driver logging
     then |extras| is also logged (in addition to default extras)."""

--- a/common/retry.py
+++ b/common/retry.py
@@ -37,6 +37,7 @@ def wrap(  # pylint: disable=too-many-arguments
         function,
         backoff=2,
         exception_type=Exception,
+        log_retries=True,
         retry_on_false=False):
     """Retry decorator for a function."""
     # To avoid circular dependency.
@@ -59,9 +60,10 @@ def wrap(  # pylint: disable=too-many-arguments
 
             if (exception is None or
                     isinstance(exception, exception_type)) and num_try < tries:
-                logs.info('Retrying on %s failed with %s. Retrying again.',
-                          function_with_type,
-                          sys.exc_info()[1])
+                if log_retries:
+                    logs.info('Retrying on %s failed with %s. Retrying again.',
+                              function_with_type,
+                              sys.exc_info()[1])
                 sleep(get_delay(num_try, delay, backoff))
                 return True
 


### PR DESCRIPTION
We use the retry wrapper to retry logging.
The retry wrapper will log that is retrying.
This can present a problem because logging can fail because of quota
limits. Obviously if that happens it won't help to log that we
are retrying logging.
Thus, solve this problem by allowing users of the wrapper to opt
out of logging on retries, and opt-out in logs.py.
See #895 