### PR TITLE
AFL integration with multiple AFL instances running and a SymCC instance with only a single AFL process.

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -73,6 +73,7 @@ jobs:
           - aflplusplus_x_d2f
           - aflplusplus_x_eh
           - aflplusplus_x_trim
+          - afl_two_instances
 
         benchmark_type:
           - oss-fuzz

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -63,6 +63,7 @@ jobs:
           - aflplusplus_pcguard_ctx_params
           # Concolic execution
           - symcc_afl
+          - symcc_afl_single
           - aflplusplus_x
           - aflplusplus_x_c1
           - aflplusplus_x_c1a

--- a/benchmarks/ffmpeg_ffmpeg_demuxer_fuzzer/benchmark.yaml
+++ b/benchmarks/ffmpeg_ffmpeg_demuxer_fuzzer/benchmark.yaml
@@ -14,3 +14,4 @@ unsupported_fuzzers:
   - eclipser
   - aflplusplus_qemu_inmem
   - symcc_afl
+  - symcc_afl_single

--- a/benchmarks/lcms-2017-03-21/benchmark.yaml
+++ b/benchmarks/lcms-2017-03-21/benchmark.yaml
@@ -16,3 +16,4 @@ fuzz_target: cms_transform_fuzzer
 project: lcms
 unsupported_fuzzers:
   - symcc_afl
+  - symcc_afl_single

--- a/benchmarks/libpcap_fuzz_both/benchmark.yaml
+++ b/benchmarks/libpcap_fuzz_both/benchmark.yaml
@@ -19,3 +19,4 @@ project: libpcap
 unsupported_fuzzers:
   - klee
   - symcc_afl
+  - symcc_afl_single

--- a/benchmarks/ndpi_fuzz_ndpi_reader/benchmark.yaml
+++ b/benchmarks/ndpi_fuzz_ndpi_reader/benchmark.yaml
@@ -13,3 +13,4 @@ unsupported_fuzzers:
   - lafintel
   - eclipser
   - symcc_afl
+  - symcc_afl_single

--- a/benchmarks/njs_njs_process_script_fuzzer/benchmark.yaml
+++ b/benchmarks/njs_njs_process_script_fuzzer/benchmark.yaml
@@ -12,3 +12,4 @@ unsupported_fuzzers:
   - weizz_qemu
   - lafintel
   - symcc_afl
+  - symcc_afl_single

--- a/benchmarks/php_php-fuzz-execute/benchmark.yaml
+++ b/benchmarks/php_php-fuzz-execute/benchmark.yaml
@@ -22,3 +22,4 @@ unsupported_fuzzers:
   - aflplusplus_pcguard_ctx_uniform
   - aflplusplus_pcguard_ctx_params
   - symcc_afl
+  - symcc_afl_single

--- a/benchmarks/php_php-fuzz-parser-2020-07-25/benchmark.yaml
+++ b/benchmarks/php_php-fuzz-parser-2020-07-25/benchmark.yaml
@@ -22,3 +22,4 @@ unsupported_fuzzers:
   - aflplusplus_pcguard_ctx_uniform
   - aflplusplus_pcguard_ctx_params
   - symcc_afl
+  - symcc_afl_single

--- a/benchmarks/php_php-fuzz-parser/benchmark.yaml
+++ b/benchmarks/php_php-fuzz-parser/benchmark.yaml
@@ -30,3 +30,4 @@ unsupported_fuzzers:
   - aflplusplus_pcguard_ctx_uniform
   - aflplusplus_pcguard_ctx_params
   - symcc_afl
+  - symcc_afl_single

--- a/benchmarks/sqlite3_ossfuzz/benchmark.yaml
+++ b/benchmarks/sqlite3_ossfuzz/benchmark.yaml
@@ -18,3 +18,4 @@ fuzz_target: ossfuzz
 project: sqlite3
 unsupported_fuzzers:
   - symcc_afl
+  - symcc_afl_single

--- a/fuzzers/afl_two_instances/builder.Dockerfile
+++ b/fuzzers/afl_two_instances/builder.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fuzzers/afl_two_instances/builder.Dockerfile
+++ b/fuzzers/afl_two_instances/builder.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Download and compile AFL v2.56b.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/google/AFL.git /afl && \
+    cd /afl && \
+    git checkout 82b5e359463238d790cadbe2dd494d6a4928bff3 && \
+    AFL_NO_X86=1 make
+
+# Use afl_driver.cpp from LLVM as our fuzzing library.
+RUN apt-get update && \
+    apt-get install wget -y && \
+    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
+    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
+    ar r /libAFL.a *.o

