### PR TITLE
Fix systemd benchmark breakage to meson new package release.

### DIFF
--- a/benchmarks/harfbuzz_hb-subset-fuzzer/Dockerfile
+++ b/benchmarks/harfbuzz_hb-subset-fuzzer/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder@sha256:7c6edc92d725ec4117ed7f380fb2fa51c2382a037c405dd3fe1ee2870deeb1a1
 RUN apt-get update && apt-get install -y python3-pip ragel pkg-config && \
-    pip3 install meson==0.53.0 ninja
+    pip3 install meson==0.53.0 ninja==1.10.0
 RUN git clone --depth 1 https://github.com/harfbuzz/harfbuzz.git
 WORKDIR harfbuzz
 COPY build.sh $SRC/

--- a/benchmarks/systemd_fuzz-link-parser/Dockerfile
+++ b/benchmarks/systemd_fuzz-link-parser/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update &&\
     apt-get install -y gperf m4 gettext python3-pip \
         libcap-dev libmount-dev libkmod-dev \
         pkg-config wget &&\
-    pip3 install meson ninja
+    pip3 install meson==0.55.3 ninja==1.10.0
 RUN git clone --depth 1 https://github.com/systemd/systemd systemd
 WORKDIR systemd
 COPY build.sh $SRC/


### PR DESCRIPTION
Fixes::

```
2020-11-12T22:16:30.9201735Z #16 7.144 meson.build:626:16: ERROR: Problem encountered: unable to determine gperf len type
2020-11-12T22:16:30.9202224Z #16 7.144 
2020-11-12T22:16:30.9203458Z #16 7.144 A full log can be found at /work/build/meson-logs/meson-log.txt
2020-11-12T22:16:30.9204200Z #16 7.144 NOTICE: You are using Python 3.5 which is EOL. Starting with v0.57, Meson will require Python 3.6 or newer
2020-11-12T22:16:31.5103520Z #16 7.639 Traceback (most recent call last):
2020-11-12T22:16:31.5104045Z #16 7.639   File "<string>", line 1, in <module>
2020-11-12T22:16:31.5105064Z #16 7.639   File "/src/fuzzers/aflplusplus_dict2file/fuzzer.py", line 28, in build
2020-11-12T22:16:31.5106082Z #16 7.640     aflplusplus_fuzzer.build("tracepc", "dict2file")
2020-11-12T22:16:31.5106852Z #16 7.640   File "/src/fuzzers/aflplusplus/fuzzer.py", line 126, in build
2020-11-12T22:16:31.5107370Z #16 7.640     utils.build_benchmark()
2020-11-12T22:16:31.5107877Z #16 7.640   File "/src/fuzzers/utils.py", line 68, in build_benchmark
2020-11-12T22:16:31.5109064Z #16 7.640     subprocess.check_call(['/bin/bash', '-ex', build_script], env=env)
2020-11-12T22:16:31.5109706Z #16 7.640   File "/usr/local/lib/python3.8/subprocess.py", line 364, in check_call
2020-11-12T22:16:31.5110335Z #16 7.640     raise CalledProcessError(retcode, cmd)
2020-11-12T22:16:31.5111777Z #16 7.640 subprocess.CalledProcessError: Command '['/bin/bash', '-ex', '/src/build.sh']' returned non-zero exit status 1.
2020-11-12T22:16:31.6035768Z #16 ERROR: executor failed running [/bin/sh -c PYTHONPATH=$SRC python3 -u -c "from fuzzers import utils; utils.initialize_env(); from fuzzers.$FUZZER import fuzzer; fuzzer.build()"]: runc did not terminate sucessfully
2020-11-12T22:16:31.6037099Z ------
2020-11-12T22:16:31.6038210Z  > [stage-1 12/12] RUN PYTHONPATH=/src python3 -u -c "from fuzzers import utils; utils.initialize_env(); from fuzzers.aflplusplus_dict2file import fuzzer; fuzzer.build()":
2020-11-12T22:16:31.6039138Z ------
2020-11-12T22:16:31.6040631Z failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/sh -c PYTHONPATH=$SRC python3 -u -c "from fuzzers import utils; utils.initialize_env(); from fuzzers.$FUZZER import fuzzer; fuzzer.build()"]: runc did not terminate sucessfully
2020-11-12T22:16:31.6094904Z make: *** [.aflplusplus_dict2file-systemd_fuzz-link-parser-builder] Error 1
```