### PR TITLE
Add missing type:bug for bug based benchmarks.

### DIFF
--- a/.github/workflows/build_and_test_run_fuzzer_benchmarks.py
+++ b/.github/workflows/build_and_test_run_fuzzer_benchmarks.py
@@ -29,12 +29,10 @@ RETRY_DELAY = 60
 OSS_FUZZ_BENCHMARKS = {
     'bloaty_fuzz_target',
     'curl_curl_fuzzer_http',
-    'harfbuzz_hb-subset-fuzzer',
     'jsoncpp_jsoncpp_fuzzer',
     'libpcap_fuzz_both',
     'libxslt_xpath',
     'mbedtls_fuzz_dtlsclient',
-    'openh264_decoder_fuzzer',
     'openssl_x509',
     'sqlite3_ossfuzz',
     'systemd_fuzz-link-parser',
@@ -56,9 +54,11 @@ STANDARD_BENCHMARKS = {
 }
 
 BUG_BENCHMARKS = {
+    'harfbuzz_hb-subset-fuzzer',
     'libhevc_hevc_dec_fuzzer',
     'matio_matio_fuzzer',
     'ndpi_fuzz_ndpi_reader',
+    'openh264_decoder_fuzzer',
     'stb_stbi_read_fuzzer',
     'wabt_wasm2wat_fuzzer',
 }

--- a/benchmarks/harfbuzz_hb-subset-fuzzer/benchmark.yaml
+++ b/benchmarks/harfbuzz_hb-subset-fuzzer/benchmark.yaml
@@ -2,5 +2,11 @@ commit: 48ad745996159337fb4733561e834a0ffbe3a1ae
 commit_date: 2020-07-29 02:08:00+00:00
 fuzz_target: hb-subset-fuzzer
 project: harfbuzz
+type: bug
 unsupported_fuzzers:
+  - aflcc
+  - afl_qemu
+  - aflplusplus_qemu
+  - honggfuzz_qemu
   - klee
+  - weizz_qemu

--- a/benchmarks/libhevc_hevc_dec_fuzzer/benchmark.yaml
+++ b/benchmarks/libhevc_hevc_dec_fuzzer/benchmark.yaml
@@ -2,5 +2,12 @@ commit: d28f2210ee8e65afdfb07a1fd6582285d3d178e0
 commit_date: 2019-09-06 01:29:00+00:00
 fuzz_target: hevc_dec_fuzzer
 project: libhevc
+type: bug
 unsupported_fuzzers:
   - aflcc
+  - afl_qemu
+  - aflplusplus_qemu
+  - honggfuzz_qemu
+  - klee
+  - weizz_qemu
+

--- a/benchmarks/matio_matio_fuzzer/benchmark.yaml
+++ b/benchmarks/matio_matio_fuzzer/benchmark.yaml
@@ -5,4 +5,8 @@ project: matio
 type: bug
 unsupported_fuzzers:
   - aflcc
+  - afl_qemu
+  - aflplusplus_qemu
+  - honggfuzz_qemu
   - klee
+  - weizz_qemu

--- a/benchmarks/ndpi_fuzz_ndpi_reader/benchmark.yaml
+++ b/benchmarks/ndpi_fuzz_ndpi_reader/benchmark.yaml
@@ -2,5 +2,11 @@ commit: 98d9f524f9ff7746d0345939fe543020f8057212
 commit_date: 2020-01-15 03:36:00+00:00
 fuzz_target: fuzz_ndpi_reader
 project: ndpi
+type: bug
 unsupported_fuzzers:
+  - aflcc
+  - afl_qemu
+  - aflplusplus_qemu
+  - honggfuzz_qemu
   - klee
+  - weizz_qemu

--- a/benchmarks/openh264_decoder_fuzzer/benchmark.yaml
+++ b/benchmarks/openh264_decoder_fuzzer/benchmark.yaml
@@ -2,3 +2,11 @@ commit: c185ac351eff0ae277bfe14a3b2ad52e9ed8ab81
 commit_date: 2019-10-22 04:51:00+00:00
 fuzz_target: decoder_fuzzer
 project: openh264
+type: bug
+unsupported_fuzzers:
+  - aflcc
+  - afl_qemu
+  - aflplusplus_qemu
+  - honggfuzz_qemu
+  - klee
+  - weizz_qemu

--- a/benchmarks/stb_stbi_read_fuzzer/benchmark.yaml
+++ b/benchmarks/stb_stbi_read_fuzzer/benchmark.yaml
@@ -2,3 +2,11 @@ commit: f54acd4e13430c5122cab4ca657705c84aa61b08
 commit_date: 2020-05-27 02:31:00+00:00
 fuzz_target: stbi_read_fuzzer
 project: stb
+type: bug
+unsupported_fuzzers:
+  - aflcc
+  - afl_qemu
+  - aflplusplus_qemu
+  - honggfuzz_qemu
+  - klee
+  - weizz_qemu

--- a/benchmarks/wabt_wasm2wat_fuzzer/benchmark.yaml
+++ b/benchmarks/wabt_wasm2wat_fuzzer/benchmark.yaml
@@ -2,3 +2,11 @@ commit: c74e612ff9d95d6afd1bbfb6d9656655aa6d70ed
 commit_date: 2020-01-28 07:03:00+00:00
 fuzz_target: wasm2wat_fuzzer
 project: wabt
+type: bug
+unsupported_fuzzers:
+  - aflcc
+  - afl_qemu
+  - aflplusplus_qemu
+  - honggfuzz_qemu
+  - klee
+  - weizz_qemu


### PR DESCRIPTION
Also, disable unsupported fuzzers - aflcc, klee and qemu variants.