### PR TITLE
Fix issue with query calls not properly scoped.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -375,7 +375,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=experiment_df.fuzzer
+generated-members=experiment_df.fuzzer,session
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -55,8 +55,9 @@ def create_work_subdirs(subdirs: List[str]):
 def _initialize_experiment_in_db(experiment_config: dict):
     """Initializes |experiment| in the database by creating the experiment
     entity."""
-    experiment_exists = db_utils.query(models.Experiment).filter(
-        models.Experiment.name == experiment_config['experiment']).first()
+    with db_utils.session_scope() as session:
+        experiment_exists = session.query(models.Experiment).filter(
+            models.Experiment.name == experiment_config['experiment']).first()
     if experiment_exists:
         raise Exception('Experiment already exists in database.')
 
@@ -73,8 +74,9 @@ def _initialize_experiment_in_db(experiment_config: dict):
 
 def _record_experiment_time_ended(experiment_name: str):
     """Record |experiment| end time in the database."""
-    experiment = db_utils.query(models.Experiment).filter(
-        models.Experiment.name == experiment_name).one()
+    with db_utils.session_scope() as session:
+        experiment = session.query(models.Experiment).filter(
+            models.Experiment.name == experiment_name).one()
     experiment.time_ended = datetime.datetime.utcnow()
     db_utils.add_all([experiment])
 

--- a/experiment/measurer/coverage_utils.py
+++ b/experiment/measurer/coverage_utils.py
@@ -203,13 +203,14 @@ def get_coverage_binary(benchmark: str) -> str:
 
 def get_trial_ids(experiment: str, fuzzer: str, benchmark: str):
     """Gets ids of all finished trials for a pair of fuzzer and benchmark."""
-    trial_ids = [
-        trial_id_tuple[0]
-        for trial_id_tuple in db_utils.query(models.Trial.id).filter(
-            models.Trial.experiment == experiment, models.Trial.fuzzer ==
-            fuzzer, models.Trial.benchmark == benchmark,
-            ~models.Trial.preempted)
-    ]
+    with db_utils.session_scope() as session:
+        trial_ids = [
+            trial_id_tuple[0]
+            for trial_id_tuple in session.query(models.Trial.id).filter(
+                models.Trial.experiment == experiment, models.Trial.fuzzer ==
+                fuzzer, models.Trial.benchmark == benchmark,
+                ~models.Trial.preempted)
+        ]
     return trial_ids
 
 

--- a/experiment/test_dispatcher.py
+++ b/experiment/test_dispatcher.py
@@ -74,13 +74,15 @@ def test_initialize_experiment_in_db(dispatcher_experiment):
     dispatcher._initialize_experiment_in_db(dispatcher_experiment.config)
     dispatcher._initialize_trials_in_db(trials)
 
-    db_experiments = db_utils.query(models.Experiment).all()
-    assert len(db_experiments) == 1
-    db_experiment = db_experiments[0]
-    assert db_experiment.name == os.environ['EXPERIMENT']
-    trials = db_utils.query(models.Trial).all()
-    fuzzer_and_benchmarks = [(trial.benchmark, trial.fuzzer) for trial in trials
-                            ]
+    with db_utils.session_scope() as session:
+        db_experiments = session.query(models.Experiment).all()
+        assert len(db_experiments) == 1
+        db_experiment = db_experiments[0]
+        assert db_experiment.name == os.environ['EXPERIMENT']
+        trials = session.query(models.Trial).all()
+        fuzzer_and_benchmarks = [
+            (trial.benchmark, trial.fuzzer) for trial in trials
+        ]
     assert fuzzer_and_benchmarks == ([('benchmark-1', 'fuzzer-a'),
                                       ('benchmark-1', 'fuzzer-b')] *
                                      4) + [('benchmark-2', 'fuzzer-a'),

--- a/service/automatic_run_experiment.py
+++ b/service/automatic_run_experiment.py
@@ -184,8 +184,9 @@ def run_requested_experiment(dry_run):
     requested_experiment = None
     for experiment_config in reversed(requested_experiments):
         experiment_name = _get_experiment_name(experiment_config)
-        is_new_experiment = db_utils.query(models.Experiment).filter(
-            models.Experiment.name == experiment_name).first() is None
+        with db_utils.session_scope() as session:
+            is_new_experiment = session.query(models.Experiment).filter(
+                models.Experiment.name == experiment_name).first() is None
         if is_new_experiment:
             requested_experiment = experiment_config
             break

--- a/src_analysis/experiment_changes.py
+++ b/src_analysis/experiment_changes.py
@@ -29,9 +29,10 @@ def get_fuzzers_changed_since_last():
 
     # Loop over experiments since some may have hashes that are not in the
     # current branch.
-    experiments = list(
-        db_utils.query(models.Experiment).order_by(
-            models.Experiment.time_created.desc()))
+    with db_utils.session_scope() as session:
+        experiments = list(
+            session.query(models.Experiment).order_by(
+                models.Experiment.time_created.desc()))
     if not experiments:
         raise Exception('No experiments found. Cannot find changed fuzzers.')
 


### PR DESCRIPTION
Query calls can be followed by join/filter sub-calls which were
not caught for exceptions and hence session rollback did not
occur. This caught furthur calls to exception out on
"Can't reconnect until invalid transaction is rolled back"