### PR TITLE
small improvements to the default report

### DIFF
--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -264,9 +264,10 @@ class BenchmarkResults:
 
     def _generic_violin_plot(self, filename, bugs=False):
         """Violin plot."""
-        plot_filename = self._prefix_with_benchmark('violin.svg')
+        plot_filename = self._prefix_with_benchmark(filename)
         self._plotter.write_violin_plot(self._benchmark_snapshot_df,
-                                        self._get_full_path(plot_filename))
+                                        self._get_full_path(plot_filename),
+                                        bugs=bugs)
         return plot_filename
 
     @property

--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -121,6 +121,12 @@ class BenchmarkResults:
         return data_utils.benchmark_summary(self._benchmark_snapshot_df)
 
     @property
+    def bug_summary_table(self):
+        """Statistical summary table."""
+        return data_utils.benchmark_summary(self._benchmark_snapshot_df,
+                                            key='bugs_covered')
+
+    @property
     def rank_by_mean(self):
         """Fuzzer ranking by mean coverage."""
         return data_utils.benchmark_rank_by_mean(self._benchmark_snapshot_df)

--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -240,14 +240,15 @@ class BenchmarkResults:
             self._get_full_path(plot_filename))
         return plot_filename
 
-    def _coverage_growth_plot(self, filename, logscale=False):
+    def _coverage_growth_plot(self, filename, bugs=False, logscale=False):
         """Coverage growth plot helper function"""
         plot_filename = self._prefix_with_benchmark(filename)
         self._plotter.write_coverage_growth_plot(
             self._benchmark_df,
             self._get_full_path(plot_filename),
             wide=True,
-            logscale=logscale)
+            logscale=logscale,
+            bugs=bugs)
         return plot_filename
 
     @property
@@ -261,13 +262,40 @@ class BenchmarkResults:
         return self._coverage_growth_plot('coverage_growth_logscale.svg',
                                           logscale=True)
 
-    @property
-    def violin_plot(self):
+    def _generic_violin_plot(self, filename, bugs=False):
         """Violin plot."""
         plot_filename = self._prefix_with_benchmark('violin.svg')
         self._plotter.write_violin_plot(self._benchmark_snapshot_df,
                                         self._get_full_path(plot_filename))
         return plot_filename
+
+    @property
+    def violin_plot(self):
+        """Region coverage violin plot."""
+        return self._generic_violin_plot('violin.svg')
+
+    @property
+    def bug_violin_plot(self):
+        """Region coverage violin plot."""
+        return self._generic_violin_plot('bug_violin.svg', bugs=True)
+
+    def _generic_box_plot(self, filename, bugs=False):
+        """Generic internal boxplot."""
+        plot_filename = self._prefix_with_benchmark(filename)
+        self._plotter.write_box_plot(self._benchmark_snapshot_df,
+                                     self._get_full_path(plot_filename),
+                                     bugs=bugs)
+        return plot_filename
+
+    @property
+    def box_plot(self):
+        """Region coverage boxplot."""
+        return self._generic_box_plot('boxplot.svg')
+
+    @property
+    def bug_box_plot(self):
+        """Bug coverage boxplot."""
+        return self._generic_box_plot('bug_boxplot.svg', bugs=True)
 
     @property
     def distribution_plot(self):
@@ -324,27 +352,17 @@ class BenchmarkResults:
             self._get_full_path(plot_filename))
         return plot_filename
 
-    def _bug_coverage_growth_plot(self, filename, logscale=False):
-        """Bug coverage growth plot."""
-        plot_filename = self._prefix_with_benchmark(filename)
-        self._plotter.write_coverage_growth_plot(
-            self._benchmark_df,
-            self._get_full_path(plot_filename),
-            wide=True,
-            logscale=logscale,
-            bugs=True)
-        return plot_filename
-
     @property
     def bug_coverage_growth_plot(self):
         """Bug coverage growth plot (linear scale)."""
-        return self._bug_coverage_growth_plot('bug_coverage_growth_plot.svg')
+        return self._coverage_growth_plot('bug_coverage_growth_plot.svg',
+                                          bugs=True)
 
     @property
     def bug_coverage_growth_plot_logscale(self):
         """Bug coverage growth plot (logscale)."""
