### PR TITLE
[queue][presubmit] Allow third_party directories anywhere.

### DIFF
--- a/presubmit.py
+++ b/presubmit.py
@@ -60,9 +60,9 @@ _LICENSE_CHECK_EXTENSIONS = [
 _LICENSE_CHECK_STRING = 'http://www.apache.org/licenses/LICENSE-2.0'
 
 _SRC_ROOT = Path(__file__).absolute().parent
+THIRD_PARTY_DIR_NAME = 'third_party'
 _IGNORE_DIRECTORIES = [
     os.path.join(_SRC_ROOT, 'database', 'alembic'),
-    os.path.join(_SRC_ROOT, 'third_party'),
     os.path.join(_SRC_ROOT, 'benchmarks'),
 ]
 
@@ -306,11 +306,18 @@ def validate_experiment_requests(paths: List[Path]):
     return result
 
 
-def is_path_in_ignore_directory(path: Path) -> bool:
-    """Returns True if |path| is a subpath of an ignored directory."""
+def is_path_ignored(path: Path) -> bool:
+    """Returns True if |path| is a subpath of an ignored directory or is a
+    third_party directory."""
     for ignore_directory in _IGNORE_DIRECTORIES:
         if filesystem.is_subpath(ignore_directory, path):
             return True
+
+    # Third party directories can be anywhere.
+    path_parts = str(path).split(os.sep)
+    if any(path_part == THIRD_PARTY_DIR_NAME for path_part in path_parts):
+        return True
+
     return False
 
 
@@ -327,7 +334,7 @@ def license_check(paths: List[Path]) -> bool:
                 extension not in _LICENSE_CHECK_EXTENSIONS):
             continue
 
-        if is_path_in_ignore_directory(path):
+        if is_path_ignored(path):
             continue
 
         with open(path) as file_handle:
@@ -349,7 +356,7 @@ def get_all_files() -> List[Path]:
 def filter_ignored_files(paths: List[Path]) -> List[Path]:
     """Returns a list of absolute paths of files in this repo that can be
     checked statically."""
-    return [path for path in paths if not is_path_in_ignore_directory(path)]
+    return [path for path in paths if not is_path_ignored(path)]
 
 
 def do_tests() -> bool:


### PR DESCRIPTION
Ignore files in directories named third_party when doing license checks
even if they aren't in $ROOT/third_party.

See #895.