### PR TITLE
Use secret manager to reuse service account keys

### DIFF
--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -143,3 +143,9 @@ def delete_instance_template(template_name: str):
         'gcloud', 'compute', 'instance-templates', 'delete', template_name
     ]
     return new_process.execute(command)
+
+
+def get_account():
+    """Get the email address of the current account being used."""
+    return new_process.execute(['gcloud', 'config', 'get-value',
+                                'account']).output.strip()

--- a/common/gcloud.py
+++ b/common/gcloud.py
@@ -146,6 +146,6 @@ def delete_instance_template(template_name: str):
 
 
 def get_account():
-    """Get the email address of the current account being used."""
+    """Returns the email address of the current account being used."""
     return new_process.execute(['gcloud', 'config', 'get-value',
                                 'account']).output.strip()

--- a/docker/dispatcher-image/startup-dispatcher.sh
+++ b/docker/dispatcher-image/startup-dispatcher.sh
@@ -28,15 +28,9 @@ tar -xvzf ${WORK}/src.tar.gz -C ${WORK}/src
 
 # Set up credentials locally as cloud metadata service does not scale.
 credentials_file=${WORK}/creds.json
-iam_account=`gcloud config get-value account`
-gcloud iam service-accounts keys create ${credentials_file} \
-    --iam-account=${iam_account}
+PYTHONPATH=${WORK}/src python3 \
+  ${WORK}/src/experiment/cloud/service_account_key.py $credentials_file $CLOUD_PROJECT
 
 # Start dispatcher.
 PYTHONPATH=${WORK}/src GOOGLE_APPLICATION_CREDENTIALS=${credentials_file} \
     python3 "${WORK}/src/experiment/dispatcher.py"
-
-# Revoke created credentials.
-key_id=$(cat "${credentials_file}" | jq -r ".private_key_id")
-gcloud iam service-accounts keys delete ${key_id} -q \
-    --iam-account=${iam_account}

