### PR TITLE
Enhance local experiments

### DIFF
--- a/docs/running-a-local-experiment/running_a_local_experiment.md
+++ b/docs/running-a-local-experiment/running_a_local_experiment.md
@@ -92,6 +92,12 @@ You can optionally add:
 * `--no-dictionaries` - to skip using dictionaries across all benchmarks.
 * `--oss-fuzz-corpus` - use the latest corpora from OSS-Fuzz across all
   benchmarks (where available).
+* `--concurrent-builds N` - to limit the number of concurrent builds, useful
+  when having limited memory.
+* `--runners-cpus` - to limit the number of usable CPUs by the runner containers
+  (in which fuzzers run).
+* `--measurers-cpus` - to limit the number of usable CPUs by the measurer
+  containers.
 
 ## Viewing reports
 

--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -101,6 +101,8 @@ class Experiment:  # pylint: disable=too-many-instance-attributes
         self.experiment_name = self.config['experiment']
         self.git_hash = self.config['git_hash']
         self.concurrent_builds = self.config['concurrent_builds']
+        self.measurers_cpus = self.config['measurers_cpus']
+        self.runners_cpus = self.config['runners_cpus']
         self.preemptible = self.config.get('preemptible_runners')
 
 
@@ -164,11 +166,14 @@ def dispatcher_main():
 
     # Start measurer and scheduler in seperate threads/processes.
     scheduler_loop_thread = threading.Thread(target=scheduler.schedule_loop,
-                                             args=(experiment.config,))
+                                             args=(experiment.config,
+                                                   experiment.runners_cpus))
     scheduler_loop_thread.start()
 
     measurer_main_process = multiprocessing.Process(
-        target=measure_manager.measure_main, args=(experiment.config,))
+        target=measure_manager.measure_main,
+        args=(experiment.config, experiment.measurers_cpus,
+              experiment.runners_cpus))
 
     measurer_main_process.start()
 

--- a/experiment/dispatcher.py
+++ b/experiment/dispatcher.py
@@ -100,9 +100,6 @@ class Experiment:  # pylint: disable=too-many-instance-attributes
         self.num_trials = self.config['trials']
         self.experiment_name = self.config['experiment']
         self.git_hash = self.config['git_hash']
-        self.concurrent_builds = self.config['concurrent_builds']
-        self.measurers_cpus = self.config['measurers_cpus']
-        self.runners_cpus = self.config['runners_cpus']
         self.preemptible = self.config.get('preemptible_runners')
 
 
@@ -159,21 +156,18 @@ def dispatcher_main():
     trials = build_images_for_trials(experiment.fuzzers, experiment.benchmarks,
                                      experiment.num_trials,
                                      experiment.preemptible,
-                                     experiment.concurrent_builds)
+                                     experiment.config['concurrent_builds'])
     _initialize_trials_in_db(trials)
 
     create_work_subdirs(['experiment-folders', 'measurement-folders'])
 
     # Start measurer and scheduler in seperate threads/processes.
     scheduler_loop_thread = threading.Thread(target=scheduler.schedule_loop,
-                                             args=(experiment.config,
-                                                   experiment.runners_cpus))
+                                             args=(experiment.config,))
     scheduler_loop_thread.start()
 
     measurer_main_process = multiprocessing.Process(
-        target=measure_manager.measure_main,
-        args=(experiment.config, experiment.measurers_cpus,
-              experiment.runners_cpus))
+        target=measure_manager.measure_main, args=(experiment.config,))
 
     measurer_main_process.start()
 

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -21,13 +21,13 @@ import json
 import os
 import pathlib
 import posixpath
-import psutil
 import sys
 import tempfile
 import tarfile
 import time
 from typing import List, Set
 import queue
+import psutil
 
 from sqlalchemy import func
 from sqlalchemy import orm
@@ -92,13 +92,15 @@ def _process_init(cores_queue):
         psutil.Process().cpu_affinity([cpu])
 
 
-def measure_loop(experiment: str, max_total_time: int, measurers_cpus,
-                 runners_cpus):
+def measure_loop(experiment: str,
+                 max_total_time: int,
+                 measurers_cpus=None,
+                 runners_cpus=None):
     """Continuously measure trials for |experiment|."""
     logger.info('Start measure_loop.')
 
     pool_args = ()
