### PR TITLE
Add llvm-cov options for coverage summary generation

### DIFF
--- a/experiment/measurer/coverage_utils.py
+++ b/experiment/measurer/coverage_utils.py
@@ -251,7 +251,7 @@ class TrialCoverage:  # pylint: disable=too-many-instance-attributes
 def generate_json_summary(coverage_binary,
                           profdata_file,
                           output_file,
-                          summary_only=True):
+                          summary_only=False):
     """Generates the json summary file from |coverage_binary|
     and |profdata_file|."""
     command = [

--- a/experiment/measurer/coverage_utils.py
+++ b/experiment/measurer/coverage_utils.py
@@ -251,7 +251,7 @@ class TrialCoverage:  # pylint: disable=too-many-instance-attributes
 def generate_json_summary(coverage_binary,
                           profdata_file,
                           output_file,
-                          summary_only=False):
+                          summary_only=True):
     """Generates the json summary file from |coverage_binary|
     and |profdata_file|."""
     command = [

--- a/experiment/measurer/coverage_utils.py
+++ b/experiment/measurer/coverage_utils.py
@@ -255,7 +255,8 @@ def generate_json_summary(coverage_binary,
     """Generates the json summary file from |coverage_binary|
     and |profdata_file|."""
     command = [
-        'llvm-cov', 'export', '-format=text', coverage_binary,
+        'llvm-cov', 'export', '-format=text', '-num-threads=1',
+        '-region-coverage-gt=0', '-skip-expansions', coverage_binary,
         '-instr-profile=%s' % profdata_file
     ]
 

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -380,7 +380,7 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
         self.UNIT_BLACKLIST[self.benchmark] = (
             self.UNIT_BLACKLIST[self.benchmark].union(set(crashing_units)))
 
-    def generate_summary(self, cycle: int, summary_only=True):
+    def generate_summary(self, cycle: int, summary_only=False):
         """Transforms the .profdata file into json form."""
         coverage_binary = coverage_utils.get_coverage_binary(self.benchmark)
         result = coverage_utils.generate_json_summary(coverage_binary,

--- a/experiment/measurer/test_measure_manager.py
+++ b/experiment/measurer/test_measure_manager.py
@@ -152,9 +152,10 @@ def test_generate_summary(mocked_get_coverage_binary, mocked_execute,
     snapshot_measurer.generate_summary(CYCLE)
 
     expected = [
-        'llvm-cov', 'export', '-format=text',
+        'llvm-cov', 'export', '-format=text', '-num-threads=1',
+        '-region-coverage-gt=0', '-skip-expansions',
         '/work/coverage-binaries/benchmark-a/fuzz-target',
-        '-instr-profile=/reports/data.profdata', '-summary-only'
+        '-instr-profile=/reports/data.profdata'
     ]
 
     assert (len(mocked_execute.call_args_list)) == 1


### PR DESCRIPTION
This PR is about adding a few more options to the `llvm-cov` call in `coverage_utils.py`.

The options added on top of the existing ones are as follows:

- `-num-thread=1` :  llvm-cov auto-detects an appropriate number of threads to use. Here we are forcing usage of a single thread to export coverage data.

- `-region-coverage-gt=0` : As the current `covered_regions.json` only accounts for regions with hits greater than 0, we can simply add this option rather than filtering it out later in (`extract_covered_regions_from_summary_json`).

- `-skip-expansions` : This option enables us to skip exporting of macro expansion coverage data.

All these changes are made so that during measuring we can generate a full fledged summary to export segment and function coverage. As suggested, the changes to code to record segment and function coverage will follow in a new PR.