### PR TITLE
Export detailed coverage data (functions & segments) as State files (json)

### DIFF
--- a/experiment/measurer/coverage_utils.py
+++ b/experiment/measurer/coverage_utils.py
@@ -16,6 +16,8 @@
 import os
 import json
 
+import pandas
+
 from common import experiment_path as exp_path
 from common import experiment_utils as exp_utils
 from common import new_process
@@ -293,3 +295,51 @@ def extract_covered_regions_from_summary_json(summary_json_file):
     except Exception:  # pylint: disable=broad-except
         logger.error('Coverage summary json file defective or missing.')
     return covered_regions
+
+
+def extract_segments_and_functions_from_summary_json(
+        # pylint: disable=too-many-arguments
+        cov_summary_file,
+        benchmark,
+        fuzzer,
+        trial_num,
+        this_time,
+        segment_coverage,
+        function_coverage,
+        recorded_segments):
+    """Returns a tuple of data frames with detailed segment and function
+    coverage information given a trial-specific coverage summary json file."""
+
+    try:
+        coverage_info = get_coverage_infomation(cov_summary_file)
+        for function_data in coverage_info['data'][0]['functions']:
+            entry = pandas.Series([
+                benchmark, fuzzer, trial_num, function_data['name'],
+                function_data['count'], this_time
+            ],
+                                  index=function_coverage.columns)
+            function_coverage = function_coverage.append(entry,
+                                                         ignore_index=True)
+
+        for file in coverage_info['data'][0]['files']:
+            for segment in file['segments']:
+                if [segment[0], segment[1]] not in recorded_segments:
+                    if segment[2] != 0:
+                        entry = pandas.Series(
+                            [
+                                benchmark,
+                                fuzzer,
+                                trial_num,
+                                file['filename'],
+                                segment[0],  # Segment line.
+                                segment[1],  # Segment column.
+                                this_time
+                            ],
+                            index=segment_coverage.columns)
+                        segment_coverage = segment_coverage.append(
+                            entry, ignore_index=True)
+
+    except (ValueError, KeyError, IndexError):
+        logger.error('Failed to extract trial-specific segment and function '
+                     'information from coverage summary.')
+    return segment_coverage, function_coverage

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -27,6 +27,7 @@ import tempfile
 import time
 from typing import List, Set
 import queue
+import pandas
 
 from sqlalchemy import func
 from sqlalchemy import orm
@@ -396,7 +397,53 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
             self.logger.error(
                 'Coverage profdata generation failed for cycle: %d.', cycle)
 
-    def generate_coverage_information(self, cycle: int):
+    def update_coverage_state(self, cycle, this_time):
+        """Update the previous trial-specific coverage data with coverage
+        information from this cycle."""
+
+        # Create function data frame and load previous segment data frame.
+        function_coverage_state_file = measure_worker.StateFile(
+            measure_worker.FUNCTION_COVERAGE_STATE_NAME, self.state_dir, cycle)
+        function_coverage = pandas.DataFrame(columns=[
+            'benchmark', 'fuzzer', 'trial', 'time', 'function', 'hits'
+        ])
+
+        segment_coverage_state_file = measure_worker.StateFile(
+            measure_worker.SEGMENT_COVERAGE_STATE_NAME, self.state_dir, cycle)
+
+        # Using Try and Except since "get_previous()" returns [] if there is no
+        # previous data to return which raises a ValueError while trying to load
+        # it onto a data frame with orient='table'
+        try:
+            segment_coverage = pandas.DataFrame.from_dict(
+                segment_coverage_state_file.get_previous(cycle_dependent=False),
+                orient='table')
+        except ValueError:
+            segment_coverage = pandas.DataFrame(columns=[
+                'benchmark', 'fuzzer', 'trial', 'time', 'file', 'line', 'column'
+            ])
+
+        # Store all the observed [line, column] (segments) in a list to help us
+        # determine redundant segment entries while adding entries for this
+        # cycle. (Reduces memory consumption)
+        recorded_segments = [
+            list(x) for x in zip(segment_coverage['line'].to_list(),
+                                 segment_coverage['column'].to_list())
+        ]
+
+        segment_coverage, function_coverage = \
+            coverage_utils.extract_segments_and_functions_from_summary_json(
+                self.cov_summary_file, self.benchmark, self.fuzzer,
+                self.trial_num, this_time, segment_coverage, function_coverage,
+                recorded_segments)
+
+        # Set coverage information state accordingly
+        function_coverage_state_file.set_current(
+            function_coverage.to_json(orient='table'))
+        segment_coverage_state_file.set_current(
+            segment_coverage.to_json(orient='table'), cycle_dependent=False)
+
+    def generate_coverage_information(self, cycle: int, time_stamp):
         """Generate the .profdata file and then transform it into
         json summary."""
         if not self.get_profraw_files():
