### PR TITLE
Update to make zafl failures obvious.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ docker/generated.mk
 \#*\#
 
 .vscode
+
+# Vim backup files.
+.*.swp

--- a/fuzzers/aflplusplus_zafl/fuzzer.py
+++ b/fuzzers/aflplusplus_zafl/fuzzer.py
@@ -39,7 +39,9 @@ def build():
     utils.append_flags('CXXFLAGS', ['-fPIC', '-lpthread'])
     os.environ['FUZZER_LIB'] = '/out/fakeLibrary.a'
     utils.build_benchmark()
-    os.system('bash -x /zafl_bins.sh')
+    res = os.system('bash -x /zafl_bins.sh')
+    if res != 0:
+        os.system('rm -rf /out')
 
 
 #

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -18,6 +18,16 @@
 #
 # You can run "make presubmit" to do basic validation on this file.
 # Please add new experiment requests towards the top of this file.
+#
+- experiment: 2021-10-29
+  description: "Compare Zafl to standard source-only and binary-only fuzzers."
+  fuzzers:
+    - aflplusplus
+    - aflplusplus_zafl
+    - aflplusplus_tracepc
+    - aflplusplus_qemu_tracepc
+    - aflplusplus_qemu
+
 
 - experiment: 2021-10-29-aflpp
   description: "afl++"


### PR DESCRIPTION
1) When zafl_bins.sh fails, detect this in fuzzer.py and force an rm -rf
/out to force the benchmark build to fail.  Prior shortcoming caused
benchmarks to report success when zafl failed, thus no tracing
information being created resulting in black-box fuzzing instead
of grey-box fuzzing.

2) VIM swap file in .gitignore for convenience.