### PR TITLE
Add a new fuzzer aflchurn

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -20,6 +20,7 @@ jobs:
           - afl
           - aflcc
           - aflfast
+          - aflchurn
           - aflplusplus
           - aflplusplus_optimal
           - aflsmart

--- a/fuzzers/aflchurn/README.md
+++ b/fuzzers/aflchurn/README.md
@@ -1,0 +1,20 @@
+working benchmarks (2021-03-17):
+- unbound_fuzz_1_fuzzer
+- aspell_aspell_fuzzer
+- usrsctp_fuzzer_connect
+- file_magic_fuzzer
+- yara_dotnet_fuzzer
+- libxml2_libxml2_xml_reader_for_file_fuzzer
+- systemd_fuzz-varlink
+- openvswitch_odp_target
+- neomutt_address-fuzz
+- picotls_fuzz-asn1
+- readstat_fuzz_format_spss_commands
+- openssl_x509
+- libgit2_objects_fuzzer
+- libhtp_fuzz_htp
+- unicorn_fuzz_emu_arm_armbe
+- zstd_stream_decompress
+- grok_grk_decompress_fuzzer
+- ndpi_fuzz_process_packet
+- harfbuzz_hb-shape-fuzzer

--- a/fuzzers/aflchurn/builder.Dockerfile
+++ b/fuzzers/aflchurn/builder.Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN apt-get install -y python-software-properties software-properties-common && \
+    add-apt-repository ppa:git-core/ppa -y && \
+    apt-get update && \
+    apt-get install git -y
+
+# Add and compile AFLChurn
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/aflchurn/aflchurn.git /afl && \
+    cd /afl && \ 
+    AFL_NO_X86=1 make && \
+    INITIAL_CXXFLAGS=$CXXFLAGS && \
+    INITIAL_CFLAGS=$CFLAGS && \
+    unset CFLAGS CXXFLAGS && \
+    cd llvm_mode && \
+    make && \
+    CXXFLAGS=$INITIAL_CXXFLAGS && \
+    CFLAGS=$INITIAL_CFLAGS
+
+# Use afl_driver.cpp from LLVM as our fuzzing library.
+# clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
+RUN apt-get update && \
+    apt-get install wget -y && \
+    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
+    ar r /libAFL.a *.o

--- a/fuzzers/aflchurn/fuzzer.py
+++ b/fuzzers/aflchurn/fuzzer.py
@@ -1,0 +1,120 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for AFLChurn fuzzer."""
+
+import shutil
+import subprocess
+import os
+
+from fuzzers import utils
+
+
+# '-fsanitize-coverage=trace-pc-guard'
+def prepare_build_environment():
+    """Set environment variables used to build targets for AFL-based
+    fuzzers."""
+    cflags = ['-fsanitize=address', '-fsanitize-address-use-after-scope']
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cflags)
+    utils.append_flags('ASAN_OPTIONS', ['abort_on_error=1', 'symbolize=0'])
+
+    os.environ['CC'] = '/afl/afl-clang-fast'
+    os.environ['CXX'] = '/afl/afl-clang-fast++'
+    os.environ['FUZZER_LIB'] = '/libAFL.a'
+
+    os.system(
+        'apt-get install -y python-software-properties software-properties-common && \
+        add-apt-repository ppa:git-core/ppa -y && \
+        apt-get update && \
+        apt-get install git -y')
+
+
+def build():
+    """Build benchmark."""
+    prepare_build_environment()
+
+    utils.build_benchmark()
+
+    print('[post_build] Copying afl-fuzz to $OUT directory')
+    # Copy out the afl-fuzz binary as a build artifact.
+    shutil.copy('/afl/afl-fuzz', os.environ['OUT'])
+
+
+def prepare_fuzz_environment(input_corpus):
+    """Prepare to fuzz with AFL or another AFL-based fuzzer."""
+    # Tell AFL to not use its terminal UI so we get usable logs.
+    os.environ['AFL_NO_UI'] = '1'
+    # Skip AFL's CPU frequency check (fails on Docker).
+    os.environ['AFL_SKIP_CPUFREQ'] = '1'
+    # No need to bind affinity to one core, Docker enforces 1 core usage.
+    os.environ['AFL_NO_AFFINITY'] = '1'
+    # AFL will abort on startup if the core pattern sends notifications to
+    # external programs. We don't care about this.
+    os.environ['AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES'] = '1'
+
+    # AFL needs at least one non-empty seed to start.
+    utils.create_seed_file_for_empty_corpus(input_corpus)
+
+
+def run_afl_fuzz(input_corpus,
+                 output_corpus,
+                 target_binary,
+                 additional_flags=None,
+                 hide_output=False):
+    """Run afl-fuzz."""
+    # Spawn the afl fuzzing process.
+    # FIXME: Currently AFL will exit if it encounters a crashing input in seed
+    # corpus (usually timeouts). Add a way to skip/delete such inputs and
+    # re-run AFL.
+    print('[run_afl_fuzz] Running target with afl-fuzz')
+    command = [
+        './afl-fuzz',
+        '-i',
+        input_corpus,
+        '-o',
+        output_corpus,
+        # Use deterministic mode as it does best when we don't have
+        # seeds which is often the case.
+        '-d',
+        # Use no memory limit as ASAN doesn't play nicely with one.
+        '-m',
+        'none',
+        '-t',
+        '1000+',  # Use same default 1 sec timeout, but add '+' to skip hangs.
+    ]
+    if additional_flags:
+        command.extend(additional_flags)
+    dictionary_path = utils.get_dictionary_path(target_binary)
+    if dictionary_path:
+        command.extend(['-x', dictionary_path])
+    command += [
+        '--',
+        target_binary,
+        # Pass INT_MAX to afl the maximize the number of persistent loops it
+        # performs.
+        '2147483647'
+    ]
+    print('[run_afl_fuzz] Running command: ' + ' '.join(command))
+    output_stream = subprocess.DEVNULL if hide_output else None
+    subprocess.check_call(command, stdout=output_stream, stderr=output_stream)
+
+
+def fuzz(input_corpus, output_corpus, target_binary, flags=tuple()):
+    """Run afl-fuzz on target."""
+    prepare_fuzz_environment(input_corpus)
+
+    run_afl_fuzz(input_corpus,
+                 output_corpus,
+                 target_binary,
+                 additional_flags=flags)

--- a/fuzzers/aflchurn/runner.Dockerfile
+++ b/fuzzers/aflchurn/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image


### PR DESCRIPTION
Add a new fuzzer [AFLChurn](https://github.com/aflchurn/aflchurn) and its benchmarks.

AFLChurn is a regression greybox fuzzer that focusses on code that is changed more recently or more frequently. In our empirical study on bugs in OSSFuzz, we found that every four in five bugs reported in OSSFuzz are introduced by recent changes, so called regressions. Unlike a directed fuzzer, AFLChurn is not directed towards a single recent commit. Instead, it uses the entire commit history of a project to steer the fuzzing efforts towards code regions where such regressions may lurk. For AFLChurn, ever basic block (BB) is a target. However, some BBs have more and others less weight. Specifically, executed BBs that are changed more recently or more frequently will contribute a greater weight towards the power schedule of AFLChurn.