-    if measurers_cpus is not None:
+    if measurers_cpus is not None and runners_cpus is not None:
         local_experiment = experiment_utils.is_local_experiment()
         if local_experiment:
             cores_queue = multiprocessing.Queue()

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -66,7 +66,7 @@ def exists_in_experiment_filestore(path: pathlib.Path) -> bool:
                               must_exist=False).retcode == 0
 
 
-def measure_main(experiment_config, measurers_cpus, runners_cpus):
+def measure_main(experiment_config):
     """Do the continuously measuring and the final measuring."""
     initialize_logs()
     logger.info('Start measuring.')
@@ -74,6 +74,8 @@ def measure_main(experiment_config, measurers_cpus, runners_cpus):
     # Start the measure loop first.
     experiment = experiment_config['experiment']
     max_total_time = experiment_config['max_total_time']
+    measurers_cpus = experiment_config['measurers_cpus']
+    runners_cpus = experiment_config['runners_cpus']
     measure_loop(experiment, max_total_time, measurers_cpus, runners_cpus)
 
     # Clean up resources.

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -102,6 +102,8 @@ def measure_loop(experiment: str, max_total_time: int, measurers_cpus,
         local_experiment = experiment_utils.is_local_experiment()
         if local_experiment:
             cores_queue = multiprocessing.Queue()
+            logger.info('Scheduling measurers from core %d to %d.' %
+                        (runners_cpus, runners_cpus + measurers_cpus - 1))
             for cpu in range(runners_cpus, runners_cpus + measurers_cpus):
                 cores_queue.put(cpu)
             pool_args = (measurers_cpus, _process_init, (cores_queue,))

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -21,6 +21,7 @@ import json
 import os
 import pathlib
 import posixpath
+import psutil
 import sys
 import tempfile
 import tarfile
@@ -65,7 +66,7 @@ def exists_in_experiment_filestore(path: pathlib.Path) -> bool:
                               must_exist=False).retcode == 0
 
 
-def measure_main(experiment_config):
+def measure_main(experiment_config, measurers_cpus, runners_cpus):
     """Do the continuously measuring and the final measuring."""
     initialize_logs()
     logger.info('Start measuring.')
@@ -73,7 +74,7 @@ def measure_main(experiment_config):
     # Start the measure loop first.
     experiment = experiment_config['experiment']
     max_total_time = experiment_config['max_total_time']
-    measure_loop(experiment, max_total_time)
+    measure_loop(experiment, max_total_time, measurers_cpus, runners_cpus)
 
     # Clean up resources.
     gc.collect()
@@ -84,11 +85,31 @@ def measure_main(experiment_config):
     logger.info('Finished measuring.')
 
 
-def measure_loop(experiment: str, max_total_time: int):
+def _process_init(cores_queue):
+    """Cpu pin for each pool process"""
+    cpu = cores_queue.get()
+    if sys.platform == 'linux':
+        psutil.Process().cpu_affinity([cpu])
+
+
+def measure_loop(experiment: str, max_total_time: int, measurers_cpus,
+                 runners_cpus):
     """Continuously measure trials for |experiment|."""
     logger.info('Start measure_loop.')
 
-    with multiprocessing.Pool() as pool, multiprocessing.Manager() as manager:
+    pool_args = ()
+    if measurers_cpus is not None:
+        local_experiment = experiment_utils.is_local_experiment()
+        if local_experiment:
+            cores_queue = multiprocessing.Queue()
+            for cpu in range(runners_cpus, runners_cpus + measurers_cpus):
+                cores_queue.put(cpu)
+            pool_args = (measurers_cpus, _process_init, (cores_queue,))
+        else:
+            pool_args = (measurers_cpus,)
+
+    with multiprocessing.Pool(
+            *pool_args) as pool, multiprocessing.Manager() as manager:
         set_up_coverage_binaries(pool, experiment)
         # Using Multiprocessing.Queue will fail with a complaint about
         # inheriting queue.

--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -53,4 +53,5 @@ docker run \
 -e LOCAL_EXPERIMENT={{local_experiment}} \
 {% if not local_experiment %}--name=runner-container {% endif %}\
 --cap-add SYS_NICE --cap-add SYS_PTRACE \
