### PR TITLE
Switch to n1-highcpu-32 for gcb, fixes arrow benchmark hang.

### DIFF
--- a/experiment/build/gcb_build.py
+++ b/experiment/build/gcb_build.py
@@ -34,8 +34,8 @@ CONFIG_DIR = 'config'
 # Maximum time to wait for a GCB config to finish build.
 GCB_BUILD_TIMEOUT = 4 * 60 * 60  # 4 hours.
 
-# High cpu configuration for faster builds.
-GCB_MACHINE_TYPE = 'n1-highcpu-8'
+# High cpu and memory configuration, matches OSS-Fuzz.
+GCB_MACHINE_TYPE = 'n1-highcpu-32'
 
 logger = logs.Logger('builder')  # pylint: disable=invalid-name
 

--- a/experiment/build/gcb_build.py
+++ b/experiment/build/gcb_build.py
@@ -70,10 +70,10 @@ def build_coverage(benchmark):
     _build(config, config_name)
 
 
-def _build(config: Dict,
-           config_name: str,
-           timeout_seconds: int = GCB_BUILD_TIMEOUT
-          ) -> new_process.ProcessResult:
+def _build(
+        config: Dict,
+        config_name: str,
+        timeout_seconds: int = GCB_BUILD_TIMEOUT) -> new_process.ProcessResult:
     """Submit build to GCB."""
     with tempfile.NamedTemporaryFile() as config_file:
         yaml_utils.write(config_file.name, config)


### PR DESCRIPTION
This also matches OSS-Fuzz configuration.
See
https://console.cloud.google.com/cloud-build/builds/d0876d12-65f6-4cc2-bc6c-7a8a04cbf680?authuser=0&project=fuzzbench
(failure)
vs
https://console.cloud.google.com/cloud-build/builds/30a99746-4a1a-4421-8d93-428fa51957f3?authuser=0&project=fuzzbench
(success)