### PR TITLE
Fix certificate error for libxml2_libxml2_xml_reader_for_file_fuzzer benchmark

### DIFF
--- a/benchmarks/libxml2_libxml2_xml_reader_for_file_fuzzer/Dockerfile
+++ b/benchmarks/libxml2_libxml2_xml_reader_for_file_fuzzer/Dockerfile
@@ -16,7 +16,9 @@
 
 FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
-RUN apt-get update && apt-get install -y make autoconf automake libtool pkg-config python-dev python3-dev
+# Upgrade to avoid certs errors
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y make autoconf automake libtool pkg-config python-dev python3-dev
 
 RUN git clone https://gitlab.gnome.org/GNOME/libxml2.git
 WORKDIR libxml2


### PR DESCRIPTION
SSL verification fails when cloning libxml2:

```
$ make build-coverage-libxml2_libxml2_xml_reader_for_file_fuzzer
...
 => ERROR [3/6] RUN git clone https://gitlab.gnome.org/GNOME/libxml2.git                                                                            0.7s
------                                                                                                                                                   
 > [3/6] RUN git clone https://gitlab.gnome.org/GNOME/libxml2.git:
#7 0.431 Cloning into 'libxml2'...
#7 0.726 fatal: unable to access 'https://gitlab.gnome.org/GNOME/libxml2.git/': server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
------
executor failed running [/bin/sh -c git clone https://gitlab.gnome.org/GNOME/libxml2.git]: exit code: 128
docker/generated.mk:2748: recipe for target '.libxml2_libxml2_xml_reader_for_file_fuzzer-project-builder' failed
make: *** [.libxml2_libxml2_xml_reader_for_file_fuzzer-project-builder] Error 1
```

