### PR TITLE
adds tabbed coverage growth plots (linear and logscale)

### DIFF
--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -239,25 +239,26 @@ class BenchmarkResults:
             self._get_full_path(plot_filename))
         return plot_filename
 
-    @property
-    def coverage_growth_plot(self):
-        """Coverage growth plot."""
-        plot_filename = self._prefix_with_benchmark('coverage_growth.svg')
-        self._plotter.write_coverage_growth_plot(
-            self._benchmark_df, self._get_full_path(plot_filename), wide=True)
-        return plot_filename
-
-    @property
-    def coverage_growth_plot_logscale(self):
-        """Coverage growth plot."""
-        plot_filename = self._prefix_with_benchmark(
-            'coverage_growth_logscale.svg')
+    def _coverage_growth_plot(self, filename, logscale=False):
+        """Coverage growth plot helper function"""
+        plot_filename = self._prefix_with_benchmark(filename)
         self._plotter.write_coverage_growth_plot(
             self._benchmark_df,
             self._get_full_path(plot_filename),
             wide=True,
-            logscale=True)
+            logscale=logscale)
         return plot_filename
+
+    @property
+    def coverage_growth_plot(self):
+        """Coverage growth plot (linear scale)."""
+        return self._coverage_growth_plot('coverage_growth.svg')
+
+    @property
+    def coverage_growth_plot_logscale(self):
+        """Coverage growth plot (logscale)."""
+        return self._coverage_growth_plot('coverage_growth_logscale.svg',
+                                          logscale=True)
 
     @property
     def violin_plot(self):

--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -250,9 +250,13 @@ class BenchmarkResults:
     @property
     def coverage_growth_plot_logscale(self):
         """Coverage growth plot."""
-        plot_filename = self._prefix_with_benchmark('coverage_growth_logscale.svg')
+        plot_filename = self._prefix_with_benchmark(
+            'coverage_growth_logscale.svg')
         self._plotter.write_coverage_growth_plot(
-            self._benchmark_df, self._get_full_path(plot_filename), wide=True, logscale=True)
+            self._benchmark_df,
+            self._get_full_path(plot_filename),
+            wide=True,
+            logscale=True)
         return plot_filename
 
     @property

--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -248,6 +248,14 @@ class BenchmarkResults:
         return plot_filename
 
     @property