--- a/docs/running-a-cloud-experiment/setting_up_a_google_cloud_project.md
+++ b/docs/running-a-cloud-experiment/setting_up_a_google_cloud_project.md
@@ -160,6 +160,9 @@ optimized for doing so.
 * [Enable Cloud SQL Admin API](https://console.cloud.google.com/apis/library/sqladmin.googleapis.com)
 so that FuzzBench can connect to the database.
 
+* [Enable Secret Manager API](https://console.cloud.google.com/apis/library/secretmanager.googleapis.com)
+so that FuzzBench can store service account keys.
+
 ## Configure networking
 
 * Go to the networking page for the network you want to run your experiment in.

--- a/experiment/cloud/secret_manager.py
+++ b/experiment/cloud/secret_manager.py
@@ -16,8 +16,6 @@ import posixpath
 
 from google.cloud import secretmanager
 
-# !!! Document enabling it: https://pantheon.corp.google.com/apis/library/secretmanager.googleapis.com?project=fuzzbench
-
 
 def get_secret_manager_client():
     """Returns the secretmanager client."""

--- a/experiment/cloud/secret_manager.py
+++ b/experiment/cloud/secret_manager.py
@@ -1,0 +1,68 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MOdule for dealing with the Google Cloud secret manager."""
+import posixpath
+
+from google.cloud import secretmanager
+
+# !!! Document enabling it: https://pantheon.corp.google.com/apis/library/secretmanager.googleapis.com?project=fuzzbench
+
+
+def get_secret_manager_client():
+    """Returns the secretmanager client."""
+    return secretmanager.SecretManagerServiceClient()
+
+
+def get_parent(project):
+    """Creates the parent resource."""
+    return f'projects/{project}'
+
+
+def _create_secret(client, secret_id, project):
+    """Creates and returns a secret (identified by |secret_id| for |project|)
+    using |client."""
+    client = get_secret_manager_client()
+    parent = get_parent(project)
+    return client.create_secret(
+        request={
+            'parent': parent,
+            'secret_id': secret_id,
+            'secret': {
+                'replication': {
+                    'automatic': {}
+                }
+            },
+        })
+
+
+def save(secret_id, value, project):
+    """Saves |value| using |secret_id| in |project|."""
+    client = get_secret_manager_client()
+    secret = _create_secret(client, secret_id, project)
+    client.add_secret_version(request={
+        'parent': secret.name,
+        'payload': {
+            'data': value
+        }
+    })
+
+
+def get(secret_id, project):
+    """Returns the value of the secret identified by |secret_id| in
+    |project|."""
+    parent = get_parent(project)
+    name = posixpath.join(parent, 'secrets', secret_id, 'versions', '1')
+    client = get_secret_manager_client()
+    response = client.access_secret_version(request={'name': name})
+    return response.payload.data

--- a/experiment/cloud/secret_manager.py
+++ b/experiment/cloud/secret_manager.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""MOdule for dealing with the Google Cloud secret manager."""
+"""Module for dealing with the Google Cloud secret manager."""
 import posixpath
 
 from google.cloud import secretmanager

--- a/experiment/cloud/secret_manager.py
+++ b/experiment/cloud/secret_manager.py
@@ -22,8 +22,8 @@ def get_secret_manager_client():
     return secretmanager.SecretManagerServiceClient()
 
 
-def get_parent(project):
-    """Creates the parent resource."""
+def get_parent_resource(project):
+    """Returns the parent resource."""
     return f'projects/{project}'
 
 
@@ -31,7 +31,7 @@ def _create_secret(client, secret_id, project):
     """Creates and returns a secret (identified by |secret_id| for |project|)
     using |client."""
     client = get_secret_manager_client()
-    parent = get_parent(project)
+    parent = get_parent_resource(project)
     return client.create_secret(
         request={
             'parent': parent,
@@ -59,7 +59,7 @@ def save(secret_id, value, project):
 def get(secret_id, project):
     """Returns the value of the secret identified by |secret_id| in
     |project|."""
-    parent = get_parent(project)
+    parent = get_parent_resource(project)
     name = posixpath.join(parent, 'secrets', secret_id, 'versions', '1')
     client = get_secret_manager_client()
     response = client.access_secret_version(request={'name': name})

--- a/experiment/cloud/service_account_key.py
+++ b/experiment/cloud/service_account_key.py
@@ -1,0 +1,76 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for dealing with service account keys."""
+import sys
+import base64
+import json
+
+import google.api_core.exceptions
+import google.auth
+import googleapiclient.discovery
+
+from common import filesystem
+from common import gcloud
+from common import logs
+from experiment.cloud import secret_manager
+
+SECRET_ID = 'service-account-key'
+
+
+def get_iam_service():
+    """Returns the IAM Google Cloud service."""
+    credentials, _ = google.auth.default()
+    return googleapiclient.discovery.build('iam', 'v1', credentials=credentials)
+
+
+def create_key(project):
+    """Creates a service account key in |project|."""
+    service = get_iam_service()
+    account = gcloud.get_account()
+    name = f'projects/{project}/serviceAccounts/{account}'
+    key = service.projects().serviceAccounts().keys().create(  # pylint: disable=no-member
+        name=name, body={}).execute()
+    # Load and dump json to remove formatting.
+    return str.encode(
+        json.dumps(json.loads(base64.b64decode(key['privateKeyData']))))
+
+
+def get_or_create_key(project, file_path):
+    """Gets the service account key (for |project|) from the secret manager and
+    saves it to |file_path| or creates one, saves it using the secretmanager
+    (for future use) and saves it to |file_path|."""
+    try:
+        service_account_key = secret_manager.get(SECRET_ID, project)
+    except google.api_core.exceptions.NotFound:
+        service_account_key = create_key(project)
+        secret_manager.save(SECRET_ID, service_account_key, project)
+    filesystem.write(file_path, service_account_key, 'wb')
+
+
+def main():
+    """Creates or gets an already created service account key and saves it to
+    the provided path."""
+    logs.initialize()
+    try:
+        keyfile = sys.argv[1]
+        get_or_create_key(sys.argv[2], keyfile)
+        logs.info('Saved key to %s.', keyfile)
+    except Exception:  # pylint: disable=broad-except
+        logs.error('Failed to get or create key.')
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/experiment/cloud/service_account_key.py
+++ b/experiment/cloud/service_account_key.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Utilities for dealing with service account keys."""
+"""Script for getting a service account key for use in an experiment."""
 import sys
 import base64
 import json

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ google-api-python-client==1.8.2
 google-auth==1.21.2
 google-cloud-error-reporting==0.33.0
 google-cloud-logging==1.14.0
+google-cloud-secret-manager==2.1.0
 clusterfuzz==0.0.1a0
 Jinja2==2.11.1
 numpy==1.18.1


### PR DESCRIPTION
Do this instead of recreating them every experiment.
This should replace a common source of silent issues in FuzzBench.