### PR TITLE
[HOTFIX] Remove entrypoint from builder dockerfile

### DIFF
--- a/docker/benchmark-builder/Dockerfile
+++ b/docker/benchmark-builder/Dockerfile
@@ -51,7 +51,4 @@ RUN export CHECKOUT_COMMIT=$(cat /benchmark.yaml | tr -d ' ' | grep 'commit:' | 
     python3 -u /opt/fuzzbench/checkout_commit.py $CHECKOUT_COMMIT $SRC
 RUN echo "#!/bin/bash\nPYTHONPATH=$SRC python3 -u -c \"from fuzzers import utils; utils.initialize_env(); from fuzzers.$FUZZER import fuzzer; fuzzer.build()\"" > /usr/bin/fuzzer_build && \
     chmod +x /usr/bin/fuzzer_build
-RUN if [ -z "$debug_builder" ] ; then fuzzer_build; fi
-
-ENTRYPOINT echo "Run fuzzer_build to build the target" && \
-           /bin/bash
+RUN echo "Run fuzzer_build to build the target" && if [ -z "$debug_builder" ] ; then fuzzer_build; fi

--- a/docker/generate_makefile.py
+++ b/docker/generate_makefile.py
@@ -71,7 +71,8 @@ def _get_makefile_run_template(image):
         if run_type == 'test-run':
             section += '\t-e MAX_TOTAL_TIME=20 \\\n\t-e SNAPSHOT_PERIOD=10 \\\n'
         if run_type == 'debug-builder':
-            section += '\t-e DEBUG_BUILDER=1 \\\n\t-it '
+            section += '\t-e DEBUG_BUILDER=1 \\\n'
+            section += '\t--entrypoint "/bin/bash" \\\n\t-it '
         elif run_type == 'debug':
             section += '\t--entrypoint "/bin/bash" \\\n\t-it '
         elif run_type == 'repro-bugs':

--- a/docker/test_generate_makefile.py
+++ b/docker/test_generate_makefile.py
@@ -116,5 +116,6 @@ def test_get_rules_for_runner_image():
 \t-e FUZZER=afl \\\n\
 \t-e BENCHMARK=zlib \\\n\
 \t-e FUZZ_TARGET=$(zlib-fuzz-target) \\\n\
-\t-e DEBUG_BUILDER=1 \\\
+\t-e DEBUG_BUILDER=1 \\\n\
+\t--entrypoint "/bin/bash \\\
 \n') + '\t-it gcr.io/fuzzbench/builders/afl/zlib\n\n')

--- a/docker/test_generate_makefile.py
+++ b/docker/test_generate_makefile.py
@@ -117,5 +117,5 @@ def test_get_rules_for_runner_image():
 \t-e BENCHMARK=zlib \\\n\
 \t-e FUZZ_TARGET=$(zlib-fuzz-target) \\\n\
 \t-e DEBUG_BUILDER=1 \\\n\
-\t--entrypoint "/bin/bash \\\
+\t--entrypoint "/bin/bash" \\\
 \n') + '\t-it gcr.io/fuzzbench/builders/afl/zlib\n\n')


### PR DESCRIPTION
My last patch conflicts with the experiments run.
Fuzzbench expects to overwrite the command of the builder when starting an experiment, and this is impossible when there is an ENTRYPOINT in the dockerfile.
This should be the reason of the failed libafl experiment.