### PR TITLE
Remove base-builder hardcode from benchmarks.

### DIFF
--- a/benchmarks/bloaty_fuzz_target/Dockerfile
+++ b/benchmarks/bloaty_fuzz_target/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:12125f1ecb9e4905a19c35700a3402c1eba43c82ea2d227f01c28833d75e3574
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y cmake ninja-build g++
 RUN git clone --depth 1 https://github.com/google/bloaty.git bloaty
 WORKDIR bloaty

--- a/benchmarks/curl_curl_fuzzer_http/Dockerfile
+++ b/benchmarks/curl_curl_fuzzer_http/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:aea783f76a46298085620e73d9943fad84c912e38b8a1a482177ae84360152ec
+FROM gcr.io/oss-fuzz-base/base-builder
 
 # Curl will be checked out to the commit hash specified in benchmark.yaml.
 RUN git clone --depth 1 https://github.com/curl/curl.git /src/curl

--- a/benchmarks/jsoncpp_jsoncpp_fuzzer/Dockerfile
+++ b/benchmarks/jsoncpp_jsoncpp_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:8e56964113db5e06130b8bc5b94becb5d90a88e90c9b593f2ea24f33b0a467d0
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y build-essential make curl wget
 
 # Install latest cmake.

--- a/benchmarks/libhevc_hevc_dec_fuzzer/Dockerfile
+++ b/benchmarks/libhevc_hevc_dec_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:270e52ac2c38de7d7d678ab488252c81652a161b378fc9fc9f3df6c79e475afa
+FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER harish.mahendrakar@ittiam.com
 RUN apt-get update && apt-get install -y wget cmake
 RUN git clone https://android.googlesource.com/platform/external/libhevc

--- a/benchmarks/libpcap_fuzz_both/Dockerfile
+++ b/benchmarks/libpcap_fuzz_both/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:c18f9615c9824b61ce982e0bac4b157b2eff5b9240cc6310a4815a826bb804e3
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make cmake flex bison
 RUN git clone --depth 1 https://github.com/the-tcpdump-group/libpcap.git libpcap
 # for corpus as wireshark

--- a/benchmarks/libxslt_xpath/Dockerfile
+++ b/benchmarks/libxslt_xpath/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:b9f4c6bf872a08e67cc36fdd9431d4fcac45d575830facb30f5271b26d2e2a28
+FROM gcr.io/oss-fuzz-base/base-builder
 
 # Note that we don't use the system libxml2 but a custom instrumented build.
 # libgcrypt is required for the crypto extensions of libexslt.

--- a/benchmarks/mbedtls_fuzz_dtlsclient/Dockerfile
+++ b/benchmarks/mbedtls_fuzz_dtlsclient/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:fee307a212b2f77f208b209e2335e4a5e640f55dbe6dbe76a3e50475f9160eca
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make cmake
 RUN git clone --recursive --depth 1 https://github.com/ARMmbed/mbedtls.git mbedtls
 RUN git clone --depth 1 https://github.com/google/boringssl.git boringssl

--- a/benchmarks/openh264_decoder_fuzzer/Dockerfile
+++ b/benchmarks/openh264_decoder_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:d321113ffaca3cd8dcec0ceff2c594c01b6a860971d02058da7d42c0c82e3d23
+FROM gcr.io/oss-fuzz-base/base-builder
 MAINTAINER twsmith@mozilla.com
 RUN dpkg --add-architecture i386 && \
     apt-get update && \

--- a/benchmarks/openssl_x509/Dockerfile
+++ b/benchmarks/openssl_x509/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:02b6f53c6220b84cfb671dfc65bb8f1e224e8a5c56940e358f0fbcbd74b44734
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/openssl/openssl.git
 WORKDIR openssl

--- a/benchmarks/php_php-fuzz-execute/Dockerfile
+++ b/benchmarks/php_php-fuzz-execute/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:ccb5bcb44c8d2027a756947ae24cb48f7ce647897f57bbec50b4bcaff1367e44
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y autoconf automake libtool bison re2c pkg-config
 RUN git clone --depth 1 --branch master https://github.com/php/php-src.git php-src

--- a/benchmarks/php_php-fuzz-parser-2020-07-25/Dockerfile
+++ b/benchmarks/php_php-fuzz-parser-2020-07-25/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:2ce1013051aeea4f96886a076cdd14f27dffca129b6baf2ed5f45ddaa02e580c
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y autoconf automake libtool bison re2c pkg-config
 RUN git clone --depth 1 --branch master https://github.com/php/php-src.git php-src

