### PR TITLE
Add aflplusplus_qemu_tracepc configure to workflows to get experiment to pass

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -45,6 +45,7 @@ jobs:
           - honggfuzz_qemu
           - weizz_qemu
           - aflplusplus_qemu
+          - aflplusplus_qemu_tracepc
           - aflplusplus_frida
           # Concolic execution
           - fuzzolic_aflplusplus_z3

--- a/fuzzers/aflplusplus_qemu_tracepc/builder.Dockerfile
+++ b/fuzzers/aflplusplus_qemu_tracepc/builder.Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Install the necessary packages.
+RUN apt-get update && \
+    apt-get install -y wget libstdc++-5-dev libtool-bin automake flex bison \
+                       libglib2.0-dev libpixman-1-dev python3-setuptools unzip
+
+# Why do some build images have ninja, other not? Weird.
+RUN cd / && wget https://github.com/ninja-build/ninja/releases/download/v1.10.1/ninja-linux.zip && \
+    unzip ninja-linux.zip && chmod 755 ninja && mv ninja /usr/local/bin
+
+# Download afl++
+RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
+    cd /afl && git checkout 3483715789beee1bacca26a65ab215b3d51e8b34
+    
+# Build afl++ without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && \
+    unset CFLAGS && unset CXXFLAGS && \
+    AFL_NO_X86=1 CC=clang PYTHON_INCLUDE=/ make && \
+    cd qemu_mode && ./build_qemu_support.sh && cd .. && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLQemuDriver.a /libAFLDriver.a && \
+    cp utils/aflpp_driver/aflpp_qemu_driver_hook.so /

--- a/fuzzers/aflplusplus_qemu_tracepc/description.md
+++ b/fuzzers/aflplusplus_qemu_tracepc/description.md
@@ -1,0 +1,14 @@
+# aflplusplus_qemu
+
+AFL++ fuzzer instance for binary-only fuzzing with qemu_mode.
+The following config active for all benchmarks:
+  - qemu_mode with:
+    - entrypoint set to afl_qemu_driver_stdin_input
+    - persisten mode set to afl_qemu_driver_stdin_input
+    - cmplog
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_qemu_tracepc/fuzzer.py
+++ b/fuzzers/aflplusplus_qemu_tracepc/fuzzer.py
@@ -1,0 +1,49 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for AFLplusplus fuzzer."""
+
+import os
+import subprocess
+
+from fuzzers.aflplusplus import fuzzer as aflplusplus_fuzzer
+
+
+def build():
+    """Build benchmark."""
+    aflplusplus_fuzzer.build('qemu')
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    # Get LLVMFuzzerTestOneInput address.
+    nm_proc = subprocess.run([
+        'sh', '-c',
+        'nm \'' + target_binary + '\' | grep -i \'T afl_qemu_driver_stdin\''
+    ],
+                             stdout=subprocess.PIPE,
+                             check=True)
+    target_func = "0x" + nm_proc.stdout.split()[0].decode("utf-8")
+    print('[fuzz] afl_qemu_driver_stdin_input() address =', target_func)
+
+    # Fuzzer options for qemu_mode.
+    flags = ['-Q']
+
+    os.environ['AFL_QEMU_PERSISTENT_ADDR'] = target_func
+    os.environ['AFL_ENTRYPOINT'] = target_func
+    os.environ['AFL_QEMU_PERSISTENT_CNT'] = "1000000"
+    os.environ['AFL_QEMU_DRIVER_NO_HOOK'] = "1"
+    aflplusplus_fuzzer.fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            flags=flags)

--- a/fuzzers/aflplusplus_qemu_tracepc/runner.Dockerfile
+++ b/fuzzers/aflplusplus_qemu_tracepc/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -20,6 +20,29 @@
 # Please add new experiment requests towards the top of this file.
 #
 
+- experiment: 2021-11-18-bug
+  description: "Compare Zafl to standard source-only and binary-only fuzzers (bug)."
+  type: bug
+  fuzzers:
+    - aflplusplus
+    - aflplusplus_dict2file
+    - aflplusplus_cmplog
+    - aflplusplus_zafl
+    - aflplusplus_tracepc
+    - aflplusplus_qemu_tracepc
+    - aflplusplus_qemu
+
+- experiment: 2021-11-18-coverage
+  description: "Compare Zafl to standard source-only and binary-only fuzzers (coverage)."
+  fuzzers:
+    - aflplusplus
+    - aflplusplus_dict2file
+    - aflplusplus_cmplog
+    - aflplusplus_zafl
+    - aflplusplus_tracepc
+    - aflplusplus_qemu_tracepc
+    - aflplusplus_qemu
+
 - experiment: 2021-11-16-aflbb
   description: "Evaluate fuzzer effectiveness in blackbox mode - experiment 2"
   fuzzers:


### PR DESCRIPTION
Prior experiment request resulted in this CI error when committed to master (see below).  I think this is because the merge resulted in `aflplusplus_qemu_tracpec` being a removed configuration between when I submitted the PR and when it was merged.

This PR reverts the delete and updates the experiment request, as I still need/want `aflplusplus_qemu_tracepc` (afl++/qemuw /o redqueen) for my Zafl comparisons.

```
================= 294 passed, 19 skipped, 4 warnings in 39.13s =================
ERROR:root:Encountered "No module named 'fuzzers.aflplusplus_qemu_tracepc'" while trying to import fuzzers.aflplusplus_qemu_tracepc.fuzzer. Extras: {'traceback': 'Traceback (most recent call last):\n  File "/home/runner/work/fuzzbench/fuzzbench/common/fuzzer_utils.py", line 122, in validate\n    importlib.import_module(module_name)\n  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/importlib/__init__.py", line 127, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import\n  File "<frozen importlib._bootstrap>", line 991, in _find_and_load\n  File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked\n  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed\n  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import\n  File "<frozen importlib._bootstrap>", line 991, in _find_and_load\n  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked\nModuleNotFoundError: No module named \'fuzzers.aflplusplus_qemu_tracepc\'\n'}
ERROR:root:Fuzzer: aflplusplus_qemu_tracepc is invalid. Extras: {'traceback': 'Traceback (most recent call last):\n  File "/home/runner/work/fuzzbench/fuzzbench/service/automatic_run_experiment.py", line 119, in _validate_individual_experiment_requests\n    run_experiment.validate_fuzzer(fuzzer)\n  File "/home/runner/work/fuzzbench/fuzzbench/experiment/run_experiment.py", line 175, in validate_fuzzer\n    raise ValidationError(\'Fuzzer: %s is invalid.\' % fuzzer)\nexperiment.run_experiment.ValidationError: Fuzzer: aflplusplus_qemu_tracepc is invalid.\n'}
/home/runner/work/fuzzbench/fuzzbench/service/experiment-requests.yaml is not valid.
ERROR: validate_experiment_requests failed, see errors above.
Failed checks: validate_experiment_requests
Failed.
make: *** [Makefile:60: presubmit] Error 1
```