### PR TITLE
Remove unneeded timeout afl hack with 1000+.

### DIFF
--- a/fuzzers/afl/fuzzer.py
+++ b/fuzzers/afl/fuzzer.py
@@ -107,8 +107,6 @@ def run_afl_fuzz(input_corpus,
         # Use no memory limit as ASAN doesn't play nicely with one.
         '-m',
         'none',
-        '-t',
-        '1000+',  # Use same default 1 sec timeout, but add '+' to skip hangs.
     ]
     # Use '-d' to skip deterministic mode, as long as it it compatible with
     # additional flags.

--- a/fuzzers/weizz_qemu/fuzzer.py
+++ b/fuzzers/weizz_qemu/fuzzer.py
@@ -61,8 +61,6 @@ def fuzz(input_corpus, output_corpus, target_binary):
         input_corpus,
         '-o',
         output_corpus,
-        '-t',
-        '1000+',  # Use same default 1 sec timeout, but add '+' to skip hangs.
     ]
     dictionary_path = utils.get_dictionary_path(target_binary)
     if dictionary_path:


### PR DESCRIPTION
This is not needed after AFL_SKIP_CRASHES=1 which skips crashes
in seed corpus. Remove this hack as it break afl based fuzzers
on some benchmarks, e.g. https://www.fuzzbench.com/reports/2020-11-23/index.html#libpcap_fuzz_both

This regressed in https://github.com/google/fuzzbench/commit/c7e7bda1f373b406e37e27efd324c42fd388b945