### PR TITLE
Pin images to specific base-builder and base-clang build.

### DIFF
--- a/benchmarks/arrow_parquet-arrow-fuzz/Dockerfile
+++ b/benchmarks/arrow_parquet-arrow-fuzz/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -y -q && \

--- a/benchmarks/aspell_aspell_fuzzer/Dockerfile
+++ b/benchmarks/aspell_aspell_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && apt-get install -y pkg-config
 

--- a/benchmarks/bloaty_fuzz_target/Dockerfile
+++ b/benchmarks/bloaty_fuzz_target/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && apt-get install -y cmake ninja-build g++
 RUN git clone --depth 1 https://github.com/google/bloaty.git bloaty
 WORKDIR bloaty

--- a/benchmarks/curl_curl_fuzzer_http/Dockerfile
+++ b/benchmarks/curl_curl_fuzzer_http/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 # Curl will be checked out to the commit hash specified in benchmark.yaml.
 RUN git clone --depth 1 https://github.com/curl/curl.git /src/curl

--- a/benchmarks/ffmpeg_ffmpeg_demuxer_fuzzer/Dockerfile
+++ b/benchmarks/ffmpeg_ffmpeg_demuxer_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:c0eeba3437a2173c6a7115cf43062b351ed48cc2b54f54f895423d6a5af1dc3e
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a@sha256:c0eeba3437a2173c6a7115cf43062b351ed48cc2b54f54f895423d6a5af1dc3e
 ADD bionic.list /etc/apt/sources.list.d/bionic.list
 ADD nasm_apt.pin /etc/apt/preferences
 RUN apt-get update && apt-get install -y make autoconf automake libtool build-essential \

--- a/benchmarks/file_magic_fuzzer/Dockerfile
+++ b/benchmarks/file_magic_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 MAINTAINER mike.aizatsky@gmail.com
 RUN apt-get update && apt-get install -y make autoconf automake libtool shtool zlib1g-dev
 RUN git clone --depth 1 https://github.com/file/file.git

--- a/benchmarks/freetype2-2017/Dockerfile
+++ b/benchmarks/freetype2-2017/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update &&  \
     apt-get install -y \

--- a/benchmarks/grok_grk_decompress_fuzzer/Dockerfile
+++ b/benchmarks/grok_grk_decompress_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN git clone https://github.com/GrokImageCompression/grok.git grok
 RUN git clone https://github.com/GrokImageCompression/grok-test-data.git grok/data

--- a/benchmarks/harfbuzz-1.3.2/Dockerfile
+++ b/benchmarks/harfbuzz-1.3.2/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/jsoncpp_jsoncpp_fuzzer/Dockerfile
+++ b/benchmarks/jsoncpp_jsoncpp_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && apt-get install -y build-essential make curl wget
 
 # Install latest cmake.

--- a/benchmarks/lcms-2017-03-21/Dockerfile
+++ b/benchmarks/lcms-2017-03-21/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/libarchive_libarchive_fuzzer/Dockerfile
+++ b/benchmarks/libarchive_libarchive_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 # Installing optional libraries can utilize more code path and/or improve
 # performance (avoid calling external programs).

--- a/benchmarks/libgit2_objects_fuzzer/Dockerfile
+++ b/benchmarks/libgit2_objects_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && apt-get install -y make autoconf automake libtool cmake
 RUN git clone https://github.com/libgit2/libgit2 libgit2

--- a/benchmarks/libhevc_hevc_dec_fuzzer/Dockerfile
+++ b/benchmarks/libhevc_hevc_dec_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 MAINTAINER harish.mahendrakar@ittiam.com
 RUN apt-get update && apt-get install -y wget cmake
 RUN git clone https://android.googlesource.com/platform/external/libhevc

--- a/benchmarks/libhtp_fuzz_htp/Dockerfile
+++ b/benchmarks/libhtp_fuzz_htp/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && apt-get install -y make autoconf automake libtool zlib1g-dev liblzma-dev
 RUN git clone https://github.com/OISF/libhtp.git libhtp

