### PR TITLE
Pin MarkupSafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ google-cloud-logging==1.15.1
 google-cloud-secret-manager==2.4.0
 clusterfuzz==0.0.1a0
 Jinja2==2.11.3
+MarkupSafe==2.0.1
 numpy==1.18.1
 Orange3==3.28.0
 pandas==1.2.4


### PR DESCRIPTION
Latest version of MarkupSafe, a Jinja2 dependency, causes the following error:

```
$ make presubmit
...
Traceback (most recent call last):
  File "/home/sears/fuzzbench2/presubmit.py", line 41, in <module>
    from service import automatic_run_experiment
  File "/home/sears/fuzzbench2/service/automatic_run_experiment.py", line 32, in <module>
    from experiment import run_experiment
  File "/home/sears/fuzzbench2/experiment/run_experiment.py", line 27, in <module>
    import jinja2
  File "/home/sears/fuzzbench2/.venv/lib/python3.9/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/home/sears/fuzzbench2/.venv/lib/python3.9/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/home/sears/fuzzbench2/.venv/lib/python3.9/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/home/sears/fuzzbench2/.venv/lib/python3.9/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/home/sears/fuzzbench2/.venv/lib/python3.9/site-packages/markupsafe/__init__.py)
Makefile:60: recipe for target 'presubmit' failed
make: *** [presubmit] Error 1
```

See pallets/markupsafe#284. Alternatively, upgrade Jinja2 to >3.0.0.