+--security-opt seccomp=unconfined \
 {{docker_image_url}} 2>&1 | tee /tmp/runner-log.txt

--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -36,6 +36,7 @@ done{% endif %}
 
 docker run \
 --privileged --cpus={{num_cpu_cores}} --rm \
+{% if local_experiment %}--cpuset-cpus={{cpuset}} {% endif %}\
 -e INSTANCE_NAME={{instance_name}} \
 -e FUZZER={{fuzzer}} \
 -e BENCHMARK={{benchmark}} \

--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -36,7 +36,7 @@ done{% endif %}
 
 docker run \
 --privileged --cpus={{num_cpu_cores}} --rm \
-{% if local_experiment %}--cpuset-cpus={{cpuset}} {% endif %}\
+{% if cpuset %}--cpuset-cpus={{cpuset}} {% endif %}\
 -e INSTANCE_NAME={{instance_name}} \
 -e FUZZER={{fuzzer}} \
 -e BENCHMARK={{benchmark}} \

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -563,24 +563,27 @@ def main():
     if concurrent_builds is not None:
         if not concurrent_builds.isdigit():
             parser.error(
-                "The concurrent build argument must be a positive number")
+                'The concurrent build argument must be a positive number')
         concurrent_builds = int(concurrent_builds)
+    runners_cpus = args.runners_cpus
+    if runners_cpus is not None:
+        if not runners_cpus.isdigit():
+            parser.error('The runners cpus argument must be a positive number')
+        runners_cpus = int(runners_cpus)
     measurers_cpus = args.measurers_cpus
     if measurers_cpus is not None:
         if not measurers_cpus.isdigit():
             parser.error(
-                "The measurers cpus argument must be a positive number")
+                'The measurers cpus argument must be a positive number')
+        if runners_cpus is None:
+            parser.error(
+                'With the measurers cpus argument you need to specity the'
+                ' runners cpus argument too')
         measurers_cpus = int(measurers_cpus)
-    runners_cpus = args.runners_cpus
-    if runners_cpus is not None:
-        if not runners_cpus.isdigit():
-            parser.error("The runners cpus argument must be a positive number")
-        runners_cpus = int(runners_cpus)
     if (runners_cpus if runners_cpus else 0) + (measurers_cpus if measurers_cpus
                                                 else 0) > os.cpu_count():