--- a/benchmarks/libjpeg-turbo-07-2017/Dockerfile
+++ b/benchmarks/libjpeg-turbo-07-2017/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/libpcap_fuzz_both/Dockerfile
+++ b/benchmarks/libpcap_fuzz_both/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && apt-get install -y make cmake flex bison
 RUN git clone --depth 1 https://github.com/the-tcpdump-group/libpcap.git libpcap
 # for corpus as wireshark

--- a/benchmarks/libpng-1.2.56/Dockerfile
+++ b/benchmarks/libpng-1.2.56/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/libxml2-v2.9.2/Dockerfile
+++ b/benchmarks/libxml2-v2.9.2/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/libxml2_libxml2_xml_reader_for_file_fuzzer/Dockerfile
+++ b/benchmarks/libxml2_libxml2_xml_reader_for_file_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config python-dev python3-dev
 

--- a/benchmarks/libxslt_xpath/Dockerfile
+++ b/benchmarks/libxslt_xpath/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 # Note that we don't use the system libxml2 but a custom instrumented build.
 # libgcrypt is required for the crypto extensions of libexslt.

--- a/benchmarks/matio_matio_fuzzer/Dockerfile
+++ b/benchmarks/matio_matio_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 MAINTAINER t-beu@users.sourceforge.net
 RUN apt-get update && apt-get install -y make autoconf automake libhdf5-dev libtool zlib1g-dev
 ENV HDF5_DIR /usr/lib/x86_64-linux-gnu/hdf5/serial

--- a/benchmarks/mbedtls_fuzz_dtlsclient/Dockerfile
+++ b/benchmarks/mbedtls_fuzz_dtlsclient/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && apt-get install -y make cmake
 RUN git clone --recursive --depth 1 https://github.com/ARMmbed/mbedtls.git mbedtls
 RUN git clone --depth 1 https://github.com/google/boringssl.git boringssl

--- a/benchmarks/muparser_set_eval_fuzzer/Dockerfile
+++ b/benchmarks/muparser_set_eval_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN apt-get install -y build-essential cmake pkg-config
 RUN git clone https://github.com/beltoforion/muparser.git muparser

--- a/benchmarks/ndpi_fuzz_ndpi_reader/Dockerfile
+++ b/benchmarks/ndpi_fuzz_ndpi_reader/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && apt-get install -y make autoconf automake autogen pkg-config libtool flex bison
 RUN git clone --depth 1 https://github.com/ntop/nDPI.git ndpi
 ADD https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz libpcap-1.9.1.tar.gz

--- a/benchmarks/njs_njs_process_script_fuzzer/Dockerfile
+++ b/benchmarks/njs_njs_process_script_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && apt-get install -y make autoconf automake libtool \
     mercurial libpcre3-dev subversion
 RUN hg clone http://hg.nginx.org/njs

--- a/benchmarks/openh264_decoder_fuzzer/Dockerfile
+++ b/benchmarks/openh264_decoder_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 MAINTAINER twsmith@mozilla.com
 RUN dpkg --add-architecture i386 && \
     apt-get update && \

--- a/benchmarks/openssl_x509/Dockerfile
+++ b/benchmarks/openssl_x509/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && apt-get install -y make
 RUN git clone --depth 1 https://github.com/openssl/openssl.git
 WORKDIR openssl

--- a/benchmarks/openthread-2019-12-23/Dockerfile
+++ b/benchmarks/openthread-2019-12-23/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/php_php-fuzz-execute/Dockerfile
+++ b/benchmarks/php_php-fuzz-execute/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && \
     apt-get install -y autoconf automake libtool bison re2c pkg-config
 RUN git clone --depth 1 --branch master https://github.com/php/php-src.git php-src

--- a/benchmarks/php_php-fuzz-parser-2020-07-25/Dockerfile
+++ b/benchmarks/php_php-fuzz-parser-2020-07-25/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && \
     apt-get install -y autoconf automake libtool bison re2c pkg-config
 RUN git clone --depth 1 --branch master https://github.com/php/php-src.git php-src

--- a/benchmarks/php_php-fuzz-parser/Dockerfile
+++ b/benchmarks/php_php-fuzz-parser/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && \
     apt-get install -y autoconf automake libtool bison re2c pkg-config
 

