### PR TITLE
Don't process crashes for non-bug benchmarks.

### DIFF
--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -355,9 +355,6 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
         self.cov_summary_file = os.path.join(self.report_dir,
                                              'cov_summary.json')
 
-        self.is_bug_benchmark = (
-            benchmark_config.get_config(benchmark).get('type') == 'bug')
-
     def get_profraw_files(self):
         """Return generated profraw files."""
         return [
@@ -514,7 +511,9 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
 
     def process_crashes(self, cycle):
         """Process and store crashes."""
-        if not self.is_bug_benchmark:
+        benchmark_type = benchmark_config.get_config(self.benchmark).get('type')
+        is_bug_benchmark = benchmark_type == 'bug'
+        if not is_bug_benchmark:
             return []
 
         if not os.listdir(self.crashes_dir):

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -31,11 +31,11 @@ import queue
 from sqlalchemy import func
 from sqlalchemy import orm
 
+from common import benchmark_config
 from common import experiment_utils
 from common import experiment_path as exp_path
 from common import filesystem
 from common import fuzzer_stats
-
 from common import filestore_utils
 from common import logs
 from common import utils
@@ -355,6 +355,9 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
         self.cov_summary_file = os.path.join(self.report_dir,
                                              'cov_summary.json')
 
+        self.is_bug_benchmark = (
+            benchmark_config.get_config(benchmark).get('type') == 'bug')
+
     def get_profraw_files(self):
         """Return generated profraw files."""
         return [
@@ -511,6 +514,9 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
 
     def process_crashes(self, cycle):
         """Process and store crashes."""
+        if not self.is_bug_benchmark:
+            return []
+
         if not os.listdir(self.crashes_dir):
             logs.info('No crashes found for cycle %d.', cycle)
             return []

--- a/experiment/measurer/run_crashes.py
+++ b/experiment/measurer/run_crashes.py
@@ -47,6 +47,14 @@ def _filter_crash_state(crash_state):
 
 def process_crash(app_binary, crash_testcase_path, crashes_dir):
     """Returns the crashing unit in coverage_binary_output."""
+    crash_filename = os.path.basename(crash_testcase_path)
+    if (crash_filename.startswith('oom-') or
+            crash_filename.startswith('timeout-')):
+        # Don't spend time processing ooms and timeouts as these are
+        # uninteresting crashes anyway. These are also excluded below, but don't
+        # process them in the first place based on filename.
+        return None
+
     # Run the crash with sanitizer options set in environment.
     env = os.environ.copy()
     sanitizer.set_sanitizer_options(env)


### PR DESCRIPTION
Also, optimize by not processing ooms and timeout by looking
at filenames.

Basically, in regular non-bug benchmark experiments, woff benchmark generates a lot of ooms, so we shouldn't be processing them.