-        parser.error(
-            "The sum of runners and measurers cpus is greater than the available cpu cores (%d)"
-            % os.cpu_count())
+        parser.error('The sum of runners and measurers cpus is greater than the'
+                     ' available cpu cores (%d)' % os.cpu_count())
 
     start_experiment(args.experiment_name,
                      args.experiment_config,

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -577,7 +577,7 @@ def main():
                 'The measurers cpus argument must be a positive number')
         if runners_cpus is None:
             parser.error(
-                'With the measurers cpus argument you need to specity the'
+                'With the measurers cpus argument you need to specify the'
                 ' runners cpus argument too')
         measurers_cpus = int(measurers_cpus)
     if (runners_cpus if runners_cpus else 0) + (measurers_cpus if measurers_cpus

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -552,6 +552,8 @@ def schedule_loop(experiment_config: dict, runners_cpus):
         if local_experiment:
             runner_num_cpu_cores = experiment_config['runner_num_cpu_cores']
             processes = runners_cpus // runner_num_cpu_cores
+            logger.info('Scheduling runners from core 0 to %d.' %
+                        (processes - 1))
             cores_queue = multiprocessing.Queue()
             for cpu in range(0, runner_num_cpu_cores * processes,
                              runner_num_cpu_cores):

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -536,7 +536,7 @@ def _process_init(cores_queue):
     CPUSET = cores_queue.get()
 
 
-def schedule_loop(experiment_config: dict, runners_cpus=None):
+def schedule_loop(experiment_config: dict):
     """Continuously run the scheduler until there is nothing left to schedule.
     Note that this should not be called unless
     multiprocessing.set_start_method('spawn') was called first. Otherwise it
@@ -548,6 +548,7 @@ def schedule_loop(experiment_config: dict, runners_cpus=None):
         get_experiment_trials(experiment_config['experiment']).all())
     local_experiment = experiment_utils.is_local_experiment()
     pool_args = ()
+    runners_cpus = experiment_config['runners_cpus']
     if runners_cpus is not None:
         if local_experiment:
             runner_num_cpu_cores = experiment_config['runner_num_cpu_cores']
@@ -751,12 +752,11 @@ def main():
     })
 
     if len(sys.argv) != 2:
-        print('Usage: {} <experiment_config.yaml> [cpus]'.format(sys.argv[0]))
+        print('Usage: {} <experiment_config.yaml>'.format(sys.argv[0]))
         return 1
 
     experiment_config = yaml_utils.read(sys.argv[1])
-    runners_cpus = None if len(sys.argv) < 3 else int(sys.argv[2])
-    schedule_loop(experiment_config, runners_cpus)
+    schedule_loop(experiment_config)
 
     return 0
 

--- a/experiment/test_data/experiment-config.yaml
+++ b/experiment/test_data/experiment-config.yaml
@@ -33,5 +33,7 @@ no_dictionaries: false
 oss_fuzz_corpus: false
 description: "Test experiment"
 concurrent_builds: null
+runners_cpus: null
+measurers_cpus: null
 runner_num_cpu_cores: 1
 runner_machine_type: 'n1-standard-1'

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -108,6 +108,7 @@ done
 
 docker run \\
 --privileged --cpus=1 --rm \\
+\\
 -e INSTANCE_NAME=r-test-experiment-9 \\
 -e FUZZER=fuzzer-a \\
 -e BENCHMARK={benchmark} \\
@@ -124,6 +125,7 @@ docker run \\
 -e LOCAL_EXPERIMENT=False \\
 --name=runner-container \\
 --cap-add SYS_NICE --cap-add SYS_PTRACE \\
+--security-opt seccomp=unconfined \\
 {docker_image_url} 2>&1 | tee /tmp/runner-log.txt'''
     with mock.patch('common.benchmark_utils.get_fuzz_target',
                     return_value=expected_target):
@@ -153,6 +155,7 @@ def test_create_trial_instance_local_experiment(benchmark, expected_image,
 
 docker run \\
 --privileged --cpus=1 --rm \\
+\\
 -e INSTANCE_NAME=r-test-experiment-9 \\
 -e FUZZER=fuzzer-a \\
 -e BENCHMARK={benchmark} \\
@@ -166,6 +169,7 @@ docker run \\
 -e LOCAL_EXPERIMENT=True \\
 \\
 --cap-add SYS_NICE --cap-add SYS_PTRACE \\
+--security-opt seccomp=unconfined \\
 {docker_image_url} 2>&1 | tee /tmp/runner-log.txt'''
     _test_create_trial_instance(benchmark, expected_image, expected_target,
                                 expected_startup_script,

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ numpy==1.21.0
 MarkupSafe==2.0.1
 Orange3==3.28.0
 pandas==1.2.4
+psutil==5.9.0
 psycopg2-binary==2.8.4
 pyfakefs==3.7.1
 pytest==6.1.2


### PR DESCRIPTION
Followup to my `--concurrent-builds` PR to fix the local experiments.
Here there are several contributions:
+ Improve syscalls speed in the containers with `--security-opt seccomp=unconfined` (see the AFL++ system config script) when running runners containers
+ Pin runners and measures to specific cores with `--cpuset-cpus` for runners and psutil for measures.
+ Allow the user to specify how many cores the measures must use with `--measurers-cpus` in run_experiment.py
+ Allow the user to specify how many cores the runners must use with `--runners-cpus` in run_experiment.py

Now, for instance, I can easily run a local experiment even on my desktop without any explosion of docker or OOM with

```
PYTHONPATH=. python3 experiment/run_experiment.py \
--experiment-config foo.yaml \
--benchmarks libpng-1.2.56 jsoncpp_jsoncpp_fuzzer \
--experiment-name foo \
--concurrent-builds 2 \
--measurers-cpus 4 \
--runners-cpus 4 \
--fuzzers afl aflfast \
```
The outcome is

![Screenshot at 2022-03-17 16-00-40](https://user-images.githubusercontent.com/16168186/158839563-b5b1e22d-170d-4143-b0a3-5636d5ac4928.png)

Before was a mess with cores not used at 100% and overlapped with measurers.

I tested it with and without the new arguments and it works, but before merging you should try to start a remote experiment even if in theory I didn't touch the remote part.