--- a/fuzzers/afl_two_instances/fuzzer.py
+++ b/fuzzers/afl_two_instances/fuzzer.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Integration code for two AFL instances. This one is useful 
+"""Integration code for two AFL instances. This one is useful
    since some hybrid fuzzers rely on multiple processes, e.g.
    one for AFL and one for concolic execution, and thus potentially
    claim more total CPU power than a single AFL process. Examples
    of this include SymCC and Eclipser.
-   This integration is to have a fairer comparison between such 
+   This integration is to have a fairer comparison between such
    integrations."""
 
 import time

--- a/fuzzers/afl_two_instances/fuzzer.py
+++ b/fuzzers/afl_two_instances/fuzzer.py
@@ -1,0 +1,41 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for MOpt fuzzer."""
+
+import time
+import threading
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    afl_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+
+    # Master instance
+    afl_master_thread = threading.Thread(target=afl_fuzzer.run_afl_fuzz,
+                                         args=(input_corpus, output_corpus,
+                                               target_binary, ['-M', 'afl-master']))
+    afl_master_thread.start()
+    time.sleep(5)
+    # Secondary instance
+    afl_secondary_thread = threading.Thread(target=afl_fuzzer.run_afl_fuzz,
+                                         args=(input_corpus, output_corpus,
+                                               target_binary, ['-S', 'afl-secondary']))
+    afl_secondary_thread.start()

--- a/fuzzers/afl_two_instances/fuzzer.py
+++ b/fuzzers/afl_two_instances/fuzzer.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Integration code for MOpt fuzzer."""
+"""Integration code for two AFL instances. This one is useful 
+   since some hybrid fuzzers rely on multiple processes, e.g.
+   one for AFL and one for concolic execution, and thus potentially
+   claim more total CPU power than a single AFL process. Examples
+   of this include SymCC and Eclipser.
+   This integration is to have a fairer comparison between such 
+   integrations."""
 
 import time
 import threading
@@ -31,11 +37,13 @@ def fuzz(input_corpus, output_corpus, target_binary):
     # Master instance
     afl_master_thread = threading.Thread(target=afl_fuzzer.run_afl_fuzz,
                                          args=(input_corpus, output_corpus,
-                                               target_binary, ['-M', 'afl-master']))
+                                               target_binary,
+                                               ['-M', 'afl-master']))
     afl_master_thread.start()
     time.sleep(5)
     # Secondary instance
     afl_secondary_thread = threading.Thread(target=afl_fuzzer.run_afl_fuzz,
-                                         args=(input_corpus, output_corpus,
-                                               target_binary, ['-S', 'afl-secondary']))
+                                            args=(input_corpus, output_corpus,
+                                                  target_binary,
+                                                  ['-S', 'afl-secondary']))
     afl_secondary_thread.start()

