### PR TITLE
AFL variants new experiment request

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -82,6 +82,14 @@ jobs:
           - cfctx_randomic
           - cfctx_params
           - cfctx_plain
+          - afl_no_favs
+          - afl_rf
+          - afl_rf_u
+          - afl_rf_u_wrs
+          - afl_wrs
+          - afl_wrs_rf
+          - afl_wrs_rf_rp
+          - afl_wrs_rp
           # Concolic execution
           - aflplusplus_cmplog_double
           - aflplusplus_qemu_double

--- a/fuzzers/afl_no_favs/builder.Dockerfile
+++ b/fuzzers/afl_no_favs/builder.Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/Practical-Formal-Methods/AFL-public.git /afl && \
+    cd /afl && \
+    git checkout random_params && \
+    AFL_NO_X86=1 make
+
+# Use afl_driver.cpp from LLVM as our fuzzing library.
+RUN apt-get update && \
+    apt-get install wget -y && \
+    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
+    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
+    ar r /libAFL.a *.o

--- a/fuzzers/afl_no_favs/fuzzer.py
+++ b/fuzzers/afl_no_favs/fuzzer.py
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for FairFuzz fuzzer."""
+
+import os
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    afl_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    os.environ['AFL_DISABLE_WRS'] ='1'
+    os.environ['AFL_DISABLE_RF'] ='1'
+    os.environ['AFL_DISABLE_FAVS'] ='1'
+    os.environ['AFL_DISABLE_RP'] ='1'
+    afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_no_favs/fuzzer.py
+++ b/fuzzers/afl_no_favs/fuzzer.py
@@ -25,8 +25,8 @@ def build():
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
-    os.environ['AFL_DISABLE_WRS'] ='1'
-    os.environ['AFL_DISABLE_RF'] ='1'
-    os.environ['AFL_DISABLE_FAVS'] ='1'
-    os.environ['AFL_DISABLE_RP'] ='1'
+    os.environ['AFL_DISABLE_WRS'] = '1'
+    os.environ['AFL_DISABLE_RF'] = '1'
+    os.environ['AFL_DISABLE_FAVS'] = '1'
+    os.environ['AFL_DISABLE_RP'] = '1'
     afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_no_favs/runner.Dockerfile
+++ b/fuzzers/afl_no_favs/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/afl_rf/builder.Dockerfile
+++ b/fuzzers/afl_rf/builder.Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/Practical-Formal-Methods/AFL-public.git /afl && \
+    cd /afl && \
+    git checkout random_params && \
+    AFL_NO_X86=1 make
+
+# Use afl_driver.cpp from LLVM as our fuzzing library.
+RUN apt-get update && \
+    apt-get install wget -y && \
+    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
+    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
+    ar r /libAFL.a *.o

--- a/fuzzers/afl_rf/fuzzer.py
+++ b/fuzzers/afl_rf/fuzzer.py
@@ -25,6 +25,6 @@ def build():
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
-    os.environ['AFL_DISABLE_WRS'] ='1'
-    os.environ['AFL_DISABLE_RP'] ='1'
+    os.environ['AFL_DISABLE_WRS'] = '1'
+    os.environ['AFL_DISABLE_RP'] = '1'
     afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_rf/fuzzer.py
+++ b/fuzzers/afl_rf/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for FairFuzz fuzzer."""
+
+import os
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    afl_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    os.environ['AFL_DISABLE_WRS'] ='1'
+    os.environ['AFL_DISABLE_RP'] ='1'
+    afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_rf/runner.Dockerfile
+++ b/fuzzers/afl_rf/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/afl_rf_u/builder.Dockerfile
+++ b/fuzzers/afl_rf_u/builder.Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/Practical-Formal-Methods/AFL-public.git /afl && \
+    cd /afl && \
+    git checkout random_params && \
+    AFL_NO_X86=1 make
+
+# Use afl_driver.cpp from LLVM as our fuzzing library.
+RUN apt-get update && \
+    apt-get install wget -y && \
+    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
+    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
+    ar r /libAFL.a *.o