+    def coverage_growth_plot_logscale(self):
+        """Coverage growth plot."""
+        plot_filename = self._prefix_with_benchmark('coverage_growth_logscale.svg')
+        self._plotter.write_coverage_growth_plot(
+            self._benchmark_df, self._get_full_path(plot_filename), wide=True, logscale=True)
+        return plot_filename
+
+    @property
     def violin_plot(self):
         """Violin plot."""
         plot_filename = self._prefix_with_benchmark('violin.svg')

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -155,10 +155,10 @@ def generate_report(experiment_names,
     data_path = os.path.join(report_directory, 'data.csv.gz')
     if from_cached_data and os.path.exists(data_path):
         experiment_df = pd.read_csv(data_path)
+        description = "from cached data"
     else:
         experiment_df = queries.get_experiment_data(experiment_names)
-
-    description = queries.get_experiment_description(main_experiment_name)
+        description = queries.get_experiment_description(main_experiment_name)
 
     data_utils.validate_data(experiment_df)
 

--- a/analysis/plotting.py
+++ b/analysis/plotting.py
@@ -118,7 +118,7 @@ class Plotter:
         finally:
             plt.close(fig)
 
-    def coverage_growth_plot(self, benchmark_df, axes=None):
+    def coverage_growth_plot(self, benchmark_df, axes=None, logscale=False):
         """Draws coverage growth plot on given |axes|.
 
         The fuzzer labels will be in the order of their mean coverage at the
@@ -156,7 +156,7 @@ class Plotter:
         axes.set(ylabel='Edge coverage')
         axes.set(xlabel='Time (hour:minute)')
 
-        if self._logscale:
+        if self._logscale or logscale:
             axes.set_xscale('log')
             ticks = np.logspace(
                 # Start from the time of the first measurement.
@@ -179,7 +179,8 @@ class Plotter:
         self._write_plot_to_image(self.coverage_growth_plot,
                                   benchmark_df,
                                   image_path,
-                                  wide=wide)
+                                  wide=wide,
+                                  logscale=False)
 
     def violin_plot(self, benchmark_snapshot_df, axes=None):
         """Draws violin plot.

--- a/analysis/plotting.py
+++ b/analysis/plotting.py
@@ -174,13 +174,17 @@ class Plotter:
 
         sns.despine(ax=axes, trim=True)
 
-    def write_coverage_growth_plot(self, benchmark_df, image_path, wide=False):
+    def write_coverage_growth_plot(self,
+                                   benchmark_df,
+                                   image_path,
+                                   wide=False,
+                                   logscale=False):
         """Writes coverage growth plot."""
         self._write_plot_to_image(self.coverage_growth_plot,
                                   benchmark_df,
                                   image_path,
                                   wide=wide,
-                                  logscale=False)
+                                  logscale=logscale)
 
     def violin_plot(self, benchmark_snapshot_df, axes=None):
         """Draws violin plot.

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -195,7 +195,7 @@
                 <div id="{{ benchmark.name }}_region_logscale" class="col s12">
                     <h5 class="center-align">Mean coverage growth over time</h5>
                     <img class="responsive-img materialboxed"
-                         src="log/{{ benchmark.coverage_growth_plot_logscale }}">
+                         src="{{ benchmark.coverage_growth_plot_logscale }}">
                 </div>
                 <div class="center-align">
                     * The error bands show the 95% confidence interval

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -182,15 +182,27 @@
             </div>
             <div class="row">
                 <div class="col s12">
+                    <ul class="tabs">
+                      <li class="tab col s6"><a href="#{{ benchmark.name }}_region_normal" class="green-text text-darken-3">Region coverage (linear)</a></li>
+                      <li class="tab col s6"><a href="#{{ benchmark.name }}_region_logscale" class="green-text text-darken-3">Region coverage (log)</a></li>
+                    </ul>
+                </div>
+                <div id="{{ benchmark.name }}_region_normal" class="col s12">
                     <h5 class="center-align">Mean coverage growth over time</h5>
                     <img class="responsive-img materialboxed"
                          src="{{ benchmark.coverage_growth_plot }}">
-                    <div class="center-align">
-                        * The error bands show the 95% confidence interval
-                          around the mean coverage.
-                    </div>
+                </div>
+                <div id="{{ benchmark.name }}_region_logscale" class="col s12">
+                    <h5 class="center-align">Mean coverage growth over time</h5>
+                    <img class="responsive-img materialboxed"
+                         src="log/{{ benchmark.coverage_growth_plot_logscale }}">
+                </div>
+                <div class="center-align">
+                    * The error bands show the 95% confidence interval
+                      around the mean coverage.
                 </div>
             </div>
+
 
             {% if benchmark.fuzzers_with_not_enough_samples and not in_progress %}
             <div class="card-panel deep-orange lighten-3">
@@ -336,6 +348,10 @@
          var scrollspy_elems = document.querySelectorAll('.scrollspy');
          var scrollspy_options = {scrollOffset: 0};
          M.ScrollSpy.init(scrollspy_elems, scrollspy_options);
+
+         var tabs_elems = document.querySelectorAll('.tabs');
+         var tabs_options = {duration: 500};
+         var instance = M.Tabs.init(tabs_elems, tabs_options);
      });
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.2/anchor.min.js"></script>


### PR DESCRIPTION
- changes the coverage growth plot in the default report to
  generate both linear and logscale plots and a tabbed interface
  to switch between the two.  This will take much longer to generate,
  but adds a requested feature to all reports.
