### PR TITLE
Improve deduplication slightly by removing bytes read/written.

### DIFF
--- a/experiment/measurer/run_crashes.py
+++ b/experiment/measurer/run_crashes.py
@@ -15,6 +15,7 @@
 
 import collections
 import os
+import re
 
 from clusterfuzz import stacktraces
 
@@ -29,6 +30,12 @@ Crash = collections.namedtuple('Crash', [
     'crash_testcase', 'crash_type', 'crash_address', 'crash_state',
     'crash_stacktrace'
 ])
+NUMBER_REGEX = re.compile(r'\s[0-9]+', re.DOTALL)
+
+
+def _filter_crash_type(crash_type):
+    """Filters crash type to remove numbers."""
+    return NUMBER_REGEX.sub('', crash_type)
 
 
 def process_crash(app_binary, crash_testcase_path, crashes_dir):
@@ -65,7 +72,7 @@ def process_crash(app_binary, crash_testcase_path, crashes_dir):
 
     return Crash(crash_testcase=os.path.relpath(crash_testcase_path,
                                                 crashes_dir),
-                 crash_type=crash_result.crash_type,
+                 crash_type=_filter_crash_type(crash_result.crash_type),
                  crash_address=crash_result.crash_address,
                  crash_state=crash_result.crash_state,
                  crash_stacktrace=crash_result.crash_stacktrace)

--- a/experiment/measurer/run_crashes.py
+++ b/experiment/measurer/run_crashes.py
@@ -30,7 +30,7 @@ Crash = collections.namedtuple('Crash', [
     'crash_testcase', 'crash_type', 'crash_address', 'crash_state',
     'crash_stacktrace'
 ])
-NUMBER_REGEX = re.compile(r'\s[0-9]+', re.DOTALL)
+NUMBER_REGEX = re.compile(r'\s([0-9]+|{\*})', re.DOTALL)
 
 
 def _filter_crash_type(crash_type):

--- a/experiment/measurer/run_crashes.py
+++ b/experiment/measurer/run_crashes.py
@@ -30,12 +30,12 @@ Crash = collections.namedtuple('Crash', [
     'crash_testcase', 'crash_type', 'crash_address', 'crash_state',
     'crash_stacktrace'
 ])
-NUMBER_REGEX = re.compile(r'\s([0-9]+|{\*})', re.DOTALL)
+SIZE_REGEX = re.compile(r'\s([0-9]+|{\*})$', re.DOTALL)
 
 
 def _filter_crash_type(crash_type):
-    """Filters crash type to remove numbers."""
-    return NUMBER_REGEX.sub('', crash_type)
+    """Filters crash type to remove size numbers."""
+    return SIZE_REGEX.sub('', crash_type)
 
 
 def process_crash(app_binary, crash_testcase_path, crashes_dir):

--- a/experiment/measurer/test_run_crashes.py
+++ b/experiment/measurer/test_run_crashes.py
@@ -58,4 +58,6 @@ def test_filter_crash_type():
     """Tests _filter_crash_type."""
     assert (run_crashes._filter_crash_type('Heap-buffer-overflow\nREAD 4') ==
             'Heap-buffer-overflow\nREAD')
+    assert (run_crashes._filter_crash_type('Heap-buffer-overflow\nWRITE {*}') ==
+            'Heap-buffer-overflow\nWRITE')
     assert run_crashes._filter_crash_type('Timeout') == 'Timeout'

--- a/experiment/measurer/test_run_crashes.py
+++ b/experiment/measurer/test_run_crashes.py
@@ -51,3 +51,11 @@ class TestIntegrationRunCoverage:
         assert actual_crash.crash_state == 'fuzz_target.c\n'
         assert ('ERROR: AddressSanitizer: ABRT on unknown address'
                 in actual_crash.crash_stacktrace)
+
+
+# pylint: disable=protected-access
+def test_filter_crash_type():
+    """Tests _filter_crash_type."""
+    assert (run_crashes._filter_crash_type('Heap-buffer-overflow\nREAD 4') ==
+            'Heap-buffer-overflow\nREAD')
+    assert run_crashes._filter_crash_type('Timeout') == 'Timeout'


### PR DESCRIPTION
This is needed since we currently don't support crash grouping
similar to ClusterFuzz.