### PR TITLE
Disable libFuzzer, entropic patches

### DIFF
--- a/fuzzers/entropic/builder.Dockerfile
+++ b/fuzzers/entropic/builder.Dockerfile
@@ -15,12 +15,9 @@
 ARG parent_image
 FROM $parent_image
 
-COPY patch.diff /
-
 RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
     cd /llvm-project && \
     git checkout 5cda4dc7b4d28fcd11307d4234c513ff779a1c6f && \
-    patch -p1 < /patch.diff && \
     cd compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
       clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \

--- a/fuzzers/libfuzzer/builder.Dockerfile
+++ b/fuzzers/libfuzzer/builder.Dockerfile
@@ -15,12 +15,9 @@
 ARG parent_image
 FROM $parent_image
 
-COPY patch.diff /
-
 RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
     cd /llvm-project/ && \
     git checkout 5cda4dc7b4d28fcd11307d4234c513ff779a1c6f && \
-    patch -p1 < /patch.diff && \
     cd compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
       clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \


### PR DESCRIPTION
These affect bug based benchmarking and also cause issues with
seed inputs (https://github.com/google/fuzzbench/issues/801)