@@ -412,6 +459,7 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
             self.logger.error('Empty profdata file found for cycle: %d.', cycle)
             return
         self.generate_summary(cycle)
+        self.update_coverage_state(cycle, time_stamp)
 
     def is_cycle_unchanged(self, cycle: int) -> bool:
         """Returns True if |cycle| is unchanged according to the
@@ -641,7 +689,7 @@ def measure_snapshot_coverage(  # pylint: disable=too-many-locals
     snapshot_measurer.run_cov_new_units()
 
     # Generate profdata and transform it into json form.
-    snapshot_measurer.generate_coverage_information(cycle)
+    snapshot_measurer.generate_coverage_information(cycle, this_time)
 
     # Run crashes again, parse stacktraces and generate crash signatures.
     crashes = snapshot_measurer.process_crashes(cycle)

--- a/experiment/measurer/measure_worker.py
+++ b/experiment/measurer/measure_worker.py
@@ -27,6 +27,8 @@ from common import filesystem
 from common import utils
 
 MEASURED_FILES_STATE_NAME = 'measured-files'
+FUNCTION_COVERAGE_STATE_NAME = 'function-coverage'
+SEGMENT_COVERAGE_STATE_NAME = 'segment-coverage'
 
 logger = logs.Logger('measure_worker')  # pylint: disable=invalid-name
 
@@ -79,14 +81,15 @@ class StateFile:
         state_file_path = os.path.join(self.state_dir, state_file_name)
         return exp_path.filestore(pathlib.Path(state_file_path))
 
-    def _get_previous_cycle_state(self) -> list:
+    def _get_previous_cycle_state(self, cycle_dependent=True) -> list:
         """Returns the state from the previous cycle. Returns [] if |self.cycle|
         is 1."""
         if self.cycle == 1:
             return []
 
         previous_state_file_bucket_path = (
-            self._get_bucket_cycle_state_file_path(self.cycle - 1))
+            self._get_bucket_cycle_state_file_path((
+                self.cycle - 1) if cycle_dependent else 0))
 
         result = filestore_utils.cat(previous_state_file_bucket_path,
                                      expect_zero=False)
@@ -95,17 +98,17 @@ class StateFile:
 
         return json.loads(result.output)
 
-    def get_previous(self):
+    def get_previous(self, cycle_dependent=True):
         """Returns the previous state."""
         if self._prev_state is None:
-            self._prev_state = self._get_previous_cycle_state()
+            self._prev_state = self._get_previous_cycle_state(cycle_dependent)
 
         return self._prev_state
 
-    def set_current(self, state):
+    def set_current(self, state, cycle_dependent=True):
         """Sets the state for this cycle in the bucket."""
         state_file_bucket_path = self._get_bucket_cycle_state_file_path(
-            self.cycle)
+            self.cycle if cycle_dependent else 0)
         with tempfile.NamedTemporaryFile(mode='w') as temp_file:
             temp_file.write(json.dumps(state))
             temp_file.flush()

--- a/experiment/measurer/test_coverage_utils.py
+++ b/experiment/measurer/test_coverage_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for coverage_utils.py"""
 import os
+import pandas
 
 from experiment.measurer import coverage_utils
 
