### PR TITLE
Always define FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION

### DIFF
--- a/fuzzers/test_utils.py
+++ b/fuzzers/test_utils.py
@@ -83,9 +83,11 @@ def test_initialize_env_in_environment_without_sanitizer(fs, environ):
     utils.initialize_env()
     assert os.getenv('FUZZ_TARGET') == 'fuzzer'
     assert os.getenv('CFLAGS') == (
+        '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION '
         '-pthread -Wl,--no-as-needed -Wl,-ldl -Wl,-lm '
         '-Wno-unused-command-line-argument -O3')
     assert os.getenv('CXXFLAGS') == (
+        '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION '
         '-pthread -Wl,--no-as-needed -Wl,-ldl -Wl,-lm '
         '-Wno-unused-command-line-argument -stdlib=libc++ -O3')
 
@@ -96,11 +98,13 @@ def test_initialize_env_in_environment_with_sanitizer(fs, environ):
     utils.initialize_env()
     assert os.getenv('FUZZ_TARGET') == 'fuzzer'
     assert os.getenv('CFLAGS') == (
+        '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION '
         '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
         'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
         'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
         'unreachable,vla-bound,vptr -O1')
     assert os.getenv('CXXFLAGS') == (
+        '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION '
         '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
         'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
         'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
@@ -114,9 +118,11 @@ def test_initialize_env_in_var_without_sanitizer(fs):
     env = {}
     utils.initialize_env(env)
     assert env.get('FUZZ_TARGET') == 'fuzzer'
-    assert env.get('CFLAGS') == ('-pthread -Wl,--no-as-needed -Wl,-ldl -Wl,-lm '
+    assert env.get('CFLAGS') == ('-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION '
+                                 '-pthread -Wl,--no-as-needed -Wl,-ldl -Wl,-lm '
                                  '-Wno-unused-command-line-argument -O3')
     assert env.get('CXXFLAGS') == (
+        '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION '
         '-pthread -Wl,--no-as-needed -Wl,-ldl -Wl,-lm '
         '-Wno-unused-command-line-argument -stdlib=libc++ -O3')
 
@@ -128,11 +134,13 @@ def test_initialize_env_in_var_with_sanitizer(fs):
     utils.initialize_env(env)
     assert env.get('FUZZ_TARGET') == 'fuzzer'
     assert env.get('CFLAGS') == (
+        '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION '
         '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
         'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
         'return,returns-nonnull-attribute,shift,signed-integer-overflow,'
         'unreachable,vla-bound,vptr -O1')
     assert env.get('CXXFLAGS') == (
+        '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION '
         '-fsanitize=address -fsanitize=array-bounds,bool,builtin,enum,'
         'float-divide-by-zero,function,integer-divide-by-zero,null,object-size,'
         'return,returns-nonnull-attribute,shift,signed-integer-overflow,'

--- a/fuzzers/utils.py
+++ b/fuzzers/utils.py
@@ -50,6 +50,8 @@ NO_SANITIZER_COMPAT_CFLAGS = [
     '-Wno-unused-command-line-argument'
 ]
 
+FUZZING_CFLAGS = ['-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION']
+
 OSS_FUZZ_LIB_FUZZING_ENGINE_PATH = '/usr/lib/libFuzzingEngine.a'
 BENCHMARK_CONFIG_YAML_PATH = '/benchmark.yaml'
 
@@ -181,18 +183,20 @@ def set_compilation_flags(env=None):
 
     if get_config_value('type') == 'bug':
         append_flags('CFLAGS',
-                     SANITIZER_FLAGS + [BUGS_OPTIMIZATION_LEVEL],
+                     FUZZING_CFLAGS + SANITIZER_FLAGS +
+                     [BUGS_OPTIMIZATION_LEVEL],
                      env=env)
         append_flags('CXXFLAGS',
-                     SANITIZER_FLAGS +
+                     FUZZING_CFLAGS + SANITIZER_FLAGS +
                      [LIBCPLUSPLUS_FLAG, BUGS_OPTIMIZATION_LEVEL],
                      env=env)
     else:
         append_flags('CFLAGS',
-                     NO_SANITIZER_COMPAT_CFLAGS + [DEFAULT_OPTIMIZATION_LEVEL],
+                     FUZZING_CFLAGS + NO_SANITIZER_COMPAT_CFLAGS +
+                     [DEFAULT_OPTIMIZATION_LEVEL],
                      env=env)
         append_flags('CXXFLAGS',
-                     NO_SANITIZER_COMPAT_CFLAGS +
+                     FUZZING_CFLAGS + NO_SANITIZER_COMPAT_CFLAGS +
                      [LIBCPLUSPLUS_FLAG, DEFAULT_OPTIMIZATION_LEVEL],
                      env=env)
 


### PR DESCRIPTION
This PR makes sure that `-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION` is always present in `CFLAGS` and `CXXFLAGS` when building benchmarks. At least two benchmarks (`libxslt_xpath`, `libxml2_libxml2_xml_reader_for_file_fuzzer`) rely on this behavior, which is present in OSS-Fuzz.

This PR fixes #1300.