--- a/benchmarks/php_php-fuzz-parser/Dockerfile
+++ b/benchmarks/php_php-fuzz-parser/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:59fdabfe72127e145d8a387b68e883121bddd7cf391d600edb97ecbdacbc9ff8
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && \
     apt-get install -y autoconf automake libtool bison re2c pkg-config
 

--- a/benchmarks/sqlite3_ossfuzz/Dockerfile
+++ b/benchmarks/sqlite3_ossfuzz/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:32d87afee8e52e1550905b43d5e8583b33f37c2600446b6b9efeb14bfc25c71f
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool curl tcl zlib1g-dev
 
 RUN mkdir $SRC/sqlite3 && \

--- a/benchmarks/stb_stbi_read_fuzzer/Dockerfile
+++ b/benchmarks/stb_stbi_read_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:12b7b470479f04fd1b6a124291486f555169a5496a355ee75cf333c117d4bb92
+FROM gcr.io/oss-fuzz-base/base-builder
 
 RUN apt-get update && \
     apt-get install -y wget tar

--- a/benchmarks/systemd_fuzz-link-parser/Dockerfile
+++ b/benchmarks/systemd_fuzz-link-parser/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:02b6f53c6220b84cfb671dfc65bb8f1e224e8a5c56940e358f0fbcbd74b44734
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update &&\
     apt-get install -y gperf m4 gettext python3-pip \
         libcap-dev libmount-dev libkmod-dev \

--- a/benchmarks/zlib_zlib_uncompress_fuzzer/Dockerfile
+++ b/benchmarks/zlib_zlib_uncompress_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:84df55d087d82b65e3a594c01248d59f49d513d4d7362014b417e640317b11f4
+FROM gcr.io/oss-fuzz-base/base-builder
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 -b develop https://github.com/madler/zlib.git
 WORKDIR zlib

--- a/fuzzers/klee/builder.Dockerfile
+++ b/fuzzers/klee/builder.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG parent_image=gcr.io/fuzzbench/base-builder
+ARG parent_image
 FROM $parent_image
 
 # Install Clang/LLVM 6.0.
@@ -24,8 +24,7 @@ RUN apt-get update -y && \
 # Install KLEE dependencies.
 RUN apt-get install -y \
     cmake-data build-essential curl libcap-dev \
-    git cmake libncurses5-dev python-minimal \
-    python-pip unzip libtcmalloc-minimal4 \
+    git cmake libncurses5-dev unzip libtcmalloc-minimal4 \
     libgoogle-perftools-dev bison flex libboost-all-dev \
     perl zlib1g-dev libsqlite3-dev doxygen
 
@@ -55,7 +54,6 @@ RUN git clone https://github.com/klee/klee-uclibc.git /klee-uclibc && \
     ./configure --make-llvm-lib --with-llvm-config=`which llvm-config-6.0` && \
     make -j`nproc` && make install
 
-
 # Install KLEE. Use my personal repo containing seed conversion scripts for now.
 # TODO: Include seed conversion scripts in fuzzbench repo.
 # Note: don't use the 'debug' branch because it has checks for non-initialized values
@@ -67,9 +65,7 @@ RUN git clone https://github.com/lmrs2/klee.git /klee && \
     wget -O tools/ktest-tool/ktest-tool https://raw.githubusercontent.com/lmrs2/klee/debug/tools/ktest-tool/ktest-tool
 
 # The libcxx build script in the KLEE repo depends on wllvm:
-# We'll upgrade pip first to avoid a build error with the old version of pip.
-RUN pip install --upgrade pip
-RUN pip install wllvm
+RUN pip3 install wllvm
 
 # Before building KLEE, build libcxx.
 RUN cd /klee && \
@@ -105,4 +101,3 @@ RUN $CXX -stdlib=libc++ -std=c++11 -O2 -c /klee_driver.cpp -o /klee_driver.o && 
     ar r /libAFL.a /klee_driver.o && \
     $LLVM_CC_NAME -O2 -c -fPIC /klee_mock.c -o /klee_mock.o && \
     $LLVM_CC_NAME -shared -o /libKleeMock.so /klee_mock.o
-


### PR DESCRIPTION
Fixes https://github.com/google/fuzzbench/issues/1085