### PR TITLE
Fix AFL++ no_cmplog bug and ffmpeg container hash

### DIFF
--- a/benchmarks/ffmpeg_ffmpeg_demuxer_fuzzer/Dockerfile
+++ b/benchmarks/ffmpeg_ffmpeg_demuxer_fuzzer/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a@sha256:c0eeba3437a2173c6a7115cf43062b351ed48cc2b54f54f895423d6a5af1dc3e
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:c0eeba3437a2173c6a7115cf43062b351ed48cc2b54f54f895423d6a5af1dc3e
 ADD bionic.list /etc/apt/sources.list.d/bionic.list
 ADD nasm_apt.pin /etc/apt/preferences
 RUN apt-get update && apt-get install -y make autoconf automake libtool build-essential \

--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -252,7 +252,7 @@ def fuzz(input_corpus,
         flags += ['-x', './afl++.dict']
 
     # Move the following to skip for upcoming _double tests:
-    if os.path.exists(cmplog_target_binary) and no_cmplog is not False:
+    if os.path.exists(cmplog_target_binary) and no_cmplog is False:
         flags += ['-c', cmplog_target_binary]
 
     if not skip:


### PR DESCRIPTION
This PR fixes #1240 and a bug in the AFL++ fuzzer.py

This bug, introduced to evaluate the concolic executor that uses multiple instances of AFL++, disables CmpLog even when enabled in the build function, so from ~3 months AFL++ was not using CmpLog on Fuzzbench.

Now, my experiments were made inconsistent by this mistake, even the bigger one (https://www.fuzzbench.com/reports/experimental/2021-09-08-cloning/index.html) that caused the problems with the memory requirement and it is finishing to run while I'm writing. Dunno what I should do, in theory I should be able to request an experiment running just AFL++ over all the bug benchs and merging it generating a local report with all the previous fuzzers that are not affected by the bug right?