--- a/benchmarks/poppler_pdf_fuzzer/Dockerfile
+++ b/benchmarks/poppler_pdf_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 MAINTAINER jonathan@titanous.com
 RUN apt-get update && apt-get install -y make autoconf libz-dev lib32z1-dev zlib1g-dev automake libtool pkg-config cmake
 RUN git clone --depth 1 https://anongit.freedesktop.org/git/poppler/poppler.git

--- a/benchmarks/proj4-2017-08-14/Dockerfile
+++ b/benchmarks/proj4-2017-08-14/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/proj4_standard_fuzzer/Dockerfile
+++ b/benchmarks/proj4_standard_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && apt-get install -y make autoconf automake libtool g++ sqlite3 libsqlite3-dev pkg-config
 RUN git clone --depth 1 https://github.com/OSGeo/proj.4 proj.4
 WORKDIR proj.4

--- a/benchmarks/re2-2014-12-09/Dockerfile
+++ b/benchmarks/re2-2014-12-09/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/sqlite3_ossfuzz/Dockerfile
+++ b/benchmarks/sqlite3_ossfuzz/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && apt-get install -y make autoconf automake libtool curl tcl zlib1g-dev
 
 RUN mkdir $SRC/sqlite3 && \

--- a/benchmarks/stb_stbi_read_fuzzer/Dockerfile
+++ b/benchmarks/stb_stbi_read_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
     apt-get install -y wget tar

--- a/benchmarks/systemd_fuzz-link-parser/Dockerfile
+++ b/benchmarks/systemd_fuzz-link-parser/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update &&\
     apt-get install -y gperf m4 gettext python3-pip \
         libcap-dev libmount-dev libkmod-dev \

--- a/benchmarks/systemd_fuzz-varlink/Dockerfile
+++ b/benchmarks/systemd_fuzz-varlink/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/tpm2_tpm2_execute_command_fuzzer/Dockerfile
+++ b/benchmarks/tpm2_tpm2_execute_command_fuzzer/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Defines a docker image that can build fuzzers.
 #
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && apt-get install -y make libssl-dev binutils libgcc-5-dev
 RUN git clone --depth 1 https://chromium.googlesource.com/chromiumos/third_party/tpm2
 WORKDIR tpm2

--- a/benchmarks/usrsctp_fuzzer_connect/Dockerfile
+++ b/benchmarks/usrsctp_fuzzer_connect/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 MAINTAINER weinrank@fh-muenster.de
 RUN apt-get update && apt-get install -y make cmake pkg-config
 RUN git clone --branch oss-fuzz https://github.com/weinrank/usrsctp usrsctp

--- a/benchmarks/vorbis-2017-12-11/Dockerfile
+++ b/benchmarks/vorbis-2017-12-11/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/wireshark_fuzzshark_ip/Dockerfile
+++ b/benchmarks/wireshark_fuzzshark_ip/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && apt-get install -y make cmake \
                        flex bison \

--- a/benchmarks/woff2-2016-05-06/Dockerfile
+++ b/benchmarks/woff2-2016-05-06/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/zlib_zlib_uncompress_fuzzer/Dockerfile
+++ b/benchmarks/zlib_zlib_uncompress_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 RUN apt-get update && apt-get install -y make autoconf automake libtool
 RUN git clone --depth 1 -b develop https://github.com/madler/zlib.git
 WORKDIR zlib

--- a/benchmarks/zstd_stream_decompress/Dockerfile
+++ b/benchmarks/zstd_stream_decompress/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && apt-get install -y make python wget
 # Clone source

--- a/docker/dispatcher-image/Dockerfile
+++ b/docker/dispatcher-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/oss-fuzz-base/base-clang AS base-clang
+FROM gcr.io/oss-fuzz-base/base-clang@sha256:30706816922bf9c141b15ff4a5a44af8c0ec5700d4b46e0572029c15e495d45b AS base-clang
 
 FROM gcr.io/fuzzbench/base-image
 


### PR DESCRIPTION
This is so that we don't have to upgrade FuzzBench images when
OSS-Fuzz images upgrade.

This is related to https://github.com/google/oss-fuzz/issues/6180