### PR TITLE
Match sanitizer build flags and _OPTIONS same as OSS-Fuzz/ClusterFuzz

### DIFF
--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -522,7 +522,6 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
         app_binary = coverage_utils.get_coverage_binary(self.benchmark)
         crash_metadata = run_crashes.do_crashes_run(app_binary,
                                                     self.crashes_dir)
-        logs.info('Crash metadata: %s', crash_metadata)
         crashes = []
         for crash_key in crash_metadata:
             crash = crash_metadata[crash_key]

--- a/experiment/measurer/sanitizer.py
+++ b/experiment/measurer/sanitizer.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Sanitizer helpers."""
 
+# Matches ClusterFuzz configuration.
+# See https://github.com/google/clusterfuzz/blob/master/src/python/system/environment.py.
 SANITIZER_OPTIONS = {
     'handle_abort': 2,
     'handle_sigbus': 2,
@@ -21,6 +23,25 @@ SANITIZER_OPTIONS = {
     'handle_sigill': 2,
     'symbolize': 1,
     'symbolize_inline_frames': 0,
+}
+ADDITIONAL_ASAN_OPTIONS = {
+    'alloc_dealloc_mismatch': 0,
+    'allocator_may_return_null': 1,
+    'allocator_release_to_os_interval_ms': 500,
+    'allow_user_segv_handler': 0,
+    'check_malloc_usable_size': 0,
+    'detect_odr_violation': 0,
+    'detect_leaks': 1,
+    'detect_stack_use_after_return': 1,
+    'fast_unwind_on_fatal': 0,
+    'max_uar_stack_size_log': 16,
+    'quarantine_size_mb': 64,
+    'strict_memcmp': 1,
+}
+ADDITIONAL_UBSAN_OPTIONS = {
+    'allocator_release_to_os_interval_ms': 500,
+    'print_stacktrace': 1,
+    'silence_unsigned_overflow': 1,
 }
 
 
@@ -33,5 +54,11 @@ def _join_memory_tool_options(options):
 
 def set_sanitizer_options(env):
     """Sets sanitizer options in |env|."""
-    env['ASAN_OPTIONS'] = _join_memory_tool_options(SANITIZER_OPTIONS)
-    env['UBSAN_OPTIONS'] = _join_memory_tool_options(SANITIZER_OPTIONS)
+    env['ASAN_OPTIONS'] = _join_memory_tool_options({
+        **SANITIZER_OPTIONS,
+        **ADDITIONAL_ASAN_OPTIONS
+    })
+    env['UBSAN_OPTIONS'] = _join_memory_tool_options({
+        **SANITIZER_OPTIONS,
+        **ADDITIONAL_UBSAN_OPTIONS
+    })

--- a/experiment/measurer/test_measure_manager.py
+++ b/experiment/measurer/test_measure_manager.py
@@ -324,11 +324,21 @@ def test_run_cov_new_units(_, mocked_execute, fs, environ):
         'cwd': '/work/coverage-binaries/benchmark-a',
         'env': {
             'ASAN_OPTIONS':
-                ('handle_abort=2:handle_segv=2:handle_sigbus=2:handle_sigfpe=2:'
-                 'handle_sigill=2:symbolize=1:symbolize_inline_frames=0'),
+                ('alloc_dealloc_mismatch=0:allocator_may_return_null=1:'
+                 'allocator_release_to_os_interval_ms=500:'
+                 'allow_user_segv_handler=0:check_malloc_usable_size=0:'
+                 'detect_leaks=1:detect_odr_violation=0:'
+                 'detect_stack_use_after_return=1:fast_unwind_on_fatal=0:'
+                 'handle_abort=2:handle_segv=2:handle_sigbus=2:handle_sigfpe=2:'
+                 'handle_sigill=2:max_uar_stack_size_log=16:'
+                 'quarantine_size_mb=64:strict_memcmp=1:symbolize=1:'
+                 'symbolize_inline_frames=0'),
             'UBSAN_OPTIONS':
-                ('handle_abort=2:handle_segv=2:handle_sigbus=2:handle_sigfpe=2:'
-                 'handle_sigill=2:symbolize=1:symbolize_inline_frames=0'),
+                ('allocator_release_to_os_interval_ms=500:handle_abort=2:'
+                 'handle_segv=2:handle_sigbus=2:handle_sigfpe=2:'
+                 'handle_sigill=2:print_stacktrace=1:'
+                 'silence_unsigned_overflow=1:symbolize=1:'
+                 'symbolize_inline_frames=0'),
             'LLVM_PROFILE_FILE':
                 ('/work/measurement-folders/'
                  'benchmark-a-fuzzer-a/trial-12/coverage/data-%m.profraw'),

--- a/fuzzers/test_utils.py
+++ b/fuzzers/test_utils.py
@@ -95,9 +95,17 @@ def test_initialize_env_in_environment_with_sanitizer(fs, environ):
     fs.create_file('/benchmark.yaml', contents='fuzz_target: fuzzer\ntype: bug')
     utils.initialize_env()
     assert os.getenv('FUZZ_TARGET') == 'fuzzer'
-    assert os.getenv('CFLAGS') == '-fsanitize=address,undefined -O3'
+    assert os.getenv('CFLAGS') == (
+        '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
+        'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
+        'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
+        'unsigned-integer-overflow,unreachable,vla-bound,vptr -O3')
     assert os.getenv('CXXFLAGS') == (
-        '-fsanitize=address,undefined -stdlib=libc++ -O3')
+        '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
+        'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
+        'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
+        'unsigned-integer-overflow,unreachable,vla-bound,vptr -stdlib=libc++ '
+        '-O3')
 
 
 def test_initialize_env_in_var_without_sanitizer(fs):
@@ -119,6 +127,14 @@ def test_initialize_env_in_var_with_sanitizer(fs):
     env = {}
     utils.initialize_env(env)
     assert env.get('FUZZ_TARGET') == 'fuzzer'
-    assert env.get('CFLAGS') == '-fsanitize=address,undefined -O3'
+    assert env.get('CFLAGS') == (
+        '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
+        'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
+        'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
+        'unsigned-integer-overflow,unreachable,vla-bound,vptr -O3')
     assert env.get('CXXFLAGS') == (
-        '-fsanitize=address,undefined -stdlib=libc++ -O3')
+        '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
+        'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
+        'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
+        'unsigned-integer-overflow,unreachable,vla-bound,vptr -stdlib=libc++ '
+        '-O3')

--- a/fuzzers/utils.py
+++ b/fuzzers/utils.py
@@ -30,7 +30,15 @@ DEFAULT_OPTIMIZATION_LEVEL = '-O3'
 LIBCPLUSPLUS_FLAG = '-stdlib=libc++'
 
 # Flags to use when using sanitizer for bug based benchmarking.
-SANITIZER_FLAGS = ['-fsanitize=address,undefined']
+SANITIZER_FLAGS = [
+    '-fsanitize=address',
+    # Matches UBSan features enabled in OSS-Fuzz.
+    # See https://github.com/google/oss-fuzz/blob/master/infra/base-images/base-builder/Dockerfile#L94
+    '-fsanitize=array-bounds,bool,builtin,enum,float-divide-by-zero,function,'
+    'integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,'
+    'shift,signed-integer-overflow,unsigned-integer-overflow,unreachable,'
+    'vla-bound,vptr',
+]
 
 # Use these flags when compiling benchmark code without a sanitizer (e.g. when
 # using eclipser). This is necessary because many OSS-Fuzz targets cannot


### PR DESCRIPTION
- This was causing unintended crash blockers in several benchmarks, e.g. float-cast-overflow. This matches the config used in OSS-Fuzz.
- Match sanitizer options, this is needed, e.g. fixes missing stacktrace since UBSan requires print_stacktrace=1