### PR TITLE
Modify bugs_covered_column behavior and usage

### DIFF
--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -328,7 +328,7 @@ class BenchmarkResults:
         """Bug coverage growth plot."""
         plot_filename = self._prefix_with_benchmark(filename)
         self._plotter.write_coverage_growth_plot(
-            data_utils.add_bugs_covered_column(self._benchmark_df),
+            self._benchmark_df,
             self._get_full_path(plot_filename),
             wide=True,
             logscale=logscale,

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -112,7 +112,7 @@ def add_bugs_covered_column(experiment_df):
     grouping1 = ['fuzzer', 'benchmark', 'trial_id', 'crash_key']
     grouping2 = ['fuzzer', 'benchmark', 'trial_id']
     grouping3 = ['fuzzer', 'benchmark', 'trial_id', 'time']
-    df = experiment_df
+    df = experiment_df.sort_values(grouping3)
     df['firsts'] = ~df.duplicated(subset=grouping1) & ~df.crash_key.isna()
     df['bugs_cumsum'] = df.groupby(grouping2)['firsts'].transform('cumsum')
     df['bugs_covered'] = df.groupby(grouping3)['bugs_cumsum'].transform('max')

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -106,15 +106,16 @@ def filter_max_time(experiment_df, max_time):
     return experiment_df[experiment_df['time'] <= max_time]
 
 
-def add_bugs_covered_column(benchmark_df):
-    """Return a modified benchmark df in which the |crash_key| column is
-    replaced with a |bugs_covered| column."""
-    new_df = benchmark_df.drop(columns='crash_key').drop_duplicates()
-    new_df['bugs_covered'] = new_df.apply(lambda x: benchmark_df[
-        (benchmark_df['trial_id'] == x['trial_id']) &
-        (benchmark_df['fuzzer'] == x['fuzzer']) &
-        (benchmark_df['time'] <= x['time'])]['crash_key'].nunique(),
-                                          axis=1)
+def add_bugs_covered_column(experiment_df):
+    """Return a modified experiment df in which adds a |bugs_covered| column,
+    a cumulative count of bugs covered over time."""
+    grouping1 = ['fuzzer', 'benchmark', 'trial_id', 'crash_key']
+    grouping2 = ['fuzzer', 'benchmark', 'trial_id']
+    grouping3 = ['fuzzer', 'benchmark', 'trial_id', 'time']
+    df['firsts'] = ~df.duplicated(subset=grouping1) & ~df.crash_key.isna()
+    df['bugs_cumsum'] = df.groupby(grouping2)['firsts'].transform('cumsum')
+    df['bugs_covered'] = df.groupby(grouping3)['bugs_cumsum'].transform('max')
+    new_df = df.drop(columns=['bugs_cumsum', 'firsts'])
     return new_df
 
 

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -115,7 +115,8 @@ def add_bugs_covered_column(experiment_df):
     df = experiment_df.sort_values(grouping3)
     df['firsts'] = ~df.duplicated(subset=grouping1) & ~df.crash_key.isna()
     df['bugs_cumsum'] = df.groupby(grouping2)['firsts'].transform('cumsum')
-    df['bugs_covered'] = df.groupby(grouping3)['bugs_cumsum'].transform('max')
+    df['bugs_covered'] = (
+        df.groupby(grouping3)['bugs_cumsum'].transform('max').astype(int))
     new_df = df.drop(columns=['bugs_cumsum', 'firsts'])
     return new_df
 

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -112,6 +112,7 @@ def add_bugs_covered_column(experiment_df):
     grouping1 = ['fuzzer', 'benchmark', 'trial_id', 'crash_key']
     grouping2 = ['fuzzer', 'benchmark', 'trial_id']
     grouping3 = ['fuzzer', 'benchmark', 'trial_id', 'time']
+    df = experiment_df
     df['firsts'] = ~df.duplicated(subset=grouping1) & ~df.crash_key.isna()
     df['bugs_cumsum'] = df.groupby(grouping2)['firsts'].transform('cumsum')
     df['bugs_covered'] = df.groupby(grouping3)['bugs_cumsum'].transform('max')

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -178,6 +178,9 @@ def generate_report(experiment_names,
         experiment_df = data_utils.clobber_experiments_data(
             experiment_df, experiment_names)
 
+    # Add |bugs_covered| column prior to export.
+    experiment_df = data_utils.add_bugs_covered_column(experiment_df)
+
     # Save the filtered raw data along with the report if not using cached data
     # or if the data does not exist.
     if not from_cached_data or not os.path.exists(data_path):

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -186,6 +186,9 @@ def generate_report(experiment_names,
     if not from_cached_data or not os.path.exists(data_path):
         experiment_df.to_csv(data_path)
 
+    # Remove duplicate rows where only the |crash_key| column changes.
+    experiment_df = experiment_df.drop(columns='crash_key').drop_duplicates()
+
     # Load the coverage json summary file.
     coverage_dict = {}
     if coverage_report:

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -15,11 +15,21 @@
 # pylint: disable=missing-function-docstring
 """Tests for data_utils.py"""
 
+import numpy as np
 import pandas as pd
 import pandas.testing as pd_test
 import pytest
 
 from analysis import data_utils
+
+
+def random_crash_key():
+    crashes = [
+        'Stack-buffer-overflow', 'Heap-buffer-overflow', 'Heap-use-after-free',
+        'Bad-cast', 'Integer-overflow', 'Null-dereference READ', None
+    ]
+    probabilities = (0.01, 0.02, 0.03, 0.07, 0.02, 0.05, 0.8)
+    return np.random.choice(crashes, p=probabilities)
 
 
 def create_trial_data(  # pylint: disable=too-many-arguments
@@ -35,7 +45,7 @@ def create_trial_data(  # pylint: disable=too-many-arguments
         'time_ended': None,
         'time': t,
         'edges_covered': reached_coverage,
-        'crash_key': None,
+        'crash_key': random_crash_key(),
         'experiment_filestore': experiment_filestore
     } for t in range(cycles)])
 
@@ -127,6 +137,13 @@ def test_filter_benchmarks():
                                                benchmarks_to_keep)
 
     assert filtered_df.benchmark.unique() == benchmarks_to_keep
+
+
+def test_add_bugs_covered_columns():
+    experiment_df = create_experiment_data()
+    experiment_df = data_utils.add_bugs_covered_column(experiment_df)
+
+    assert 'bugs_covered' in experiment_df.columns
 
 
 def test_label_fuzzers_by_experiment():


### PR DESCRIPTION
Adds the `bugs_covered` column to the experiment dataframe instead of the benchmark dataframe.  Also, modifies the behavior so that the `bugs_covered` column is added before the csv is exported.  This will allow for easier analysis during report generation and from the published data.