### PR TITLE
Add the correct aflplusplus_cmplog variant for analysis

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -55,6 +55,7 @@ jobs:
           - aflplusplus_fast_v2
           - aflplusplus_fast_v2_late
           - aflplusplus_fast_branches_v2
+          - aflplusplus_cmplog
 
         benchmark_type:
           - oss-fuzz

--- a/fuzzers/aflplusplus_cmplog/builder.Dockerfile
+++ b/fuzzers/aflplusplus_cmplog/builder.Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Install wget to download afl_driver.cpp. Install libstdc++ to use llvm_mode.
+RUN apt-get update && \
+    apt-get install -y wget libstdc++-5-dev libtool-bin automake flex bison \
+                       libglib2.0-dev libpixman-1-dev python3-setuptools unzip \
+                       apt-utils apt-transport-https ca-certificates
+
+# Download and compile afl++ (v2.62d).
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
+    cd /afl && \
+    git checkout d0cdbc48aebf88bc0cc519db553ca762f794296e && \
+    unset CFLAGS && unset CXXFLAGS && export CC=clang && \
+    AFL_NO_X86=1 PYTHON_INCLUDE=/ make && make install && \
+    make -C examples/aflpp_driver && \
+    cp examples/aflpp_driver/libAFLDriver.a /

--- a/fuzzers/aflplusplus_cmplog/description.md
+++ b/fuzzers/aflplusplus_cmplog/description.md
@@ -1,0 +1,14 @@
+# aflplusplus
+
+AFL++ fuzzer instance that has the following config active for all benchmarks:
+  - PCGUARD instrumentation 
+  - cmplog feature
+  - dict2file feature
+  - "explore" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_cmplog/fuzzer.py
+++ b/fuzzers/aflplusplus_cmplog/fuzzer.py
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for AFLplusplus fuzzer."""
+
+# This optimized afl++ variant should always be run together with
+# "aflplusplus" to show the difference - a default configured afl++ vs.
+# a hand-crafted optimized one. afl++ is configured not to enable the good
+# stuff by default to be as close to vanilla afl as possible.
+# But this means that the good stuff is hidden away in this benchmark
+# otherwise.
+
+from fuzzers.aflplusplus import fuzzer as aflplusplus_fuzzer
+
+
+def build():  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    aflplusplus_fuzzer.build("tracepc", "cmplog")
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    run_options = ['-p', 'coe']
+
+    aflplusplus_fuzzer.fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            flags=(run_options))

--- a/fuzzers/aflplusplus_cmplog/runner.Dockerfile
+++ b/fuzzers/aflplusplus_cmplog/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+ENV AFL_MAP_SIZE=900000
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2


### PR DESCRIPTION
```
	new file:   fuzzers/aflplusplus_cmplog/builder.Dockerfile
	new file:   fuzzers/aflplusplus_cmplog/description.md
	new file:   fuzzers/aflplusplus_cmplog/fuzzer.py
	new file:   fuzzers/aflplusplus_cmplog/runner.Dockerfile
```

@vanhauser-thc 

Hello guys, 

This is a pull request for adding the correct variant of `aflplusplus_cmplog` to fuzzbench for some experiments.

Thanks!
