### PR TITLE
[queue][filestore_utils] Add `cat` and fix consistency.

### DIFF
--- a/common/filestore_utils.py
+++ b/common/filestore_utils.py
@@ -37,15 +37,15 @@ def get_impl():
     return local_filestore
 
 
-def cp(source, destination, recursive=False, parallel=False, expect_zero=True):  # pylint: disable=invalid-name
+def cp(source, destination, recursive=False, expect_zero=True, parallel=False):  # pylint: disable=invalid-name
     """Copies |source| to |destination|. If |expect_zero| is True then it can
     raise subprocess.CalledProcessError. |parallel| is only used by the gsutil
     implementation."""
     return get_impl().cp(source,
                          destination,
                          recursive=recursive,
-                         parallel=parallel,
-                         expect_zero=expect_zero)
+                         expect_zero=expect_zero,
+                         parallel=parallel)
 
 
 def ls(path, must_exist=True):  # pylint: disable=invalid-name
@@ -79,3 +79,8 @@ def rsync(  # pylint: disable=too-many-arguments
                             gsutil_options,
                             options,
                             parallel=parallel)
+
+
+def cat(file_path, expect_zero=True):
+    """Reads the file at |file_path| and returns the result."""
+    return get_impl().cat(file_path, expect_zero=expect_zero)

--- a/common/gsutil.py
+++ b/common/gsutil.py
@@ -28,7 +28,7 @@ def gsutil_command(arguments, expect_zero=True, parallel=False):
     return new_process.execute(command + arguments, expect_zero=expect_zero)
 
 
-def cp(source, destination, recursive=False, parallel=False, expect_zero=True):  # pylint: disable=invalid-name
+def cp(source, destination, recursive=False, expect_zero=True, parallel=False):  # pylint: disable=invalid-name
     """Executes gsutil's "cp" command to copy |source| to |destination|. Uses -r
     if |recursive|. If |expect_zero| is True and the command fails then this
     function will raise a subprocess.CalledError."""
@@ -37,7 +37,7 @@ def cp(source, destination, recursive=False, parallel=False, expect_zero=True): 
         command.append('-r')
     command.extend([source, destination])
 
-    return gsutil_command(command, parallel=parallel, expect_zero=expect_zero)
+    return gsutil_command(command, expect_zero=expect_zero, parallel=parallel)
 
 
 def ls(path, must_exist=True):  # pylint: disable=invalid-name
@@ -84,3 +84,12 @@ def rsync(  # pylint: disable=too-many-arguments
         command.extend(options)
     command.extend([source, destination])
     return gsutil_command(command, parallel=parallel)
+
+
+def cat(file_path, expect_zero=True):
+    """Does gsutil cat on |file_path| and returns the result."""
+    command = ['cat', file_path]
+    # TODO(metzman): Consider replacing this technique with cp to temp file
+    # and a local `cat`. The problem with this technique is stderr output
+    # from gsutil can be included.
+    return gsutil_command(command, expect_zero=expect_zero)

--- a/common/local_filestore.py
+++ b/common/local_filestore.py
@@ -23,8 +23,8 @@ def cp(  # pylint: disable=invalid-name
         source,
         destination,
         recursive=False,
-        parallel=False,  # pylint: disable=unused-argument
-        expect_zero=True):
+        expect_zero=True,
+        parallel=False):  # pylint: disable=unused-argument
     """Executes "cp" command from |source| to |destination|."""
     # Create intermediate folders for `cp` command to behave like `gsutil.cp`.
     filesystem.create_directory(os.path.dirname(destination))
@@ -91,3 +91,9 @@ def rsync(  # pylint: disable=too-many-arguments
         source = source + '/'
     command.extend([source, destination])
     return new_process.execute(command, expect_zero=True)
+
+
+def cat(file_path, expect_zero=True):
+    """Does cat on |file_path| and returns the result."""
+    command = ['cat', file_path]
+    return new_process.execute(command, expect_zero=expect_zero)


### PR DESCRIPTION
Add `cat` function.
Make arguments to cp consistent with the rest of the file (parallel
should be last).
See #895.