-        return self._bug_coverage_growth_plot(
-            'bug_coverage_growth_plot_logscale.svg', logscale=True)
+        return self._coverage_growth_plot(
+            'bug_coverage_growth_plot_logscale.svg', bugs=True, logscale=True)
 
     @property
     def type(self):

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -48,10 +48,10 @@ def drop_uninteresting_columns(experiment_df):
         'benchmark', 'fuzzer', 'trial_id', 'time', 'edges_covered',
         'bugs_covered', 'experiment', 'experiment_filestore'
     ]
-    # Remove extra columns
+    # Remove extra columns, keep interesting ones.
     experiment_df = experiment_df[columns_to_keep]
 
-    # Remove duplicate rows (crash_key) and re-index
+    # Remove duplicate rows (crash_key) and re-index.
     return experiment_df.drop_duplicates(ignore_index=True)
 
 

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -44,13 +44,15 @@ def validate_data(experiment_df):
 
 def drop_uninteresting_columns(experiment_df):
     """Returns table with only interesting columns."""
-    # Remove duplicate rows where only the |crash_key| column changes.
-    experiment_df = experiment_df.drop(columns='crash_key').drop_duplicates()
-
-    return experiment_df[[
+    columns_to_keep = [
         'benchmark', 'fuzzer', 'trial_id', 'time', 'edges_covered',
         'bugs_covered', 'experiment', 'experiment_filestore'
-    ]]
+    ]
+    # Remove extra columns
+    experiment_df = experiment_df[columns_to_keep]
+
+    # Remove duplicate rows (crash_key) and re-index
+    return experiment_df.drop_duplicates(ignore_index=True)
 
 
 def clobber_experiments_data(df, experiments):
@@ -187,12 +189,12 @@ def get_experiment_snapshots(experiment_df):
 # Summary tables containing statistics on the samples.
 
 
-def benchmark_summary(benchmark_snapshot_df):
+def benchmark_summary(benchmark_snapshot_df, key='edges_covered'):
     """Creates summary table for a benchmark snapshot with columns:
     |fuzzer|time||count|mean|std|min|25%|median|75%|max|
     """
     groups = benchmark_snapshot_df.groupby(['fuzzer', 'time'])
-    summary = groups['edges_covered'].describe()
+    summary = groups[key].describe()
     summary.rename(columns={'50%': 'median'}, inplace=True)
     return summary.sort_values(('median'), ascending=False)
 

--- a/analysis/plotting.py
+++ b/analysis/plotting.py
@@ -234,7 +234,7 @@ class Plotter:
         column_of_interest = 'bugs_covered' if bugs else 'edges_covered'
 
         fuzzer_order = data_utils.benchmark_rank_by_median(
-            benchmark_snapshot_df).index
+            benchmark_snapshot_df, key=column_of_interest).index
 
         mean_props = {
             'markersize': '10',
@@ -294,7 +294,7 @@ class Plotter:
         column_of_interest = 'bugs_covered' if bugs else 'edges_covered'
 
         fuzzers_in_order = data_utils.benchmark_rank_by_median(
-            benchmark_snapshot_df).index
+            benchmark_snapshot_df, key=column_of_interest).index
         for fuzzer in fuzzers_in_order:
             measurements_for_fuzzer = benchmark_snapshot_df[
                 benchmark_snapshot_df.fuzzer == fuzzer]
