### PR TITLE
Enable bug based statistical tests.

### DIFF
--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -82,6 +82,12 @@ class BenchmarkResults:
         return benchmark_type
 
     @property
+    def _relevant_column(self):
+        """Returns the name of the column that will be used as the basis of
+        the analysis (e.g., 'edges_covered', or 'bugs_covered')."""
+        return 'edges_covered' if self.type == 'code' else 'bugs_covered'
+
+    @property
     @functools.lru_cache()
     # TODO(lszekeres): With python3.8+, replace above two decorators with:
     # @functools.cached_property
@@ -165,13 +171,14 @@ class BenchmarkResults:
     def rank_by_stat_test_wins(self):
         """Fuzzer ranking by then number of pairwise statistical test wins."""
         return data_utils.benchmark_rank_by_stat_test_wins(
-            self._benchmark_snapshot_df)
+            self._benchmark_snapshot_df, key=self._relevant_column)
 
     @property
     @functools.lru_cache()
     def mann_whitney_p_values(self):
         """Mann Whitney U test result."""
-        return stat_tests.two_sided_u_test(self._benchmark_snapshot_df)
+        return stat_tests.two_sided_u_test(self._benchmark_snapshot_df,
+                                           key=self._relevant_column)
 
     @property
     def mann_whitney_plot(self):
@@ -184,13 +191,15 @@ class BenchmarkResults:
     @property
     def anova_p_value(self):
         """ANOVA test result."""
-        return stat_tests.anova_test(self._benchmark_snapshot_df)
+        return stat_tests.anova_test(self._benchmark_snapshot_df,
+                                     key=self._relevant_column)
 
     @property
     @functools.lru_cache()
     def anova_posthoc_p_values(self):
         """ANOVA posthoc test results."""
-        return stat_tests.anova_posthoc_tests(self._benchmark_snapshot_df)
+        return stat_tests.anova_posthoc_tests(self._benchmark_snapshot_df,
+                                              key=self._relevant_column)
 
     @property
     def anova_student_plot(self):
@@ -211,13 +220,15 @@ class BenchmarkResults:
     @property
     def kruskal_p_value(self):
         """Kruskal test result."""
-        return stat_tests.kruskal_test(self._benchmark_snapshot_df)
+        return stat_tests.kruskal_test(self._benchmark_snapshot_df,
+                                       key=self._relevant_column)
 
     @property
     @functools.lru_cache()
     def kruskal_posthoc_p_values(self):
         """Kruskal posthoc test results."""
-        return stat_tests.kruskal_posthoc_tests(self._benchmark_snapshot_df)
+        return stat_tests.kruskal_posthoc_tests(self._benchmark_snapshot_df,
+                                                key=self._relevant_column)
 
     @property
     def kruskal_conover_plot(self):

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -241,12 +241,13 @@ def benchmark_rank_by_average_rank(benchmark_snapshot_df, key='edges_covered'):
     return avg_rank['avg rank']
 
 
-def benchmark_rank_by_stat_test_wins(benchmark_snapshot_df):
+def benchmark_rank_by_stat_test_wins(benchmark_snapshot_df,
+                                     key='edges_covered'):
     """Carries out one-tailed statistical tests for each fuzzer pair.
 
     Returns ranking according to the number of statistical test wins.
     """
