### PR TITLE
Fix exceptions from #980

### DIFF
--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -45,8 +45,8 @@ def validate_data(experiment_df):
 def drop_uninteresting_columns(experiment_df):
     """Returns table with only interesting columns."""
     return experiment_df[[
-        'benchmark', 'fuzzer', 'trial_id', 'time', 'edges_covered', 'crash_key',
-        'experiment', 'experiment_filestore'
+        'benchmark', 'fuzzer', 'trial_id', 'time', 'edges_covered',
+        'bugs_covered', 'experiment', 'experiment_filestore'
     ]]
 
 

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -44,6 +44,9 @@ def validate_data(experiment_df):
 
 def drop_uninteresting_columns(experiment_df):
     """Returns table with only interesting columns."""
+    # Remove duplicate rows where only the |crash_key| column changes.
+    experiment_df = experiment_df.drop(columns='crash_key').drop_duplicates()
+
     return experiment_df[[
         'benchmark', 'fuzzer', 'trial_id', 'time', 'edges_covered',
         'bugs_covered', 'experiment', 'experiment_filestore'

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -186,9 +186,6 @@ def generate_report(experiment_names,
     if not from_cached_data or not os.path.exists(data_path):
         experiment_df.to_csv(data_path)
 
-    # Remove duplicate rows where only the |crash_key| column changes.
-    experiment_df = experiment_df.drop(columns='crash_key').drop_duplicates()
-
     # Load the coverage json summary file.
     coverage_dict = {}
     if coverage_report:

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -15,21 +15,11 @@
 # pylint: disable=missing-function-docstring
 """Tests for data_utils.py"""
 
-import numpy as np
 import pandas as pd
 import pandas.testing as pd_test
 import pytest
 
 from analysis import data_utils
-
-
-def random_crash_key():
-    crashes = [
-        'Stack-buffer-overflow', 'Heap-buffer-overflow', 'Heap-use-after-free',
-        'Bad-cast', 'Integer-overflow', 'Null-dereference READ', None
-    ]
-    probabilities = (0.01, 0.02, 0.03, 0.07, 0.02, 0.05, 0.8)
-    return np.random.choice(crashes, p=probabilities)
 
 
 def create_trial_data(  # pylint: disable=too-many-arguments
@@ -45,7 +35,7 @@ def create_trial_data(  # pylint: disable=too-many-arguments
         'time_ended': None,
         'time': t,
         'edges_covered': reached_coverage,
-        'crash_key': random_crash_key(),
+        'bugs_covered': 0,
         'experiment_filestore': experiment_filestore
     } for t in range(cycles)])
 
@@ -137,13 +127,6 @@ def test_filter_benchmarks():
                                                benchmarks_to_keep)
 
     assert filtered_df.benchmark.unique() == benchmarks_to_keep
-
-
-def test_add_bugs_covered_columns():
-    experiment_df = create_experiment_data()
-    experiment_df = data_utils.add_bugs_covered_column(experiment_df)
-
-    assert 'bugs_covered' in experiment_df.columns
 
 
 def test_label_fuzzers_by_experiment():

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -36,6 +36,7 @@ def create_trial_data(  # pylint: disable=too-many-arguments
         'time': t,
         'edges_covered': reached_coverage,
         'bugs_covered': 0,
+        'crash_key': None,
         'experiment_filestore': experiment_filestore
     } for t in range(cycles)])
 


### PR DESCRIPTION
Also, remove random incorrect tests. bugs_covered will always
exist after #980, so need to keep that column. Also, don't remove
crash_key as it is already removed with drop_duplicates.