### PR TITLE
Upgrade python requirement from 3.7 to 3.8, add clusterfuzz pkg

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Setup Python environment
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     # Copied from:
     # https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Python environment
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     # Copied from:
     # https://docs.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ SHELL := /bin/bash
 VENV_ACTIVATE := .venv/bin/activate
 
 ${VENV_ACTIVATE}: requirements.txt
-	python3.7 -m venv .venv || python3 -m venv .venv
+	python3.8 -m venv .venv || python3 -m venv .venv
 	source ${VENV_ACTIVATE} && python3 -m pip install -r requirements.txt
 
 install-dependencies: ${VENV_ACTIVATE}

--- a/database/utils.py
+++ b/database/utils.py
@@ -19,7 +19,7 @@ import threading
 import sqlalchemy
 from sqlalchemy import orm
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,no-member
 engine = None
 session = None
 lock = None

--- a/docker/base-image/Dockerfile
+++ b/docker/base-image/Dockerfile
@@ -14,9 +14,9 @@
 
 FROM ubuntu:xenial
 
-# Build Python 3.7.6 from source because pandas doesn't support xenial's
+# Build Python 3.8.6 from source because pandas doesn't support xenial's
 # Python3 version (3.5.2).
-ENV PYTHON_VERSION 3.7.6
+ENV PYTHON_VERSION 3.8.6
 RUN apt-get update -y && apt-get install -y \
     build-essential \
     rsync \

--- a/docker/benchmark-builder/Dockerfile
+++ b/docker/benchmark-builder/Dockerfile
@@ -27,9 +27,9 @@ ENV BENCHMARK $benchmark
 
 # Copy latest python3 from base-image into local.
 COPY --from=base-image /usr/local/bin/python3* /usr/local/bin/
-COPY --from=base-image /usr/local/lib/python3.7 /usr/local/lib/python3.7
-COPY --from=base-image /usr/local/include/python3.7m /usr/local/include/python3.7m
-COPY --from=base-image /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+COPY --from=base-image /usr/local/lib/python3.8 /usr/local/lib/python3.8
+COPY --from=base-image /usr/local/include/python3.8 /usr/local/include/python3.8
+COPY --from=base-image /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
 
 # Copy the entire fuzzers directory tree to allow for module dependencies.
 COPY fuzzers $SRC/fuzzers

--- a/docker/dispatcher-image/Dockerfile
+++ b/docker/dispatcher-image/Dockerfile
@@ -21,7 +21,6 @@ WORKDIR $WORK
 
 # Install runtime dependencies for benchmarks, easy json parsing.
 RUN apt-get update -y && apt-get install -y \
-    git \
     jq \
     libglib2.0-0 \
     libxml2 \
@@ -39,12 +38,6 @@ RUN DOCKER_VERSION=18.09.7 && \
 RUN curl https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 > \
     /usr/local/bin/cloud_sql_proxy
 RUN chmod +x /usr/local/bin/cloud_sql_proxy
-
-# Clone ClusterFuzz and install libClusterFuzz package for parsing stacktraces.
-RUN git clone --depth=1 https://github.com/google/clusterfuzz $WORK/clusterfuzz && \
-    cd $WORK/clusterfuzz/src/python/lib && \
-    pip3 install wheel==0.35.1 && \
-    ./build.sh
 
 # Copy llvm-tool binaries needed for clang source-code based coverage.
 COPY --from=base-clang /usr/local/bin/llvm-cov /usr/local/bin/

--- a/docker/dispatcher-image/Dockerfile
+++ b/docker/dispatcher-image/Dockerfile
@@ -21,13 +21,12 @@ WORKDIR $WORK
 
 # Install runtime dependencies for benchmarks, easy json parsing.
 RUN apt-get update -y && apt-get install -y \
+    git \
     jq \
     libglib2.0-0 \
     libxml2 \
     libarchive13 \
     libgss3
