### PR TITLE
[benchmarks] Run apt-get upgrade in broken benchmarks

### DIFF
--- a/benchmarks/arrow_parquet-arrow-fuzz/Dockerfile
+++ b/benchmarks/arrow_parquet-arrow-fuzz/Dockerfile
@@ -18,7 +18,7 @@ FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a4
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -y -q && \
-    apt-get update -y -q && \
+    apt-get upgrade -y -q && \
     apt-get install -y -q --no-install-recommends \
         bison \
         build-essential \

--- a/benchmarks/bloaty_fuzz_target/Dockerfile
+++ b/benchmarks/bloaty_fuzz_target/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
-RUN apt-get update && apt-get install -y cmake ninja-build g++
+RUN apt-get update && apt-get upgrade -y && apt-get install -y cmake ninja-build g++
 RUN git clone --depth 1 https://github.com/google/bloaty.git bloaty
 WORKDIR bloaty
 COPY build.sh $SRC/

--- a/benchmarks/freetype2-2017/Dockerfile
+++ b/benchmarks/freetype2-2017/Dockerfile
@@ -17,6 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update &&  \
+    apt-get upgrade -y && \
     apt-get install -y \
     make \
     autoconf \


### PR DESCRIPTION
To prevent https://github.com/google/fuzzbench/issues/1304