### PR TITLE
Fix broken experiment request and valdiate more.

### DIFF
--- a/common/fuzzer_utils.py
+++ b/common/fuzzer_utils.py
@@ -25,7 +25,7 @@ DEFAULT_FUZZ_TARGET_NAME = 'fuzz-target'
 FUZZ_TARGET_SEARCH_STRING = b'LLVMFuzzerTestOneInput'
 
 # Must be a valid python module and docker tag.
-VALID_FUZZER_REGEX = re.compile(r'^[a-z0-9_]+$')
+VALID_FUZZER_REGEX = re.compile(r'^[a-z][a-z0-9_]*$')
 
 FUZZERS_DIR = os.path.join(utils.ROOT_DIR, 'fuzzers')
 COVERAGE_TOOLS = {'coverage', 'coverage_source_based'}

--- a/common/logs.py
+++ b/common/logs.py
@@ -155,16 +155,19 @@ def log(logger, severity, message, *args, extras=None):
     """Log a message with severity |severity|. If using stack driver logging
     then |extras| is also logged (in addition to default extras)."""
     message = str(message)
+    if args:
+        message = message % args
+
     if utils.is_local():
         if extras:
             message += ' Extras: ' + str(extras)
-        logging.log(severity, message, *args)
+        logging.log(severity, message)
         return
+
     if logger is None:
         logger = _default_logger
     assert logger
-    if args:
-        message = message % args
+
     struct_message = {
         'message': message,
     }

--- a/experiment/test_run_experiment.py
+++ b/experiment/test_run_experiment.py
@@ -36,9 +36,9 @@ def test_validate_benchmarks_valid_benchmarks():
 
 def test_validate_benchmarks_invalid_benchmark():
     """Tests that validate_benchmarks does not validate invalid benchmarks."""
-    with pytest.raises(Exception):
+    with pytest.raises(run_experiment.ValidationError):
         run_experiment.validate_benchmarks('fake_benchmark')
-    with pytest.raises(Exception):
+    with pytest.raises(run_experiment.ValidationError):
         run_experiment.validate_benchmarks('common.sh')
 
 
@@ -164,13 +164,13 @@ def test_validate_fuzzer():
     that an invalid one is not."""
     run_experiment.validate_fuzzer('afl')
 
-    with pytest.raises(Exception) as exception:
+    with pytest.raises(run_experiment.ValidationError) as exception:
         run_experiment.validate_fuzzer('afl:')
-    assert 'may only contain' in str(exception.value)
+    assert 'is invalid' in str(exception.value)
 
-    with pytest.raises(Exception) as exception:
+    with pytest.raises(run_experiment.ValidationError) as exception:
         run_experiment.validate_fuzzer('not_exist')
-    assert 'does not exist' in str(exception.value)
+    assert 'is invalid' in str(exception.value)
 
 
 def test_validate_experiment_name_valid():
@@ -183,7 +183,7 @@ def test_validate_experiment_name_valid():
 def test_validate_experiment_name_invalid(experiment_name):
     """Tests that validate_experiment_name raises an exception when passed an
     an invalid experiment name."""
-    with pytest.raises(Exception) as exception:
+    with pytest.raises(run_experiment.ValidationError) as exception:
         run_experiment.validate_experiment_name(experiment_name)
     assert 'is invalid. Must match' in str(exception.value)
 

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -20,7 +20,7 @@
 # Please add new experiment requests towards the top of this file.
 
 
-- experiment: 2021-09-16-blackboxeffectiveness
+- experiment: 2021-09-23-blackboxeffect
   description: "Compare the fuzzer effectiveness of AFL dumb mode"
   fuzzers:
     - afl
@@ -28,7 +28,6 @@
     - aflplusplus
     - honggfuzz
     - libfuzzer
-
 
 - experiment: 2021-09-08-cloning
   description: >

--- a/service/test_automatic_run_experiment.py
+++ b/service/test_automatic_run_experiment.py
@@ -142,16 +142,28 @@ def test_validate_experiment_name(name, expected_result):
         ({
             'fuzzers': ['afl']
         }, False),
-        # Invalid experiment.
+        # Invalid experiment name for request.
         ({
             'experiment': 'invalid',
             'fuzzers': ['afl']
         }, False),
-        # Invalid fuzzers.
+        # Invalid experiment name.
+        ({
+            'experiment': 'i' * 100,
+            'fuzzers': ['afl']
+        }, False),
+        # Nonexistent fuzzers.
         ({
             'experiment': EXPERIMENT,
-            'fuzzers': ['1']
+            'fuzzers': ['nonexistent-fuzzer']
         }, False),
+        # Invalid fuzzers.
+        (
+            {
+                'experiment': EXPERIMENT,
+                'fuzzers': ['1']  # Need to make this exist.
+            },
+            False),
         # Invalid description.
         ({
             'experiment': EXPERIMENT,


### PR DESCRIPTION
1. Rename the invalidly named request "2021-09-16-blackboxeffectiveness"
to the valid "2021-09-23-blackboxeffect".
2. Make automatic_run_experiment uses run_experiment's
validation for experiment names and fuzzer names.
3. Log errors in automatic_run_experiment better.
4. Use the ValidationError Exception in run_experiment more.
5. Make automatic_run_experiment validate experiment types in
experiment-requests.yaml.
6. Fix issue logging locally.
7. Merge fuzzer validation in run_experiment and fuzzer_utils.
8. Validate fuzzer names better in presubmit.py