-
-RUN virtualenv --python=$(which python3) $WORK/.venv
 
 # Install docker cli.
 RUN DOCKER_VERSION=18.09.7 && \
@@ -40,6 +39,12 @@ RUN DOCKER_VERSION=18.09.7 && \
 RUN curl https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 > \
     /usr/local/bin/cloud_sql_proxy
 RUN chmod +x /usr/local/bin/cloud_sql_proxy
+
+# Clone ClusterFuzz and install libClusterFuzz package for parsing stacktraces.
+RUN git clone --depth=1 https://github.com/google/clusterfuzz $WORK/clusterfuzz && \
+    cd $WORK/clusterfuzz/src/python/lib && \
+    pip3 install wheel==0.35.1 && \
+    ./build.sh
 
 # Copy llvm-tool binaries needed for clang source-code based coverage.
 COPY --from=base-clang /usr/local/bin/llvm-cov /usr/local/bin/

--- a/docker/dispatcher-image/Dockerfile
+++ b/docker/dispatcher-image/Dockerfile
@@ -39,6 +39,9 @@ RUN curl https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 > \
     /usr/local/bin/cloud_sql_proxy
 RUN chmod +x /usr/local/bin/cloud_sql_proxy
 
+# Add libClusterFuzz for stacktrace parsing.
+RUN pip3 install clusterfuzz
+
 # Copy llvm-tool binaries needed for clang source-code based coverage.
 COPY --from=base-clang /usr/local/bin/llvm-cov /usr/local/bin/
 COPY --from=base-clang /usr/local/bin/llvm-profdata /usr/local/bin/

--- a/docker/dispatcher-image/startup-dispatcher.sh
+++ b/docker/dispatcher-image/startup-dispatcher.sh
@@ -25,8 +25,6 @@ cloud_sql_proxy -instances="$CLOUD_SQL_INSTANCE_CONNECTION_NAME" &
 gsutil -m rsync -r "${EXPERIMENT_FILESTORE}/${EXPERIMENT}/input" "${WORK}"
 mkdir ${WORK}/src
 tar -xvzf ${WORK}/src.tar.gz -C ${WORK}/src
-source "${WORK}/.venv/bin/activate"
-pip3 install -r "${WORK}/src/requirements.txt"
 
 # Set up credentials locally as cloud metadata service does not scale.
 credentials_file=${WORK}/creds.json

--- a/fuzzers/klee/fuzzer.py
+++ b/fuzzers/klee/fuzzer.py
@@ -108,8 +108,8 @@ def get_bcs_for_shared_libs(fuzz_target):
     output = ''
     try:
         output = subprocess.check_output(ldd_cmd, universal_newlines=True)
-    except subprocess.CalledProcessError:
-        raise ValueError('ldd failed')
+    except subprocess.CalledProcessError as error:
+        raise ValueError('ldd failed') from error
 
     for line in output.split('\n'):
         if '=>' not in line:

--- a/fuzzers/utils.py
+++ b/fuzzers/utils.py
@@ -139,9 +139,9 @@ def get_dictionary_path(target_binary):
     with open(options_file_path, 'r') as file_handle:
         try:
             config.read_file(file_handle)
-        except configparser.Error:
+        except configparser.Error as error:
             raise Exception('Failed to parse fuzzer options file: ' +
-                            options_file_path)
+                            options_file_path) from error
 
     for section in config.sections():
         for key, value in config.items(section):

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ seaborn==0.10.0
 sqlalchemy==1.3.19
 
 # Needed for development.
-pylint==2.4.4
-pytype==2019.11.27
-yapf==0.28.0
+pylint==2.6.0
+pytype==2020.10.8
+yapf==0.30.0


### PR DESCRIPTION
- Upgrade python 3.7 to 3.8 in images.
- Upgrade pylint, pytype and yapf packages, fix lint failures.
- Add libClusterFuzz for stacktrace parsing.