-    p_values = stat_tests.one_sided_u_test(benchmark_snapshot_df)
+    p_values = stat_tests.one_sided_u_test(benchmark_snapshot_df, key=key)
 
     # Turn "significant" p-values into 1-s.
     better_than = p_values.applymap(
@@ -259,10 +260,10 @@ def benchmark_rank_by_stat_test_wins(benchmark_snapshot_df):
     return score
 
 
-def create_better_than_table(benchmark_snapshot_df):
+def create_better_than_table(benchmark_snapshot_df, key='edges_covered'):
     """Creates table showing whether fuzzer in row is statistically
     significantly better than the fuzzer in the column."""
-    p_values = stat_tests.one_sided_u_test(benchmark_snapshot_df)
+    p_values = stat_tests.one_sided_u_test(benchmark_snapshot_df, key=key)
 
     # Turn "significant" p-values into 1-s.
     better_than = p_values.applymap(

--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -201,10 +201,8 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
     def rank_by_stat_test_wins_and_average_rank(self):
         """Rank fuzzers using statistical test wins per benchmark and average
         rank across benchmarks."""
-        return data_utils.experiment_level_ranking(
-            self._experiment_snapshots_df,
-            data_utils.benchmark_rank_by_stat_test_wins,
-            data_utils.experiment_rank_by_average_rank)
+        return self._ranking(data_utils.benchmark_rank_by_stat_test_wins,
+                             data_utils.experiment_rank_by_num_firsts)
 
     @property
     def friedman_p_value(self):

--- a/analysis/stat_tests.py
+++ b/analysis/stat_tests.py
@@ -22,6 +22,7 @@ SIGNIFICANCE_THRESHOLD = 0.05
 
 
 def _create_p_value_table(benchmark_snapshot_df,
+                          key,
                           statistical_test,
                           alternative="two-sided"):
     """Given a benchmark snapshot data frame and a statistical test function,
@@ -40,7 +41,7 @@ def _create_p_value_table(benchmark_snapshot_df,
                                 alternative=alternative).pvalue
 
     groups = benchmark_snapshot_df.groupby('fuzzer')
-    samples = groups['edges_covered'].apply(list)
+    samples = groups[key].apply(list)
     fuzzers = samples.index
 
     data = []
@@ -62,47 +63,51 @@ def _create_p_value_table(benchmark_snapshot_df,
     return p_values
 
 
-def one_sided_u_test(benchmark_snapshot_df):
+def one_sided_u_test(benchmark_snapshot_df, key):
     """Returns p-value table for one-tailed Mann-Whitney U test."""
     return _create_p_value_table(benchmark_snapshot_df,
+                                 key,
                                  ss.mannwhitneyu,
                                  alternative='greater')
 
 
-def two_sided_u_test(benchmark_snapshot_df):
+def two_sided_u_test(benchmark_snapshot_df, key):
     """Returns p-value table for two-tailed Mann-Whitney U test."""
     return _create_p_value_table(benchmark_snapshot_df,
+                                 key,
                                  ss.mannwhitneyu,
                                  alternative='two-sided')
 
 
-def one_sided_wilcoxon_test(benchmark_snapshot_df):
+def one_sided_wilcoxon_test(benchmark_snapshot_df, key):
     """Returns p-value table for one-tailed Wilcoxon signed-rank test."""
     return _create_p_value_table(benchmark_snapshot_df,
+                                 key,
                                  ss.wilcoxon,
                                  alternative='greater')
 
 
-def two_sided_wilcoxon_test(benchmark_snapshot_df):
+def two_sided_wilcoxon_test(benchmark_snapshot_df, key):
     """Returns p-value table for two-tailed Wilcoxon signed-rank test."""
     return _create_p_value_table(benchmark_snapshot_df,
+                                 key,
                                  ss.wilcoxon,
                                  alternative='two-sided')
 
 
-def anova_test(benchmark_snapshot_df):
+def anova_test(benchmark_snapshot_df, key):
     """Returns p-value for ANOVA test.
 
     Results should only considered when we can assume normal distributions.
     """
     groups = benchmark_snapshot_df.groupby('fuzzer')
-    sample_groups = groups['edges_covered'].apply(list).values
+    sample_groups = groups[key].apply(list).values
 
     _, p_value = ss.f_oneway(*sample_groups)
     return p_value
 
 
-def anova_posthoc_tests(benchmark_snapshot_df):
+def anova_posthoc_tests(benchmark_snapshot_df, key):
     """Returns p-value tables for various ANOVA posthoc tests.
 
     Results should considered only if ANOVA test rejects null hypothesis.
@@ -110,7 +115,7 @@ def anova_posthoc_tests(benchmark_snapshot_df):
     common_args = {
         'a': benchmark_snapshot_df,
         'group_col': 'fuzzer',
-        'val_col': 'edges_covered',
+        'val_col': key,
         'sort': True
     }
     p_adjust = 'holm'
@@ -123,16 +128,16 @@ def anova_posthoc_tests(benchmark_snapshot_df):
     return posthoc_tests
 
 
-def kruskal_test(benchmark_snapshot_df):
+def kruskal_test(benchmark_snapshot_df, key):
     """Returns p-value for Kruskal test."""
     groups = benchmark_snapshot_df.groupby('fuzzer')
-    sample_groups = groups['edges_covered'].apply(list).values
+    sample_groups = groups[key].apply(list).values
 
     _, p_value = ss.kruskal(*sample_groups)
     return p_value
 
 
-def kruskal_posthoc_tests(benchmark_snapshot_df):
+def kruskal_posthoc_tests(benchmark_snapshot_df, key):
     """Returns p-value tables for various Kruskal posthoc tests.
 
     Results should considered only if Kruskal test rejects null hypothesis.
@@ -140,7 +145,7 @@ def kruskal_posthoc_tests(benchmark_snapshot_df):
     common_args = {
         'a': benchmark_snapshot_df,
         'group_col': 'fuzzer',
-        'val_col': 'edges_covered',
+        'val_col': key,
         'sort': True
     }
     p_adjust = 'holm'


### PR DESCRIPTION
- Add a `key` parameter for statistical test functions, to support running stat
  tests on the 'bugs_covered' column too, not only on 'edges_covered'.
- For bug based benchmarks the statistical significance plots in the reports
  will be computed based on bug numbers.