### PR TITLE
Separate U test plot for bug and code coverage.

### DIFF
--- a/analysis/benchmark_results.py
+++ b/analysis/benchmark_results.py
@@ -178,13 +178,28 @@ class BenchmarkResults:
     def mann_whitney_p_values(self):
         """Mann Whitney U test result."""
         return stat_tests.two_sided_u_test(self._benchmark_snapshot_df,
-                                           key=self._relevant_column)
+                                           key='edges_covered')
+
+    @property
+    @functools.lru_cache()
+    def bug_mann_whitney_p_values(self):
+        """Mann Whitney U test result based on bugs covered."""
+        return stat_tests.two_sided_u_test(self._benchmark_snapshot_df,
+                                           key='bugs_covered')
 
     @property
     def mann_whitney_plot(self):
         """Mann Whitney U test plot."""
         plot_filename = self._prefix_with_benchmark('mann_whitney_plot.svg')
         self._plotter.write_heatmap_plot(self.mann_whitney_p_values,
+                                         self._get_full_path(plot_filename))
+        return plot_filename
+
+    @property
+    def bug_mann_whitney_plot(self):
+        """Mann Whitney U test plot based on bugs covered."""
+        plot_filename = self._prefix_with_benchmark('bug_mann_whitney_plot.svg')
+        self._plotter.write_heatmap_plot(self.bug_mann_whitney_p_values,
                                          self._get_full_path(plot_filename))
         return plot_filename
 

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -262,7 +262,7 @@
                             <div class="col s6 offset-s3">
                                 <h5 class="center-align">Mann-Whitney U test</h4>
                                     <img class="responsive-img materialboxed"
-                                         src="{{ benchmark.mann_whitney_plot }}">
+                                         src="{{ benchmark.bug_mann_whitney_plot }}">
                                     The table summarizes the p values of
                                     pairwise Mann-Whitney U tests.
                                     Green cells indicate that the reached


### PR DESCRIPTION
Currently, for bug based reports, for each benchmark, we have two tables:
- Sample statistics and statistical significance (bugs covered)
- Sample statistics and statistical significance (code coverage)

Containing two statistical significance test plot.