--- a/fuzzers/afl_rf_u/fuzzer.py
+++ b/fuzzers/afl_rf_u/fuzzer.py
@@ -1,0 +1,31 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for FairFuzz fuzzer."""
+
+import os
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    afl_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    os.environ['AFL_DISABLE_WRS'] ='1'
+    os.environ['AFL_ENABLE_UF'] ='1'
+    os.environ['AFL_DISABLE_RP'] ='1'
+    afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_rf_u/fuzzer.py
+++ b/fuzzers/afl_rf_u/fuzzer.py
@@ -25,7 +25,7 @@ def build():
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
-    os.environ['AFL_DISABLE_WRS'] ='1'
-    os.environ['AFL_ENABLE_UF'] ='1'
-    os.environ['AFL_DISABLE_RP'] ='1'
+    os.environ['AFL_DISABLE_WRS'] = '1'
+    os.environ['AFL_ENABLE_UF'] = '1'
+    os.environ['AFL_DISABLE_RP'] = '1'
     afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_rf_u/runner.Dockerfile
+++ b/fuzzers/afl_rf_u/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/afl_rf_u_wrs/builder.Dockerfile
+++ b/fuzzers/afl_rf_u_wrs/builder.Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/Practical-Formal-Methods/AFL-public.git /afl && \
+    cd /afl && \
+    git checkout random_params && \
+    AFL_NO_X86=1 make
+
+# Use afl_driver.cpp from LLVM as our fuzzing library.
+RUN apt-get update && \
+    apt-get install wget -y && \
+    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
+    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
+    ar r /libAFL.a *.o

--- a/fuzzers/afl_rf_u_wrs/fuzzer.py
+++ b/fuzzers/afl_rf_u_wrs/fuzzer.py
@@ -25,6 +25,6 @@ def build():
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
-    os.environ['AFL_ENABLE_UF'] ='1'
-    os.environ['AFL_DISABLE_RP'] ='1'
+    os.environ['AFL_ENABLE_UF'] = '1'
+    os.environ['AFL_DISABLE_RP'] = '1'
     afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_rf_u_wrs/fuzzer.py
+++ b/fuzzers/afl_rf_u_wrs/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for FairFuzz fuzzer."""
+
+import os
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    afl_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    os.environ['AFL_ENABLE_UF'] ='1'
+    os.environ['AFL_DISABLE_RP'] ='1'
+    afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_rf_u_wrs/runner.Dockerfile
+++ b/fuzzers/afl_rf_u_wrs/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/afl_wrs/builder.Dockerfile
+++ b/fuzzers/afl_wrs/builder.Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/Practical-Formal-Methods/AFL-public.git /afl && \
+    cd /afl && \
+    git checkout random_params && \
+    AFL_NO_X86=1 make
+
+# Use afl_driver.cpp from LLVM as our fuzzing library.
+RUN apt-get update && \
+    apt-get install wget -y && \
+    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
+    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
+    ar r /libAFL.a *.o

--- a/fuzzers/afl_wrs/fuzzer.py
+++ b/fuzzers/afl_wrs/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for FairFuzz fuzzer."""
+
+import os
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    afl_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    os.environ['AFL_DISABLE_RF'] ='1'
+    os.environ['AFL_DISABLE_RP'] ='1'
+    afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_wrs/fuzzer.py
+++ b/fuzzers/afl_wrs/fuzzer.py
@@ -25,6 +25,6 @@ def build():
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
-    os.environ['AFL_DISABLE_RF'] ='1'
-    os.environ['AFL_DISABLE_RP'] ='1'
+    os.environ['AFL_DISABLE_RF'] = '1'
+    os.environ['AFL_DISABLE_RP'] = '1'
     afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_wrs/runner.Dockerfile
+++ b/fuzzers/afl_wrs/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/afl_wrs_rf/builder.Dockerfile
+++ b/fuzzers/afl_wrs_rf/builder.Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/Practical-Formal-Methods/AFL-public.git /afl && \
+    cd /afl && \
+    git checkout random_params && \
+    AFL_NO_X86=1 make
+
+# Use afl_driver.cpp from LLVM as our fuzzing library.
+RUN apt-get update && \
+    apt-get install wget -y && \
+    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
+    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
+    ar r /libAFL.a *.o

--- a/fuzzers/afl_wrs_rf/fuzzer.py
+++ b/fuzzers/afl_wrs_rf/fuzzer.py
@@ -25,5 +25,5 @@ def build():
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
-    os.environ['AFL_DISABLE_RP'] ='1'
+    os.environ['AFL_DISABLE_RP'] = '1'
     afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_wrs_rf/fuzzer.py
+++ b/fuzzers/afl_wrs_rf/fuzzer.py
@@ -1,0 +1,29 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for FairFuzz fuzzer."""
+
+import os
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    afl_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    os.environ['AFL_DISABLE_RP'] ='1'
+    afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_wrs_rf/runner.Dockerfile
+++ b/fuzzers/afl_wrs_rf/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/afl_wrs_rf_rp/builder.Dockerfile
+++ b/fuzzers/afl_wrs_rf_rp/builder.Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/Practical-Formal-Methods/AFL-public.git /afl && \
+    cd /afl && \
+    git checkout random_params && \
+    AFL_NO_X86=1 make
+
+# Use afl_driver.cpp from LLVM as our fuzzing library.
+RUN apt-get update && \
+    apt-get install wget -y && \
+    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
+    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
+    ar r /libAFL.a *.o

