### PR TITLE
symcc-aflplusplus: add new fuzzer. 

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -63,6 +63,7 @@ jobs:
           - aflplusplus_pcguard_ctx_params
           # Concolic execution
           - symcc_afl
+          - symcc_aflplusplus
           - aflplusplus_x
           - aflplusplus_x_c1
           - aflplusplus_x_c1a

--- a/benchmarks/ffmpeg_ffmpeg_demuxer_fuzzer/benchmark.yaml
+++ b/benchmarks/ffmpeg_ffmpeg_demuxer_fuzzer/benchmark.yaml
@@ -15,3 +15,4 @@ unsupported_fuzzers:
   - aflplusplus_qemu_inmem
   - symcc_afl
   - symcc_afl_single
+  - symcc_aflplusplus

--- a/benchmarks/lcms-2017-03-21/benchmark.yaml
+++ b/benchmarks/lcms-2017-03-21/benchmark.yaml
@@ -17,3 +17,4 @@ project: lcms
 unsupported_fuzzers:
   - symcc_afl
   - symcc_afl_single
+  - symcc_aflplusplus

--- a/benchmarks/libpcap_fuzz_both/benchmark.yaml
+++ b/benchmarks/libpcap_fuzz_both/benchmark.yaml
@@ -20,3 +20,4 @@ unsupported_fuzzers:
   - klee
   - symcc_afl
   - symcc_afl_single
+  - symcc_aflplusplus

--- a/benchmarks/ndpi_fuzz_ndpi_reader/benchmark.yaml
+++ b/benchmarks/ndpi_fuzz_ndpi_reader/benchmark.yaml
@@ -14,3 +14,4 @@ unsupported_fuzzers:
   - eclipser
   - symcc_afl
   - symcc_afl_single
+  - symcc_aflplusplus

--- a/benchmarks/njs_njs_process_script_fuzzer/benchmark.yaml
+++ b/benchmarks/njs_njs_process_script_fuzzer/benchmark.yaml
@@ -13,3 +13,4 @@ unsupported_fuzzers:
   - lafintel
   - symcc_afl
   - symcc_afl_single
+  - symcc_aflplusplus

--- a/benchmarks/php_php-fuzz-execute/benchmark.yaml
+++ b/benchmarks/php_php-fuzz-execute/benchmark.yaml
@@ -23,3 +23,4 @@ unsupported_fuzzers:
   - aflplusplus_pcguard_ctx_params
   - symcc_afl
   - symcc_afl_single
+  - symcc_aflplusplus

--- a/benchmarks/php_php-fuzz-parser-2020-07-25/benchmark.yaml
+++ b/benchmarks/php_php-fuzz-parser-2020-07-25/benchmark.yaml
@@ -23,3 +23,4 @@ unsupported_fuzzers:
   - aflplusplus_pcguard_ctx_params
   - symcc_afl
   - symcc_afl_single
+  - symcc_aflplusplus

--- a/benchmarks/php_php-fuzz-parser/benchmark.yaml
+++ b/benchmarks/php_php-fuzz-parser/benchmark.yaml
@@ -31,3 +31,4 @@ unsupported_fuzzers:
   - aflplusplus_pcguard_ctx_params
   - symcc_afl
   - symcc_afl_single
+  - symcc_aflplusplus

--- a/benchmarks/sqlite3_ossfuzz/benchmark.yaml
+++ b/benchmarks/sqlite3_ossfuzz/benchmark.yaml
@@ -19,3 +19,4 @@ project: sqlite3
 unsupported_fuzzers:
   - symcc_afl
   - symcc_afl_single
+  - symcc_aflplusplus

--- a/fuzzers/symcc_afl/builder.Dockerfile
+++ b/fuzzers/symcc_afl/builder.Dockerfile
@@ -48,7 +48,7 @@ ENV CXXFLAGS=""
 RUN cd / && \
     git clone https://github.com/AdaLogics/adacc symcc && \
     cd symcc && \
-    git checkout 40c819654c77da421d7696f4c4939040f4414e95 && \
+    git checkout edda79dcb830c95ba6d303e47c698839313ef506 && \
     cd ./runtime/qsym_backend && \
     git clone https://github.com/adalogics/qsym && \
     cd qsym && \

