### PR TITLE
Remove virtualenv use from local experiment

### DIFF
--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -389,8 +389,6 @@ class LocalDispatcher:
             '"${EXPERIMENT_FILESTORE}/${EXPERIMENT}/input/" ${WORK} && '
             'mkdir ${WORK}/src && '
             'tar -xvzf ${WORK}/src.tar.gz -C ${WORK}/src && '
-            'source "${WORK}/.venv/bin/activate" && '
-            'pip3 install -r "${WORK}/src/requirements.txt" && '
             'PYTHONPATH=${WORK}/src python3 '
             '${WORK}/src/experiment/dispatcher.py || '
             '/bin/bash'  # Open shell if experiment fails.


### PR DESCRIPTION
This was missed in last cl when we removed its use in dispatcher-image.