### PR TITLE
Update google-* libs due to version conflicts.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 alembic==1.4.0
-google-api-python-client==1.8.2
-google-auth==1.24.0
-google-cloud-error-reporting==0.33.0
-google-cloud-logging==1.14.0
-google-cloud-secret-manager==2.1.0
+google-api-python-client==2.5.0
+google-auth==1.30.1
+google-cloud-error-reporting==1.1.2
+google-cloud-logging==1.15.1
+google-cloud-secret-manager==2.4.0
 clusterfuzz==0.0.1a0
 Jinja2==2.11.3
 numpy==1.18.1


### PR DESCRIPTION
See
https://stackoverflow.com/questions/67652313/python-app-hosted-on-app-engine-is-not-able-to-connect-with-firestore-where-as-w
and issue pointed in
https://github.com/google/fuzzbench/pull/1155#issuecomment-848422635