### PR TITLE
Disable lafintel for bug based benchmarks

### DIFF
--- a/benchmarks/harfbuzz_hb-subset-fuzzer/benchmark.yaml
+++ b/benchmarks/harfbuzz_hb-subset-fuzzer/benchmark.yaml
@@ -9,4 +9,5 @@ unsupported_fuzzers:
   - aflplusplus_qemu
   - honggfuzz_qemu
   - klee
+  - lafintel
   - weizz_qemu

--- a/benchmarks/libhevc_hevc_dec_fuzzer/benchmark.yaml
+++ b/benchmarks/libhevc_hevc_dec_fuzzer/benchmark.yaml
@@ -9,5 +9,6 @@ unsupported_fuzzers:
   - aflplusplus_qemu
   - honggfuzz_qemu
   - klee
+  - lafintel
   - weizz_qemu
 

--- a/benchmarks/matio_matio_fuzzer/benchmark.yaml
+++ b/benchmarks/matio_matio_fuzzer/benchmark.yaml
@@ -9,4 +9,5 @@ unsupported_fuzzers:
   - aflplusplus_qemu
   - honggfuzz_qemu
   - klee
+  - lafintel
   - weizz_qemu

--- a/benchmarks/ndpi_fuzz_ndpi_reader/benchmark.yaml
+++ b/benchmarks/ndpi_fuzz_ndpi_reader/benchmark.yaml
@@ -9,4 +9,5 @@ unsupported_fuzzers:
   - aflplusplus_qemu
   - honggfuzz_qemu
   - klee
+  - lafintel
   - weizz_qemu

--- a/benchmarks/openexr_openexr_exrenvmap_fuzzer/benchmark.yaml
+++ b/benchmarks/openexr_openexr_exrenvmap_fuzzer/benchmark.yaml
@@ -9,4 +9,5 @@ unsupported_fuzzers:
   - aflplusplus_qemu
   - honggfuzz_qemu
   - klee
+  - lafintel
   - weizz_qemu

--- a/benchmarks/openh264_decoder_fuzzer/benchmark.yaml
+++ b/benchmarks/openh264_decoder_fuzzer/benchmark.yaml
@@ -9,4 +9,5 @@ unsupported_fuzzers:
   - aflplusplus_qemu
   - honggfuzz_qemu
   - klee
+  - lafintel
   - weizz_qemu

--- a/benchmarks/php_php-fuzz-execute/benchmark.yaml
+++ b/benchmarks/php_php-fuzz-execute/benchmark.yaml
@@ -9,4 +9,5 @@ unsupported_fuzzers:
   - aflplusplus_qemu
   - honggfuzz_qemu
   - klee
+  - lafintel
   - weizz_qemu

--- a/benchmarks/php_php-fuzz-parser-2020-07-25/benchmark.yaml
+++ b/benchmarks/php_php-fuzz-parser-2020-07-25/benchmark.yaml
@@ -9,4 +9,5 @@ unsupported_fuzzers:
   - aflplusplus_qemu
   - honggfuzz_qemu
   - klee
+  - lafintel
   - weizz_qemu

--- a/benchmarks/stb_stbi_read_fuzzer/benchmark.yaml
+++ b/benchmarks/stb_stbi_read_fuzzer/benchmark.yaml
@@ -9,4 +9,5 @@ unsupported_fuzzers:
   - aflplusplus_qemu
   - honggfuzz_qemu
   - klee
+  - lafintel
   - weizz_qemu


### PR DESCRIPTION
lafintel seems to not work with sanitizer flags, crashes on
startup.

```
[*] Spinning up the fork server...

[-] Whoops, the target binary crashed suddenly, before receiving any input
    from the fuzzer! There are several probable explanations:
```