@@ -32,3 +33,38 @@ def test_extract_covered_regions_from_summary_json(fs):
     covered_regions = coverage_utils.extract_covered_regions_from_summary_json(
         summary_json_file)
     assert len(covered_regions) == 15
+
+
+def test_extract_segments_and_functions_from_summary_json(fs):
+    """Tests that segments and functions from summary json are properly
+    extracted and test for integrity of data recorded for segment and function
+    coverage."""
+
+    # Expected Constants.
+    num_function_in_cov_summary = 3
+    num_unrecorded_segment_in_cov_summary = 15
+    benchmark = 'benchmark_1'
+    fuzzer = 'fuzzer_1'
+    timestamp = 900
+    trial_num = 2
+
+    summary_json_file = get_test_data_path('cov_summary.json')
+    fs.add_real_file(summary_json_file, read_only=False)
+
+    segment_coverage = pandas.DataFrame(columns=[
+        'benchmark', 'fuzzer', 'trial', 'time', 'file', 'line', 'column'
+    ])
+
+    function_coverage = pandas.DataFrame(
+        columns=['benchmark', 'fuzzer', 'trial', 'time', 'function', 'hits'])
+
+    recorded_segments = [[1, 16]]
+
+    segment_coverage, function_coverage = (
+        coverage_utils.extract_segments_and_functions_from_summary_json(
+            summary_json_file, benchmark, fuzzer, trial_num, timestamp,
+            segment_coverage, function_coverage, recorded_segments))
+
+    # Assert length of resulting data frame is as expected.
+    assert len(segment_coverage) == num_unrecorded_segment_in_cov_summary
+    assert len(function_coverage) == num_function_in_cov_summary


### PR DESCRIPTION
This PR is a follows #987 as discussed. This patch is about exporting detailed coverage data as state files in each cycle for every |benchmark, fuzzer, trial| combination.  


### DESCRIPTION
So the idea is to persist the segment and function coverage data. For segments, we try to overwrite the same JSON state file which also serves as a blacklist of segments already discovered in the next cycle. For functions, since we need to record functions observed in each cycle regardless of the fact that it was previously discovered or not, so, we simply export the function coverage data as a state file in each cycle (seperate file for each cycle, not overwritten). 


### DATA POINTS RECORDED
- **For segment coverage** -  `Benchmark name`, `Fuzzer name`, `Trial`, `Timestamp`, `SourceFile`, `segment Line` & `segment Column`

- **For Function coverage** -  `Benchmark name`, `Fuzzer name`, `Trial`, `Timestamp`, `Function names` and `Hits`

### JSON STRUCTURE OF THE DATA BEING STORED
The coverage data being stored as JSON (state file) follows the structure below (pandas DataFrame exported as JSON in table orientation):

```
{
    "schema": {
        "fields": [
            {
                "name": "index",
                "type": "string"
            },
            {
                "name": "col 1",
                "type": "numeric"
            },
            {
                "name": "col 2",
                "type": "string"
            }
        ],
        "primaryKey": [
            "index"
        ],
        "pandas_version": "0.20.0"
    },
    "data": [
        {
            "index": "row 1",
            "col 1": "a",
            "col 2": "b"
        },
        {
            "index": "row 2",
            "col 1": "c",
            "col 2": "d"
        }
    ]
} 
``` 


### WORKFLOW
The basic workflow of this PR is mentioned below:

1. `load the previous state file for segment coverage`
2. `extract segments and function coverage data for the current cycle`  
3. `add the newly discovered segments to the previous state` 
4.  `set current state for functions (new file) and segments (overwrite previous file)`

 
###  CHANGES TO EXISTING CODE
A simple parameter 'cycle_dependent' has been added to the `get_previous()` and `set_current()` methods to determine wether to save the state as a new state file or to overwrite an existing state file.


It would be a bit hard to give the size estimate of the generated files at the moment but maybe I would be able to get back to you on this once the GCS API is exposed. Please feel free to suggest any possible improvements and other json formats if that makes things easier :)