### PR TITLE
Add file bug benchmark

### DIFF
--- a/.github/workflows/build_and_test_run_fuzzer_benchmarks.py
+++ b/.github/workflows/build_and_test_run_fuzzer_benchmarks.py
@@ -55,6 +55,7 @@ STANDARD_BENCHMARKS = {
 }
 
 BUG_BENCHMARKS = {
+    'file_magic_fuzzer',
     'harfbuzz_hb-subset-fuzzer',
     'libhevc_hevc_dec_fuzzer',
     'matio_matio_fuzzer',

--- a/benchmarks/file_magic_fuzzer/Dockerfile
+++ b/benchmarks/file_magic_fuzzer/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+MAINTAINER mike.aizatsky@gmail.com
+RUN apt-get update && apt-get install -y make autoconf automake libtool shtool
+RUN git clone --depth 1 https://github.com/file/file.git
+WORKDIR file
+COPY build.sh magic_fuzzer.cc $SRC/

--- a/benchmarks/file_magic_fuzzer/Dockerfile
+++ b/benchmarks/file_magic_fuzzer/Dockerfile
@@ -16,7 +16,7 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER mike.aizatsky@gmail.com
-RUN apt-get update && apt-get install -y make autoconf automake libtool shtool
+RUN apt-get update && apt-get install -y make autoconf automake libtool shtool zlib1g-dev
 RUN git clone --depth 1 https://github.com/file/file.git
 WORKDIR file
 COPY build.sh magic_fuzzer.cc $SRC/

--- a/benchmarks/file_magic_fuzzer/README.md
+++ b/benchmarks/file_magic_fuzzer/README.md
@@ -1,0 +1,29 @@
+# file v5.35
+
+Modified the source `magic_fuzzer.cc` to exercise the functionality that exposes
+these four CVEs (use `magic_file` versus `magic_buffer`).  These bugs are related, 
+but not easily found within 24hr fuzzing. 
+
+- bug benchmark
+- 4 known bugs with POCs
+
+## CVE-2019-8904
+- [bug report](https://bugs.astron.com/view.php?id=62)
+- [POC input](https://bugs.astron.com/file_download.php?file_id=40&type=bug)
+- [patch](https://github.com/file/file/commit/94b7501f48e134e77716e7ebefc73d6bbe72ba55)
+  Avoid non-nul-terminated string read.
+
+## CVE-2019-8905
+- [bug report](https://bugs.astron.com/view.php?id=63)
+- [POC input](https://bugs.astron.com/file_download.php?file_id=41&type=bug)
+- [patch](https://github.com/file/file/commit/d65781527c8134a1202b2649695d48d5701ac60b)
+  limit size of file_printable.
+
+## CVE-2019-8906
+- [bug report](https://bugs.astron.com/view.php?id=64)
+- [POC input](https://bugs.astron.com/file_download.php?file_id=42&type=bug)
+
+## CVE-2019-8907
+- [bug report](https://bugs.astron.com/view.php?id=65)
+- [POC input](https://bugs.astron.com/file_download.php?file_id=43&type=bug)
+

--- a/benchmarks/file_magic_fuzzer/benchmark.yaml
+++ b/benchmarks/file_magic_fuzzer/benchmark.yaml
@@ -1,0 +1,13 @@
+commit: d1ff3af7a2c6b38bdbdde7af26b59e3c50a48fff
+commit_date: 2018-10-18 23:35:42+00:00
+fuzz_target: magic_fuzzer
+project: file
+type: bug
+unsupported_fuzzers:
+  - aflcc
+  - afl_qemu
+  - aflplusplus_qemu
+  - honggfuzz_qemu
+  - klee
+  - lafintel
+  - weizz_qemu

--- a/benchmarks/file_magic_fuzzer/benchmark.yaml
+++ b/benchmarks/file_magic_fuzzer/benchmark.yaml
@@ -5,9 +5,5 @@ project: file
 type: bug
 unsupported_fuzzers:
   - aflcc
-  - afl_qemu
-  - aflplusplus_qemu
-  - honggfuzz_qemu
   - klee
   - lafintel
-  - weizz_qemu

--- a/benchmarks/file_magic_fuzzer/build.sh
+++ b/benchmarks/file_magic_fuzzer/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+autoreconf -fi
+./configure --enable-static --disable-shared --disable-libseccomp
+make V=1 all
+
+$CXX $CXXFLAGS -std=c++11 -Isrc/ \
+     $SRC/magic_fuzzer.cc -o $OUT/magic_fuzzer \
+     -lFuzzingEngine ./src/.libs/libmagic.a
+
+cp ./magic/magic.mgc $OUT/
+
+
+# Force a empty seed.
+# zip -j $OUT/magic_fuzzer_seed_corpus.zip ./tests/*.testfile

--- a/benchmarks/file_magic_fuzzer/build.sh
+++ b/benchmarks/file_magic_fuzzer/build.sh
@@ -21,7 +21,7 @@ make V=1 all
 
 $CXX $CXXFLAGS -std=c++11 -Isrc/ \
      $SRC/magic_fuzzer.cc -o $OUT/magic_fuzzer \
-     -lFuzzingEngine ./src/.libs/libmagic.a
+     -lFuzzingEngine ./src/.libs/libmagic.a -lz
 
 cp ./magic/magic.mgc $OUT/
 

--- a/benchmarks/file_magic_fuzzer/magic_fuzzer.cc
+++ b/benchmarks/file_magic_fuzzer/magic_fuzzer.cc
@@ -1,0 +1,54 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <libgen.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+
+#include <magic.h>
+
+struct Environment {
+  Environment(std::string data_dir) {
+    magic = magic_open(MAGIC_NONE);
+    std::string magic_path = data_dir + "/magic";
+    if (magic_load(magic, magic_path.c_str())) {
+      fprintf(stderr, "error loading magic file: %s\n", magic_error(magic));
+      exit(1);
+    }
+  }
+
+  magic_t magic;
+};
+
+static Environment* env;
+
+extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
+  char* exe_path = (*argv)[0];
+  // dirname() can modify its argument.
+  char* exe_path_copy = strdup(exe_path);
+  char* dir = dirname(exe_path_copy);
+  env = new Environment(dir);
+  free(exe_path_copy);
+  return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  if (size < 1)
+    return 0;
+  magic_buffer(env->magic, data, size);
+  return 0;
+}

--- a/benchmarks/file_magic_fuzzer/magic_fuzzer.cc
+++ b/benchmarks/file_magic_fuzzer/magic_fuzzer.cc
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fcntl.h>
 #include <libgen.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <magic.h>
 
@@ -35,6 +39,9 @@ struct Environment {
 };
 
 static Environment* env;
+static char tmp_filename[32];
+static int fd;
+
 
 extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
   char* exe_path = (*argv)[0];
@@ -43,12 +50,34 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
   char* dir = dirname(exe_path_copy);
   env = new Environment(dir);
   free(exe_path_copy);
+
+  strncpy(tmp_filename, "/tmp/fuzz.file-XXXXXX", 31);
+  fd = mkstemp(tmp_filename);
+  if (fd < 0) {
+      printf("failed mkstemp, errno=%d\n", errno);
+      return -2;
+  }
   return 0;
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   if (size < 1)
     return 0;
-  magic_buffer(env->magic, data, size);
+
+  lseek(fd, 0, SEEK_SET);
+
+  if (unlikely(write (fd, data, size) != size)) {
+      printf("failed write, errno=%d\n", errno);
+      close(fd);
+      return -3;
+  }
+  if (unlikely(ftruncate(fd, size))) {
+     printf("failed truncate, errno=%d\n", errno);
+     close(fd);
+     return -3;
+  }
+  lseek(fd, 0, SEEK_SET);
+
+  magic_file(env->magic, tmp_filename);
   return 0;
 }

--- a/benchmarks/file_magic_fuzzer/magic_fuzzer.cc
+++ b/benchmarks/file_magic_fuzzer/magic_fuzzer.cc
@@ -25,6 +25,9 @@
 
 #include <magic.h>
 
+#define likely(x)       __builtin_expect(!!(x), 1)
+#define unlikely(x)     __builtin_expect(!!(x), 0)
+
 struct Environment {
   Environment(std::string data_dir) {
     magic = magic_open(MAGIC_NONE);


### PR DESCRIPTION
Adding file v5.35 as a bug benchmark.  Granted, file may not be a critical piece of open source software, but these four bugs should be the appropriate level of difficulty for Fuzzbench 24hr experiments.  Unfortunately, I needed to modify the fuzzing harness to expose the problematic functions which also makes the benchmark execute more slowly since it needs to write the buffer to a file each iteration.  
I'm intentionally disabling the provided seed corpus as fuzzers will make progress with an empty seed.