### PR TITLE
 [queue] Rename measurer to measurer_manager 

### DIFF
--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -31,7 +31,7 @@ from common import yaml_utils
 from database import models
 from database import utils as db_utils
 from experiment.build import builder
-from experiment.measurer import measurer
+from experiment.measurer import measure_manager
 from experiment import reporter
 from experiment import scheduler
 from experiment import stop_experiment
@@ -156,7 +156,7 @@ def dispatcher_main():
     scheduler_loop_thread.start()
 
     measurer_main_process = multiprocessing.Process(
-        target=measurer.measure_main, args=(experiment.config,))
+        target=measure_manager.measure_main, args=(experiment.config,))
 
     measurer_main_process.start()
 

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/experiment/measurer/test_measure_manager.py
+++ b/experiment/measurer/test_measure_manager.py
@@ -135,7 +135,7 @@ def test_generate_profdata_merge(mocked_execute, experiment, fs):
 
 
 @mock.patch('common.new_process.execute')
-@mock.patch('experiment.measure_manager.coverage_utils.get_coverage_binary')
+@mock.patch('experiment.measurer.coverage_utils.get_coverage_binary')
 def test_generate_summary(mocked_get_coverage_binary, mocked_execute,
                           experiment, fs):
     """Tests that generate_summary can run the correct command."""
@@ -352,8 +352,10 @@ class TestIntegrationMeasurement:
     # portable binary.
     @pytest.mark.skipif(not os.getenv('FUZZBENCH_TEST_INTEGRATION'),
                         reason='Not running integration tests.')
-    @mock.patch('experiment.measurer.measure_manager.SnapshotMeasurer'
-                '.is_cycle_unchanged')
+    @mock.patch(
+        'experiment.measurer.measure_manager.SnapshotMeasurer'
+        '.is_cycle_unchanged'
+    )
     def test_measure_snapshot_coverage(  # pylint: disable=too-many-locals
             self, mocked_is_cycle_unchanged, db, experiment, tmp_path):
         """Integration test for measure_snapshot_coverage."""

--- a/experiment/measurer/test_measure_manager.py
+++ b/experiment/measurer/test_measure_manager.py
@@ -352,10 +352,8 @@ class TestIntegrationMeasurement:
     # portable binary.
     @pytest.mark.skipif(not os.getenv('FUZZBENCH_TEST_INTEGRATION'),
                         reason='Not running integration tests.')
-    @mock.patch(
-        'experiment.measurer.measure_manager.SnapshotMeasurer'
-        '.is_cycle_unchanged'
-    )
+    @mock.patch('experiment.measurer.measure_manager.SnapshotMeasurer'
+                '.is_cycle_unchanged')
     def test_measure_snapshot_coverage(  # pylint: disable=too-many-locals
             self, mocked_is_cycle_unchanged, db, experiment, tmp_path):
         """Integration test for measure_snapshot_coverage."""


### PR DESCRIPTION
Do this in anticipation of splitting the module into two parts:
manager and worker.

See #895.