@@ -328,7 +328,7 @@ class Plotter:
         column_of_interest = 'bugs_covered' if bugs else 'edges_covered'
 
         fuzzer_order = data_utils.benchmark_rank_by_median(
-            benchmark_snapshot_df).index
+            benchmark_snapshot_df, key=column_of_interest).index
 
         axes = sns.barplot(y=column_of_interest,
                            x='fuzzer',

--- a/analysis/plotting.py
+++ b/analysis/plotting.py
@@ -130,6 +130,13 @@ class Plotter:
         finally:
             plt.close(fig)
 
+    def _common_datafame_checks(self, benchmark_df, snapshot=False):
+        """assertions common to several plotting functions"""
+        benchmark_names = benchmark_df.benchmark.unique()
+        assert len(benchmark_names) == 1, 'Not a single benchmark data!'
+        if snapshot:
+            assert benchmark_df.time.nunique() == 1, 'Not a snapshot!'
+
     def coverage_growth_plot(self,
                              benchmark_df,
                              axes=None,
@@ -140,8 +147,7 @@ class Plotter:
         The fuzzer labels will be in the order of their mean coverage at the
         snapshot time (typically, the end of experiment).
         """
-        benchmark_names = benchmark_df.benchmark.unique()
-        assert len(benchmark_names) == 1, 'Not a single benchmark data!'
+        self._common_datafame_checks(benchmark_df)
 
         column_of_interest = 'bugs_covered' if bugs else 'edges_covered'
 
@@ -157,6 +163,7 @@ class Plotter:
             hue_order=fuzzer_order,
             data=benchmark_df[benchmark_df.time <= snapshot_time],
             ci=None if bugs or self._quick else 95,
+            estimator=np.median,
             palette=self._fuzzer_colors,
             style='fuzzer',
             dashes=False,
@@ -174,7 +181,7 @@ class Plotter:
                     loc='upper left',
                     frameon=False)
 
-        axes.set(ylabel='Bugs coverage' if bugs else 'Edge coverage')
+        axes.set(ylabel='Bug coverage' if bugs else 'Region coverage')
         axes.set(xlabel='Time (hour:minute)')
 
         if self._logscale or logscale:
@@ -210,14 +217,14 @@ class Plotter:
                                   logscale=logscale,
                                   bugs=bugs)
 
-    def violin_plot(self, benchmark_snapshot_df, axes=None):
+    def violin_plot(self, benchmark_snapshot_df, axes=None, bugs=False):
         """Draws violin plot.
 
         The fuzzer labels will be in the order of their median coverage.
         """
-        benchmark_names = benchmark_snapshot_df.benchmark.unique()
-        assert len(benchmark_names) == 1, 'Not a single benchmark data!'
-        assert benchmark_snapshot_df.time.nunique() == 1, 'Not a snapshot!'
+        self._common_datafame_checks(benchmark_snapshot_df, snapshot=True)
+
+        column_of_interest = 'bugs_covered' if bugs else 'edges_covered'
 
         fuzzer_order = data_utils.benchmark_rank_by_median(
             benchmark_snapshot_df).index
@@ -227,7 +234,7 @@ class Plotter:
         # especially with distributions with high variance. It does not have
         # however violinplot's kernel density estimation.
 
-        sns.violinplot(y='edges_covered',
+        sns.violinplot(y=column_of_interest,
                        x='fuzzer',
                        data=benchmark_snapshot_df,
                        order=fuzzer_order,
@@ -235,7 +242,8 @@ class Plotter:
                        ax=axes)
 
         axes.set_title(_formatted_title(benchmark_snapshot_df))
-        axes.set(ylabel='Reached region coverage')
+        ylabel = 'Reached {} coverage'.format('bug' if bugs else 'region')
+        axes.set(ylabel=ylabel)
         axes.set(xlabel='Fuzzer (highest median coverage on the left)')
         axes.set_xticklabels(axes.get_xticklabels(),
                              rotation=_DEFAULT_LABEL_ROTATION,
@@ -248,21 +256,69 @@ class Plotter:
         self._write_plot_to_image(self.violin_plot, benchmark_snapshot_df,
                                   image_path)
 
-    def distribution_plot(self, benchmark_snapshot_df, axes=None):
+    def box_plot(self, benchmark_snapshot_df, axes=None, bugs=False):
+        """Draws box plot.
+
+        The fuzzer labels will be in the order of their median coverage.
+        """
+        self._common_datafame_checks(benchmark_snapshot_df, snapshot=True)
+
+        column_of_interest = 'bugs_covered' if bugs else 'edges_covered'
+
+        fuzzer_order = data_utils.benchmark_rank_by_median(
+            benchmark_snapshot_df, key=column_of_interest).index
+
+        mean_props = {
+            'markersize': '10',
+            'markeredgecolor': 'black',
+            'markerfacecolor': 'white'
+        }
+
+        common_args = dict(y=column_of_interest,
+                           x='fuzzer',
+                           data=benchmark_snapshot_df,
+                           order=fuzzer_order,
+                           ax=axes)
+
+        sns.boxplot(**common_args,
+                    palette=self._fuzzer_colors,
+                    showmeans=True,
+                    meanprops=mean_props)
+
+        sns.stripplot(**common_args, size=3, color="black", alpha=0.6)
+
+        axes.set_title(_formatted_title(benchmark_snapshot_df))
+        ylabel = 'Reached {} coverage'.format('bug' if bugs else 'region')
+        axes.set(ylabel=ylabel)
+        axes.set(xlabel='Fuzzer (highest median coverage on the left)')
+        axes.set_xticklabels(axes.get_xticklabels(),
+                             rotation=_DEFAULT_LABEL_ROTATION,
+                             horizontalalignment='right')
+
+        sns.despine(ax=axes, trim=True)
+
+    def write_box_plot(self, benchmark_snapshot_df, image_path, bugs=False):
+        """Writes box plot."""
+        self._write_plot_to_image(self.box_plot,
+                                  benchmark_snapshot_df,
+                                  image_path,
+                                  bugs=bugs)
+
+    def distribution_plot(self, benchmark_snapshot_df, axes=None, bugs=False):
         """Draws distribution plot.
 
         The fuzzer labels will be in the order of their median coverage.
         """
-        benchmark_names = benchmark_snapshot_df.benchmark.unique()
-        assert len(benchmark_names) == 1, 'Not a single benchmark data!'
-        assert benchmark_snapshot_df.time.nunique() == 1, 'Not a snapshot!'
+        self._common_datafame_checks(benchmark_snapshot_df, snapshot=True)
+
+        column_of_interest = 'bugs_covered' if bugs else 'edges_covered'
 
         fuzzers_in_order = data_utils.benchmark_rank_by_median(
             benchmark_snapshot_df).index
         for fuzzer in fuzzers_in_order:
             measurements_for_fuzzer = benchmark_snapshot_df[
                 benchmark_snapshot_df.fuzzer == fuzzer]
-            sns.distplot(measurements_for_fuzzer['edges_covered'],
+            sns.distplot(measurements_for_fuzzer[column_of_interest],
                          hist=False,
                          label=fuzzer,
                          color=self._fuzzer_colors[fuzzer],
@@ -271,7 +327,7 @@ class Plotter:
         axes.set_title(_formatted_title(benchmark_snapshot_df))
         axes.legend(loc='upper right', frameon=False)
 
-        axes.set(xlabel='Edge coverage')
+        axes.set(xlabel='Bug coverage' if bugs else 'Region coverage')
         axes.set(ylabel='Density')
         axes.set_xticklabels(axes.get_xticklabels(),
                              rotation=_DEFAULT_LABEL_ROTATION,
@@ -282,19 +338,19 @@ class Plotter:
         self._write_plot_to_image(self.distribution_plot, benchmark_snapshot_df,
                                   image_path)
 
-    def ranking_plot(self, benchmark_snapshot_df, axes=None):
+    def ranking_plot(self, benchmark_snapshot_df, axes=None, bugs=False):
         """Draws ranking plot.
 
         The fuzzer labels will be in the order of their median coverage.
         """
-        benchmark_names = benchmark_snapshot_df.benchmark.unique()
-        assert len(benchmark_names) == 1, 'Not a single benchmark data!'
-        assert benchmark_snapshot_df.time.nunique() == 1, 'Not a snapshot!'
+        self._common_datafame_checks(benchmark_snapshot_df, snapshot=True)
+
+        column_of_interest = 'bugs_covered' if bugs else 'edges_covered'
 
         fuzzer_order = data_utils.benchmark_rank_by_median(
             benchmark_snapshot_df).index
 
-        axes = sns.barplot(y='edges_covered',
+        axes = sns.barplot(y=column_of_interest,
                            x='fuzzer',
                            data=benchmark_snapshot_df,
                            order=fuzzer_order,
@@ -303,7 +359,8 @@ class Plotter:
                            ax=axes)
 
         axes.set_title(_formatted_title(benchmark_snapshot_df))
-        axes.set(ylabel='Reached region coverage')
+        ylabel = 'Reached {} coverage'.format('bug' if bugs else 'region')
+        axes.set(ylabel=ylabel)
         axes.set(xlabel='Fuzzer (highest median coverage on the left)')
         axes.set_xticklabels(axes.get_xticklabels(),
                              rotation=_DEFAULT_LABEL_ROTATION,

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -190,10 +190,10 @@
                 <div class="col s12">
                     <ul class="tabs">
             {% if benchmark.type == 'bug' %}
-                      <li class="tab col s3"><a href="#{{ benchmark.name }}_code_normal" class="green-text text-darken-3">Code coverage (linear)</a></li>
-                      <li class="tab col s3"><a href="#{{ benchmark.name }}_code_logscale" class="green-text text-darken-3">Code coverage (log)</a></li>
                       <li class="tab col s3"><a href="#{{ benchmark.name }}_bugs_normal" class="green-text text-darken-3">Bug coverage (linear)</a></li>
                       <li class="tab col s3"><a href="#{{ benchmark.name }}_bugs_logscale" class="green-text text-darken-3">Bug coverage (log)</a></li>
+                      <li class="tab col s3"><a href="#{{ benchmark.name }}_code_normal" class="green-text text-darken-3">Code coverage (linear)</a></li>
+                      <li class="tab col s3"><a href="#{{ benchmark.name }}_code_logscale" class="green-text text-darken-3">Code coverage (log)</a></li>
             {% else %}
                       <li class="tab col s6"><a href="#{{ benchmark.name }}_code_normal" class="green-text text-darken-3">Code coverage (linear)</a></li>
                       <li class="tab col s6"><a href="#{{ benchmark.name }}_code_logscale" class="green-text text-darken-3">Code coverage (log)</a></li>

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -246,10 +246,40 @@
             </div>
             {% endif %}
 
+            {% if benchmark.type == 'bug' %}
             <ul class="collapsible">
                 <li>
                     <div class="collapsible-header">
-                        Sample statistics and statistical significance
+                        Sample statistics and statistical significance (bugs covered)
+                    </div>
+                    <div class="collapsible-body">
+
+                        <h5 class="center-align">Bug coverage sample statistics</h5>
+                        {{ benchmark.bug_summary_table.to_html() }}
+                        <br>
+
+                        <div class="row">
+                            <div class="col s6 offset-s3">
+                                <h5 class="center-align">Mann-Whitney U test</h4>
+                                    <img class="responsive-img materialboxed"
+                                         src="{{ benchmark.mann_whitney_plot }}">
+                                    The table summarizes the p values of
+                                    pairwise Mann-Whitney U tests.
+                                    Green cells indicate that the reached
+                                    coverage distribution of a given fuzzer pair
+                                    is significantly different.
+                            </div>
+                        </div> <!-- row -->
+
+                    </div>
+                </li>
+            </ul>
+            {% endif %}
+
+            <ul class="collapsible">
+                <li>
+                    <div class="collapsible-header">
+                        Sample statistics and statistical significance (code coverage)
                     </div>
                     <div class="collapsible-body">
 

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -168,46 +168,36 @@
 
             <h2 class="green-text text-darken-3">{{ benchmark.name }} summary</h2>
 
-            {% if benchmark.type == 'bug' %}
-
-            <div class="row">
-               <div class="col s12">
-                    <ul class="tabs">
-                      <li class="tab col s6"><a href="#{{ benchmark.name }}_bugs_normal" class="green-text text-darken-3">Bug coverage (linear)</a></li>
-                      <li class="tab col s6"><a href="#{{ benchmark.name }}_bugs_logscale" class="green-text text-darken-3">Bug coverage (log)</a></li>
-                    </ul>
-                </div>
-                <div id="{{ benchmark.name }}_bugs_normal" class="col s12">
-                    <h5 class="center-align">Mean bug coverage growth over time</h5>
-                    <img class="responsive-img materialboxed"
-                         src="{{ benchmark.bug_coverage_growth_plot }}">
-                </div>
-                <div id="{{ benchmark.name }}_bugs_logscale" class="col s12">
-                    <h5 class="center-align">Mean bug coverage growth over time</h5>
-                    <img class="responsive-img materialboxed"
-                         src="{{ benchmark.bug_coverage_growth_plot_logscale }}">
-                </div>
-            </div>
-
-            {% endif %}
-
             <div class="row">
                 <div class="col s6">
+            {% if benchmark.type == 'bug' %}
+                    <h5 class="center-align">Discovered bug coverage distribution</h5>
+                    <img class="responsive-img materialboxed"
+                         src="{{ benchmark.bug_box_plot }}">
+            {% else %}
                     <h5 class="center-align">Ranking by median reached code coverage</h5>
                     <img class="responsive-img materialboxed"
                          src="{{ benchmark.ranking_plot }}">
+            {% endif %}
                 </div>
                 <div class="col s6">
                     <h5 class="center-align">Reached code coverage distribution</h5>
                     <img class="responsive-img materialboxed"
-                         src="{{ benchmark.violin_plot }}">
+                         src="{{ benchmark.box_plot }}">
                 </div>
             </div>
             <div class="row">
                 <div class="col s12">
                     <ul class="tabs">
+            {% if benchmark.type == 'bug' %}
+                      <li class="tab col s3"><a href="#{{ benchmark.name }}_code_normal" class="green-text text-darken-3">Code coverage (linear)</a></li>
+                      <li class="tab col s3"><a href="#{{ benchmark.name }}_code_logscale" class="green-text text-darken-3">Code coverage (log)</a></li>
+                      <li class="tab col s3"><a href="#{{ benchmark.name }}_bugs_normal" class="green-text text-darken-3">Bug coverage (linear)</a></li>
+                      <li class="tab col s3"><a href="#{{ benchmark.name }}_bugs_logscale" class="green-text text-darken-3">Bug coverage (log)</a></li>
+            {% else %}
                       <li class="tab col s6"><a href="#{{ benchmark.name }}_code_normal" class="green-text text-darken-3">Code coverage (linear)</a></li>
                       <li class="tab col s6"><a href="#{{ benchmark.name }}_code_logscale" class="green-text text-darken-3">Code coverage (log)</a></li>
+            {% endif %}
                     </ul>
                 </div>
                 <div id="{{ benchmark.name }}_code_normal" class="col s12">
@@ -220,6 +210,18 @@
                     <img class="responsive-img materialboxed"
                          src="{{ benchmark.coverage_growth_plot_logscale }}">
                 </div>
+            {% if benchmark.type == 'bug' %}
+                <div id="{{ benchmark.name }}_bugs_normal" class="col s12">
+                    <h5 class="center-align">Mean bug coverage growth over time</h5>
+                    <img class="responsive-img materialboxed"
+                         src="{{ benchmark.bug_coverage_growth_plot }}">
+                </div>
+                <div id="{{ benchmark.name }}_bugs_logscale" class="col s12">
+                    <h5 class="center-align">Mean bug coverage growth over time</h5>
+                    <img class="responsive-img materialboxed"
+                         src="{{ benchmark.bug_coverage_growth_plot_logscale }}">
+                </div>
+            {% endif %}
                 <div class="center-align">
                     * The error bands show the 95% confidence interval
                       around the mean code coverage.


### PR DESCRIPTION
- Placing all coverage growth graphs in the same tabbed section.
- Updating functions to support `bugs_covered` as a metric.
- Adding a boxplot to replace the violin plot which shows
  greater detail, especially when outliers are present.
- There appears to still be a problem with the bug coverage
  growth plot as the lines are not monotonically increasing?
- Fixed drop duplicates as the first column (id) was causing duplicates not to be dropped.  This may not be an issue when querying data from the database.