--- a/fuzzers/afl_two_instances/runner.Dockerfile
+++ b/fuzzers/afl_two_instances/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/afl_two_instances/runner.Dockerfile
+++ b/fuzzers/afl_two_instances/runner.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fuzzers/symcc_afl_single/builder.Dockerfile
+++ b/fuzzers/symcc_afl_single/builder.Dockerfile
@@ -1,0 +1,84 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Download and compile AFL v2.56b.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/google/AFL.git /afl && \
+    cd /afl && \
+    git checkout 82b5e359463238d790cadbe2dd494d6a4928bff3 && \
+    AFL_NO_X86=1 make
+
+## Use afl_driver.cpp from LLVM as our fuzzing library.
+RUN apt-get update && \
+    apt-get install wget -y && \
+    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
+    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
+    ar r /libAFL.a *.o
+
+
+# Install the packages we need.
+RUN apt-get install -y ninja-build flex bison python zlib1g-dev cargo 
+
+# Install Z3 from binary
+RUN wget -qO /tmp/z3x64.zip https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-ubuntu-16.04.zip && \
+     unzip -jd /usr/include /tmp/z3x64.zip "*/include/*.h" && \
+     unzip -jd /usr/lib /tmp/z3x64.zip "*/bin/libz3.so" && \
+     rm -f /tmp/*.zip && \
+     ldconfig
+
+ENV CFLAGS=""
+ENV CXXFLAGS=""
+
+# Get and install symcc.
+RUN cd / && \
+    git clone https://github.com/AdaLogics/adacc symcc && \
+    cd symcc && \
+    git checkout 40c819654c77da421d7696f4c4939040f4414e95 && \
+    cd ./runtime/qsym_backend && \
+    git clone https://github.com/adalogics/qsym && \
+    cd qsym && \
+    git checkout adalogics && \
+    cd /symcc && \
+    mkdir build && \
+    cd build && \
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DQSYM_BACKEND=ON \
+          -DZ3_TRUST_SYSTEM_VERSION=ON ../ && \
+    ninja -j 3 && \
+    cd ../examples && \
+    export SYMCC_PC=1 && \
+    ../build/symcc -c ./libfuzz-harness-proxy.c -o /libfuzzer-harness.o && \
+    cd ../ && echo "[+] Installing cargo now 4" && \
+    cargo install --path util/symcc_fuzzing_helper
+
+# Build libcxx with the SymCC compiler so we can instrument 
+# C++ code.
+RUN git clone -b llvmorg-12.0.0 --depth 1 https://github.com/llvm/llvm-project.git /llvm_source  && \
+    mkdir /libcxx_native_install && mkdir /libcxx_native_build && \
+    cd /libcxx_native_install \
+    && export SYMCC_REGULAR_LIBCXX="" && \
+    cmake /llvm_source/llvm                                     \
+      -G Ninja  -DLLVM_ENABLE_PROJECTS="libcxx;libcxxabi"       \
+      -DLLVM_DISTRIBUTION_COMPONENTS="cxx;cxxabi;cxx-headers"   \
+      -DLLVM_TARGETS_TO_BUILD="X86" -DCMAKE_BUILD_TYPE=Release  \
+      -DCMAKE_C_COMPILER=/symcc/build/symcc                     \
+      -DCMAKE_CXX_COMPILER=/symcc/build/sym++                   \
+      -DHAVE_POSIX_REGEX=1     \
+      -DCMAKE_INSTALL_PREFIX="/libcxx_native_build" \
+      -DHAVE_STEADY_CLOCK=1 && \
+    ninja distribution && \
+    ninja install-distribution 

--- a/fuzzers/symcc_afl_single/fuzzer.py
+++ b/fuzzers/symcc_afl_single/fuzzer.py
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+''' Uses the SymCC-AFL hybrid from SymCC, although this only
+    launches a single AFL instance rather than two. '''
+
+from fuzzers.symcc_afl import fuzzer as symcc_afl_fuzzer
+
+def build():
+    """ Build an AFL version and SymCC version of the benchmark """
+    symcc_afl_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """ Launch a SymCC with a single AFL instance. """
+    symcc_afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary, True)

--- a/fuzzers/symcc_afl_single/fuzzer.py
+++ b/fuzzers/symcc_afl_single/fuzzer.py
@@ -16,6 +16,7 @@
 
 from fuzzers.symcc_afl import fuzzer as symcc_afl_fuzzer
 
+
 def build():
     """ Build an AFL version and SymCC version of the benchmark """
     symcc_afl_fuzzer.build()

--- a/fuzzers/symcc_afl_single/runner.Dockerfile
+++ b/fuzzers/symcc_afl_single/runner.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -19,6 +19,30 @@
 # You can run "make presubmit" to do basic validation on this file.
 # Please add new experiment requests towards the top of this file.
 
+- experiment: 2021-06-1-symccafl-multiple
+  description: >
+               Symcc-AFL test. The difference between this and 
+               2021-05-29-symccafl is that we now have afl benchmarks
+               that run multiple instances of afl. This is for 
+               comparison purposes since symcc also utilises mutliple
+               processes. The goal is to try and avoid any bias due
+               to more total CPU time.
+  fuzzers:
+    - symcc_afl
+    - symcc_afl_single
+    - afl_two_instances
+    - afl
+    - aflfast
+    - aflplusplus
+    - aflsmart
+    - entropic
+    - eclipser
+    - fairfuzz
+    - honggfuzz
+    - lafintel
+    - libfuzzer
+    - mopt    
+
 - experiment: 2021-06-02
   description: "Experiment to compare afl with honggfuzz and libfuzzer"
   fuzzers:

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -19,7 +19,7 @@
 # You can run "make presubmit" to do basic validation on this file.
 # Please add new experiment requests towards the top of this file.
 
-- experiment: 2021-06-1-symccafl-multiple
+- experiment: 2021-06-01-symccafl
   description: >
                Symcc-AFL test. The difference between this and 
                2021-05-29-symccafl is that we now have afl benchmarks


### PR DESCRIPTION
This integrates a version where two AFL processes are started. 

The reason for this integration is that some integrations (eclipser and symcc) rely on multiple processes as part of their workflow. This potentially gives an unfair total amount of CPU time or an unfair amount of time spent context switching in comparison to the other integrations, which in turn may twist the truth of the results. This integration is meant to be used as a comparison to such integrations. This came up from a discussion with @vanhauser-thc over here https://github.com/google/fuzzbench/pull/1165#discussion_r643100525 