--- a/fuzzers/symcc_afl_single/builder.Dockerfile
+++ b/fuzzers/symcc_afl_single/builder.Dockerfile
@@ -48,7 +48,7 @@ ENV CXXFLAGS=""
 RUN cd / && \
     git clone https://github.com/AdaLogics/adacc symcc && \
     cd symcc && \
-    git checkout 40c819654c77da421d7696f4c4939040f4414e95 && \
+    git checkout edda79dcb830c95ba6d303e47c698839313ef506 && \
     cd ./runtime/qsym_backend && \
     git clone https://github.com/adalogics/qsym && \
     cd qsym && \

--- a/fuzzers/symcc_aflplusplus/builder.Dockerfile
+++ b/fuzzers/symcc_aflplusplus/builder.Dockerfile
@@ -51,7 +51,7 @@ ENV CXXFLAGS=""
 RUN cd / && \
     git clone https://github.com/AdaLogics/adacc symcc && \
     cd symcc && \
-    git checkout 40c819654c77da421d7696f4c4939040f4414e95 && \
+    git checkout edda79dcb830c95ba6d303e47c698839313ef506 && \
     cd ./runtime/qsym_backend && \
     git clone https://github.com/adalogics/qsym && \
     cd qsym && \

--- a/fuzzers/symcc_aflplusplus/builder.Dockerfile
+++ b/fuzzers/symcc_aflplusplus/builder.Dockerfile
@@ -1,0 +1,87 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Install libstdc++ to use llvm_mode.
+RUN apt-get update && \
+    apt-get install -y wget libstdc++-5-dev libtool-bin automake flex bison \
+                       libglib2.0-dev libpixman-1-dev python3-setuptools unzip \
+                       apt-utils apt-transport-https ca-certificates
+
+# Download and compile afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
+    cd /afl && \
+    git checkout bb45398d0bbad0b86e311fa6effc286206ecc611
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && unset CFLAGS && unset CXXFLAGS && \
+    export CC=clang && export AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && make install && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /
+
+# Install the packages we need.
+RUN apt-get install -y ninja-build flex bison python zlib1g-dev cargo 
+
+# Install Z3 from binary
+RUN wget -qO /tmp/z3x64.zip https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-ubuntu-16.04.zip && \
+     unzip -jd /usr/include /tmp/z3x64.zip "*/include/*.h" && \
+     unzip -jd /usr/lib /tmp/z3x64.zip "*/bin/libz3.so" && \
+     rm -f /tmp/*.zip && \
+     ldconfig
+
+ENV CFLAGS=""
+ENV CXXFLAGS=""
+
+# Get and install symcc.
+RUN cd / && \
+    git clone https://github.com/AdaLogics/adacc symcc && \
+    cd symcc && \
+    git checkout 40c819654c77da421d7696f4c4939040f4414e95 && \
+    cd ./runtime/qsym_backend && \
+    git clone https://github.com/adalogics/qsym && \
+    cd qsym && \
+    git checkout adalogics && \
+    cd /symcc && \
+    mkdir build && \
+    cd build && \
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DQSYM_BACKEND=ON \
+          -DZ3_TRUST_SYSTEM_VERSION=ON ../ && \
+    ninja -j 3 && \
+    cd ../examples && \
+    export SYMCC_PC=1 && \
+    ../build/symcc -c ./libfuzz-harness-proxy.c -o /libfuzzer-harness.o && \
+    cd ../ && echo "[+] Installing cargo now 4" && \
+    cargo install --path util/symcc_fuzzing_helper
+
+# Build libcxx with the SymCC compiler so we can instrument 
+# C++ code.
+RUN git clone -b llvmorg-12.0.0 --depth 1 https://github.com/llvm/llvm-project.git /llvm_source  && \
+    mkdir /libcxx_native_install && mkdir /libcxx_native_build && \
+    cd /libcxx_native_install \
+    && export SYMCC_REGULAR_LIBCXX="" && \
+    cmake /llvm_source/llvm                                     \
+      -G Ninja  -DLLVM_ENABLE_PROJECTS="libcxx;libcxxabi"       \
+      -DLLVM_DISTRIBUTION_COMPONENTS="cxx;cxxabi;cxx-headers"   \
+      -DLLVM_TARGETS_TO_BUILD="X86" -DCMAKE_BUILD_TYPE=Release  \
+      -DCMAKE_C_COMPILER=/symcc/build/symcc                     \
+      -DCMAKE_CXX_COMPILER=/symcc/build/sym++                   \
+      -DHAVE_POSIX_REGEX=1     \
+      -DCMAKE_INSTALL_PREFIX="/libcxx_native_build" \
+      -DHAVE_STEADY_CLOCK=1 && \
+    ninja distribution && \
+    ninja install-distribution 

--- a/fuzzers/symcc_aflplusplus/fuzzer.py
+++ b/fuzzers/symcc_aflplusplus/fuzzer.py
@@ -1,0 +1,131 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+''' Uses the SymCC-AFL hybrid from SymCC. '''
+
+import os
+import time
+import shutil
+import threading
+import subprocess
+
+from fuzzers import utils
+from fuzzers.afl import fuzzer as afl_fuzzer
+from fuzzers.aflplusplus import fuzzer as aflplusplus_fuzzer
+
+
+def get_symcc_build_dir(target_directory):
+    """Return path to uninstrumented target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
+
+
+def build():
+    """Build an AFL version and SymCC version of the benchmark"""
+    print("Step 1: Building with AFL")
+    build_directory = os.environ['OUT']
+
+    # Save the environment for use in SymCC
+    new_env = os.environ.copy()
+
+    # First build with AFL.
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+    with utils.restore_directory(src), utils.restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        aflplusplus_fuzzer.build()
+
+    print("Step 2: Completed AFL build")
+    # Copy over AFL artifacts needed by SymCC.
+    shutil.copy("/afl/afl-fuzz", build_directory)
+    shutil.copy("/afl/afl-showmap", build_directory)
+
+    # Build the SymCC-instrumented target.
+    print("Step 3: Building the benchmark with SymCC")
+    symcc_build_dir = get_symcc_build_dir(os.environ['OUT'])
+    os.mkdir(symcc_build_dir)
+
+    # Set flags to ensure compilation with SymCC.
+    new_env['CC'] = "/symcc/build/symcc"
+    new_env['CXX'] = "/symcc/build/sym++"
+    new_env['CXXFLAGS'] = new_env['CXXFLAGS'].replace("-stlib=libc++", "")
+    new_env['FUZZER_LIB'] = '/libfuzzer-harness.o'
+    new_env['OUT'] = symcc_build_dir
+
+    new_env['CXXFLAGS'] += " -fno-sanitize=all "
+    new_env['CFLAGS'] += " -fno-sanitize=all "
+
+    # Setting this environment variable instructs SymCC to use the
+    # libcxx library compiled with SymCC instrumentation.
+    new_env['SYMCC_LIBCXX_PATH'] = "/libcxx_native_build"
+
+    # Instructs SymCC to consider no symbolic inputs at runtime. This is needed
+    # if, for example, some tests are run during compilation of the benchmark.
+    new_env['SYMCC_NO_SYMBOLIC_INPUT'] = "1"
+
+    # Build benchmark.
+    utils.build_benchmark(env=new_env)
+
+    # Copy over symcc artifacts and symbolic libc++.
+    shutil.copy(
+        "/symcc/build//SymRuntime-prefix/src/SymRuntime-build/libSymRuntime.so",
+        symcc_build_dir)
+    shutil.copy("/usr/lib/libz3.so", os.path.join(symcc_build_dir, "libz3.so"))
+    shutil.copy("/libcxx_native_build/lib/libc++.so.1", symcc_build_dir)
+    shutil.copy("/libcxx_native_build/lib/libc++abi.so.1", symcc_build_dir)
+    shutil.copy("/rust/bin/symcc_fuzzing_helper", symcc_build_dir)
+
+
+def launch_afl_thread(input_corpus, output_corpus, target_binary,
+                      additional_flags):
+    """ Simple wrapper for running AFL. """
+    afl_thread = threading.Thread(target=afl_fuzzer.run_afl_fuzz,
+                                  args=(input_corpus, output_corpus,
+                                        target_binary, additional_flags))
+    afl_thread.start()
+    return afl_thread
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """
+    Launches a master and a secondary instance of AFL, as well as
+    the symcc helper.
+    """
+    target_binary_dir = os.path.dirname(target_binary)
+    symcc_workdir = get_symcc_build_dir(target_binary_dir)
+    target_binary_name = os.path.basename(target_binary)
+    symcc_target_binary = os.path.join(symcc_workdir, target_binary_name)
+
+    # Start a master and secondary instance of AFL.
+    # We need both because of the way SymCC works.
+    print('[run_fuzzer] Running AFL for SymCC')
+    aflplusplus_fuzzer.prepare_fuzz_environment(input_corpus)
+    launch_afl_thread(input_corpus, output_corpus, target_binary,
+                      ["-M", "afl-master"])
+    time.sleep(5)
+    launch_afl_thread(input_corpus, output_corpus, target_binary,
+                      ["-S", "afl-secondary"])
+    time.sleep(5)
+
+    # Start an instance of SymCC.
+    # We need to ensure it uses the symbolic version of libc++.
+    print("Starting the SymCC helper")
+    new_environ = os.environ.copy()
+    new_environ['LD_LIBRARY_PATH'] = symcc_workdir
+    cmd = [
+        os.path.join(symcc_workdir,
+                     "symcc_fuzzing_helper"), "-o", output_corpus, "-a",
+        "afl-secondary", "-n", "symcc", "--", symcc_target_binary, "@@"
+    ]
+    subprocess.Popen(cmd, env=new_environ)

--- a/fuzzers/symcc_aflplusplus/fuzzer.py
+++ b/fuzzers/symcc_aflplusplus/fuzzer.py
@@ -107,15 +107,13 @@ def fuzz(input_corpus, output_corpus, target_binary):
     target_binary_name = os.path.basename(target_binary)
     symcc_target_binary = os.path.join(symcc_workdir, target_binary_name)
 
-
     os.environ['AFL_DISABLE_TRIM'] = "1"
 
     # Start a master and secondary instance of AFL.
     # We need both because of the way SymCC works.
     print('[run_fuzzer] Running AFL for SymCC')
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
-    launch_afl_thread(input_corpus, output_corpus, target_binary,
-                      ["-S", "afl"])
+    launch_afl_thread(input_corpus, output_corpus, target_binary, ["-S", "afl"])
     time.sleep(5)
     launch_afl_thread(input_corpus, output_corpus, target_binary,
                       ["-S", "afl-secondary"])

--- a/fuzzers/symcc_aflplusplus/fuzzer.py
+++ b/fuzzers/symcc_aflplusplus/fuzzer.py
@@ -107,12 +107,15 @@ def fuzz(input_corpus, output_corpus, target_binary):
     target_binary_name = os.path.basename(target_binary)
     symcc_target_binary = os.path.join(symcc_workdir, target_binary_name)
 
+
+    os.environ['AFL_DISABLE_TRIM'] = "1"
+
     # Start a master and secondary instance of AFL.
     # We need both because of the way SymCC works.
     print('[run_fuzzer] Running AFL for SymCC')
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     launch_afl_thread(input_corpus, output_corpus, target_binary,
-                      ["-M", "afl-master"])
+                      ["-S", "afl"])
     time.sleep(5)
     launch_afl_thread(input_corpus, output_corpus, target_binary,
                       ["-S", "afl-secondary"])
@@ -126,6 +129,6 @@ def fuzz(input_corpus, output_corpus, target_binary):
     cmd = [
         os.path.join(symcc_workdir,
                      "symcc_fuzzing_helper"), "-o", output_corpus, "-a",
-        "afl-secondary", "-n", "symcc", "--", symcc_target_binary, "@@"
+        "afl-secondary", "-n", "symcc", "-m", "--", symcc_target_binary, "@@"
     ]
     subprocess.Popen(cmd, env=new_environ)

--- a/fuzzers/symcc_aflplusplus/fuzzer.py
+++ b/fuzzers/symcc_aflplusplus/fuzzer.py
@@ -110,7 +110,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
     # Start a master and secondary instance of AFL.
     # We need both because of the way SymCC works.
     print('[run_fuzzer] Running AFL for SymCC')
-    aflplusplus_fuzzer.prepare_fuzz_environment(input_corpus)
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
     launch_afl_thread(input_corpus, output_corpus, target_binary,
                       ["-M", "afl-master"])
     time.sleep(5)

--- a/fuzzers/symcc_aflplusplus/runner.Dockerfile
+++ b/fuzzers/symcc_aflplusplus/runner.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -19,6 +19,39 @@
 # You can run "make presubmit" to do basic validation on this file.
 # Please add new experiment requests towards the top of this file.
 
+- experiment: 2021-06-02-symccafl-pp
+  description: >
+               Symcc-AFL test. The difference between this and 
+               2021-06-02-symccafl is that we now have a version of
+               symcc in combination with aflplusplus. Some bug fixing in
+               symcc has happened, which makes it less prone to crashing.
+               The bug fixing is primarily for the aflplusplus hybrid,
+               since the bugs that were fixed has not been notable
+               (maybe seen once) in the symcc-afl combination.
+               Finally, we have added an increase in the timeout
+               of how often symcc runs, switching it from every
+               5 sec to ever 20 sec. Finally, in the aflplusplus
+               hybrid there is no use of afl-showmap, which means
+               all seeds created by symcc are pushed into the afl
+               queue. This changes the symcc set up as there is no
+               filtering done on the seeds pushed to afl.
+  fuzzers:
+    - symcc_afl
+    - symcc_afl_single
+    - symcc_aflplusplus
+    - afl_two_instances
+    - afl
+    - aflfast
+    - aflplusplus
+    - aflsmart
+    - entropic
+    - eclipser
+    - fairfuzz
+    - honggfuzz
+    - lafintel
+    - libfuzzer
+    - mopt    
+
 - experiment: 2021-06-01-symccafl
   description: >
                Symcc-AFL test. The difference between this and 
@@ -42,7 +75,6 @@
     - lafintel
     - libfuzzer
     - mopt    
-
 - experiment: 2021-06-02
   description: "Experiment to compare afl with honggfuzz and libfuzzer"
   fuzzers:

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -22,7 +22,7 @@
 - experiment: 2021-06-02-symccafl-pp
   description: >
                Symcc experiment. The difference between this and 
-               2021-06-02-symccafl is that we now have a version of
+               2021-06-01-symccafl is that we now have a version of
                symcc in combination with aflplusplus. Some bug fixing in
                symcc has happened, which makes it less prone to crashing.
                The bug fixing is primarily for the aflplusplus hybrid,

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -21,7 +21,7 @@
 
 - experiment: 2021-06-02-symccafl-pp
   description: >
-               Symcc-AFL test. The difference between this and 
+               Symcc experiment. The difference between this and 
                2021-06-02-symccafl is that we now have a version of
                symcc in combination with aflplusplus. Some bug fixing in
                symcc has happened, which makes it less prone to crashing.


### PR DESCRIPTION
Following the two recent symcc_afl experiments [1](https://www.fuzzbench.com/reports/experimental/2021-05-29-symccafl/index.html) and [2](https://www.fuzzbench.com/reports/experimental/2021-05-25-symccafl/index.html) I thought it would be interesting to see how symcc and aflplusplus combines, and this is the purpose of this PR.

I combine symcc and aflplusplus in the same way as symcc and afl is combined. Thus, I don't use the custom mutator in aflplusplus [here](https://github.com/AFLplusplus/AFLplusplus/tree/48cef3c74727407f82c44800d382737265fe65b4/custom_mutators/symcc) but rather combine it using the symcc-afl set up, as I read a comment from @vanhauser-thc on the fuzzing discord that the custom mutator runs way too often (please do let me know if I read this wrong @vanhauser-thc). 

The difference between this PR and the symcc_afl integration is that I clone aflplusplus instead of afl and I use the aflplusplus fuzzer.py script to build aflplusplus, other than that it's the same as symcc_afl. I am not super familiar with aflplusplus @vanhauser-thc so if there are parts of aflplusplus that means I can't do this then please let me know :)!  

I tested this on the bloaty target and things seems to be running the way they should: I see symcc and afl output. Am currently testing on more benchmarks. 