### PR TITLE
Bug benchmarking fixes

### DIFF
--- a/docker/benchmark-runner/Dockerfile
+++ b/docker/benchmark-runner/Dockerfile
@@ -59,6 +59,8 @@ ENV ROOT_DIR=/src
 # Copy over all the build artifacts (without * to preserve directory structure).
 # This also copies seed and dictionary files if they are available.
 COPY --from=builder /out/ ./
+# Copy the benchmarks directory.
+COPY benchmarks $ROOT_DIR/benchmarks
 # Copy the fuzzers directory.
 COPY fuzzers $ROOT_DIR/fuzzers
 # Create empty __init__.py to allow python deps to work.

--- a/experiment/measurer/run_coverage.py
+++ b/experiment/measurer/run_coverage.py
@@ -21,7 +21,7 @@ from typing import List
 from common import experiment_utils
 from common import logs
 from common import new_process
-from experiment.measurer import sanitizer
+from common import sanitizer
 
 logger = logs.Logger('run_coverage')
 

--- a/experiment/measurer/run_crashes.py
+++ b/experiment/measurer/run_crashes.py
@@ -21,8 +21,8 @@ from clusterfuzz import stacktraces
 
 from common import logs
 from common import new_process
+from common import sanitizer
 from experiment.measurer import run_coverage
-from experiment.measurer import sanitizer
 
 logger = logs.Logger('run_crashes')
 

--- a/experiment/measurer/test_measure_manager.py
+++ b/experiment/measurer/test_measure_manager.py
@@ -338,8 +338,7 @@ def test_run_cov_new_units(_, mocked_execute, fs, environ):
                 ('allocator_release_to_os_interval_ms=500:handle_abort=2:'
                  'handle_segv=2:handle_sigbus=2:handle_sigfpe=2:'
                  'handle_sigill=2:print_stacktrace=1:'
-                 'silence_unsigned_overflow=1:symbolize=1:'
-                 'symbolize_inline_frames=0'),
+                 'symbolize=1:symbolize_inline_frames=0'),
             'LLVM_PROFILE_FILE':
                 ('/work/measurement-folders/'
                  'benchmark-a-fuzzer-a/trial-12/coverage/data-%m.profraw'),

--- a/experiment/test_runner.py
+++ b/experiment/test_runner.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 import pytest
 
+from common import benchmark_config
 from common import filestore_utils
 from common import new_process
 from experiment import runner
@@ -41,6 +42,8 @@ def test_run_fuzzer_log_file(mocked_communicate, fs, environ):
     os.environ['FUZZ_TARGET'] = '/out/fuzz-target'
     os.environ['RUNNER_NICENESS'] = '-5'
     os.environ['FUZZER'] = 'afl'
+    os.environ['BENCHMARK'] = 'freetype2-2017'
+    fs.add_real_directory(benchmark_config.BENCHMARKS_DIR)
     fs.create_file('/out/fuzz-target')
 
     with test_utils.mock_popen_ctx_mgr() as mocked_popen:

--- a/fuzzers/test_utils.py
+++ b/fuzzers/test_utils.py
@@ -99,12 +99,12 @@ def test_initialize_env_in_environment_with_sanitizer(fs, environ):
         '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
         'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
         'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
-        'unsigned-integer-overflow,unreachable,vla-bound,vptr -O3')
+        'unreachable,vla-bound,vptr -O3')
     assert os.getenv('CXXFLAGS') == (
         '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
         'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
         'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
-        'unsigned-integer-overflow,unreachable,vla-bound,vptr -stdlib=libc++ '
+        'unreachable,vla-bound,vptr -stdlib=libc++ '
         '-O3')
 
 
@@ -131,10 +131,10 @@ def test_initialize_env_in_var_with_sanitizer(fs):
         '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
         'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
         'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
