### PR TITLE
Don't show error band on bugs coverage growth plot.

### DIFF
--- a/analysis/plotting.py
+++ b/analysis/plotting.py
@@ -156,7 +156,7 @@ class Plotter:
             hue='fuzzer',
             hue_order=fuzzer_order,
             data=benchmark_df[benchmark_df.time <= snapshot_time],
-            ci=None if self._quick else 95,
+            ci=None if bugs or self._quick else 95,
             palette=self._fuzzer_colors,
             style='fuzzer',
             dashes=False,

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -187,10 +187,6 @@
                     <img class="responsive-img materialboxed"
                          src="{{ benchmark.bug_coverage_growth_plot_logscale }}">
                 </div>
-                <div class="center-align">
-                    * The error bands show the 95% confidence interval
-                      around the mean unique bugs.
-                </div>
             </div>
 
             {% endif %}


### PR DESCRIPTION
(Creating new PR, as #976 wasn't merged into master.)