--- a/fuzzers/afl_wrs_rf_rp/fuzzer.py
+++ b/fuzzers/afl_wrs_rf_rp/fuzzer.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Integration code for FairFuzz fuzzer."""
 
+import os
+
 from fuzzers.afl import fuzzer as afl_fuzzer
 
 
@@ -23,4 +25,5 @@ def build():
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
+    os.environ['AFL_RP_PROB'] = '20'
     afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_wrs_rf_rp/fuzzer.py
+++ b/fuzzers/afl_wrs_rf_rp/fuzzer.py
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for FairFuzz fuzzer."""
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    afl_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_wrs_rf_rp/runner.Dockerfile
+++ b/fuzzers/afl_wrs_rf_rp/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/afl_wrs_rp/builder.Dockerfile
+++ b/fuzzers/afl_wrs_rp/builder.Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Set AFL_NO_X86 to skip flaky tests.
+RUN git clone https://github.com/Practical-Formal-Methods/AFL-public.git /afl && \
+    cd /afl && \
+    git checkout random_params && \
+    AFL_NO_X86=1 make
+
+# Use afl_driver.cpp from LLVM as our fuzzing library.
+RUN apt-get update && \
+    apt-get install wget -y && \
+    wget https://raw.githubusercontent.com/llvm/llvm-project/5feb80e748924606531ba28c97fe65145c65372e/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    clang -Wno-pointer-sign -c /afl/llvm_mode/afl-llvm-rt.o.c -I/afl && \
+    clang++ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp && \
+    ar r /libAFL.a *.o

--- a/fuzzers/afl_wrs_rp/fuzzer.py
+++ b/fuzzers/afl_wrs_rp/fuzzer.py
@@ -25,5 +25,6 @@ def build():
 
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
-    os.environ['AFL_DISABLE_RF'] ='1'
+    os.environ['AFL_DISABLE_RF'] = '1'
+    os.environ['AFL_RP_PROB'] = '20'
     afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_wrs_rp/fuzzer.py
+++ b/fuzzers/afl_wrs_rp/fuzzer.py
@@ -1,0 +1,29 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for FairFuzz fuzzer."""
+
+import os
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    afl_fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    os.environ['AFL_DISABLE_RF'] ='1'
+    afl_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/afl_wrs_rp/runner.Dockerfile
+++ b/fuzzers/afl_wrs_rp/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -20,6 +20,19 @@
 # Please add new experiment requests towards the top of this file.
 
 
+- experiment: 2021-07-30-random-params
+  description: "Evaluate various random parameters for afl"
+  fuzzers:
+    - afl
+    - afl_no_favs
+    - afl_rf
+    - afl_rf_u
+    - afl_rf_u_wrs
+    - afl_wrs
+    - afl_wrs_rf
+    - afl_wrs_rf_rp
+    - afl_wrs_rp
+
 - experiment: 2021-07-30-aflpp
   description: "afl++ cmplog"
   fuzzers:


### PR DESCRIPTION
I'd like to request a new experiment to benchmark AFL variants which exploit a bunch of random approaches for fuzzing. There are 8 fuzzers that I add in this PR and their configurations are almost the same except for the environment variables that are set differently for each fuzzer. 