-        'unsigned-integer-overflow,unreachable,vla-bound,vptr -O3')
+        'unreachable,vla-bound,vptr -O3')
     assert env.get('CXXFLAGS') == (
         '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
         'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
         'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
-        'unsigned-integer-overflow,unreachable,vla-bound,vptr -stdlib=libc++ '
+        'unreachable,vla-bound,vptr -stdlib=libc++ '
         '-O3')

--- a/fuzzers/test_utils.py
+++ b/fuzzers/test_utils.py
@@ -99,13 +99,13 @@ def test_initialize_env_in_environment_with_sanitizer(fs, environ):
         '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
         'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
         'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
-        'unreachable,vla-bound,vptr -O3')
+        'unreachable,vla-bound,vptr -O1')
     assert os.getenv('CXXFLAGS') == (
         '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
         'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
         'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
         'unreachable,vla-bound,vptr -stdlib=libc++ '
-        '-O3')
+        '-O1')
 
 
 def test_initialize_env_in_var_without_sanitizer(fs):
@@ -131,10 +131,10 @@ def test_initialize_env_in_var_with_sanitizer(fs):
         '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
         'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
         'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
-        'unreachable,vla-bound,vptr -O3')
+        'unreachable,vla-bound,vptr -O1')
     assert env.get('CXXFLAGS') == (
         '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
         'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
         'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
         'unreachable,vla-bound,vptr -stdlib=libc++ '
-        '-O3')
+        '-O1')

--- a/fuzzers/utils.py
+++ b/fuzzers/utils.py
@@ -36,8 +36,7 @@ SANITIZER_FLAGS = [
     # See https://github.com/google/oss-fuzz/blob/master/infra/base-images/base-builder/Dockerfile#L94
     '-fsanitize=array-bounds,bool,builtin,enum,float-divide-by-zero,function,'
     'integer-divide-by-zero,null,object-size,return,returns-nonnull-attribute,'
-    'shift,signed-integer-overflow,unsigned-integer-overflow,unreachable,'
-    'vla-bound,vptr',
+    'shift,signed-integer-overflow,unreachable,vla-bound,vptr',
 ]
 
 # Use these flags when compiling benchmark code without a sanitizer (e.g. when

--- a/fuzzers/utils.py
+++ b/fuzzers/utils.py
@@ -26,6 +26,7 @@ import yaml
 # Keep all fuzzers at same optimization level until fuzzer explicitly needs or
 # specifies it.
 DEFAULT_OPTIMIZATION_LEVEL = '-O3'
+BUGS_OPTIMIZATION_LEVEL = '-O1'
 
 LIBCPLUSPLUS_FLAG = '-stdlib=libc++'
 
@@ -180,11 +181,11 @@ def set_compilation_flags(env=None):
 
     if get_config_value('type') == 'bug':
         append_flags('CFLAGS',
-                     SANITIZER_FLAGS + [DEFAULT_OPTIMIZATION_LEVEL],
+                     SANITIZER_FLAGS + [BUGS_OPTIMIZATION_LEVEL],
                      env=env)
         append_flags('CXXFLAGS',
                      SANITIZER_FLAGS +
-                     [LIBCPLUSPLUS_FLAG, DEFAULT_OPTIMIZATION_LEVEL],
+                     [LIBCPLUSPLUS_FLAG, BUGS_OPTIMIZATION_LEVEL],
                      env=env)
     else:
         append_flags('CFLAGS',


### PR DESCRIPTION
- Set sanitizer options in runner, to match measurer.
- Remove unsigned-integer-overflow, it breaks builds and is also
  unused in OSS-Fuzz, we only see stacks and then silence them.
  Best to just remove it altogether.
- Move sanitizer.py to common/ since runner cannot access files
  in experiment/measurer and also this is now for common given
  the usecase.
- Optimize sanitizer flags for fuzzing, see
  https://github.com/google/AFL/blob/master/afl-fuzz.c#L7558
  and https://github.com/google/fuzzbench/pull/988#issuecomment-746009404
Fixes https://github.com/google/fuzzbench/issues/994