### PR TITLE
Fix arrow benchmark

### DIFF
--- a/benchmarks/arrow_parquet-arrow-fuzz/Dockerfile
+++ b/benchmarks/arrow_parquet-arrow-fuzz/Dockerfile
@@ -30,4 +30,4 @@ RUN apt-get update -y -q && \
 
 RUN git clone --depth=1 https://github.com/apache/arrow.git $SRC/arrow
 
-COPY build.sh $SRC/
+COPY build.sh thrift.patch $SRC/

--- a/benchmarks/arrow_parquet-arrow-fuzz/build.sh
+++ b/benchmarks/arrow_parquet-arrow-fuzz/build.sh
@@ -17,6 +17,12 @@
 
 set -ex
 
+# Fix thrift download.
+# This needs to be done in build.sh because the checkout happens after the
+# builder.Dockerfile completes.
+cd $SRC/arrow
+git apply ../thrift.patch || true
+cd -
 ARROW=${SRC}/arrow/cpp
 
 cd ${WORK}

--- a/benchmarks/arrow_parquet-arrow-fuzz/thrift.patch
+++ b/benchmarks/arrow_parquet-arrow-fuzz/thrift.patch
@@ -1,0 +1,22 @@
+diff --git a/cpp/cmake_modules/ThirdpartyToolchain.cmake b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+index 9c062f86a..5d04ef92c 100644
+--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+@@ -39,7 +39,7 @@ endif()
+ # ----------------------------------------------------------------------
+ # We should not use the Apache dist server for build dependencies
+ 
+-set(APACHE_MIRROR "")
++set(APACHE_MIRROR "https://archive.apache.org")
+ 
+ macro(get_apache_mirror)
+   if(APACHE_MIRROR STREQUAL "")
+@@ -1129,7 +1129,7 @@ macro(build_thrift)
+     get_apache_mirror()
+     set(
+       THRIFT_SOURCE_URL
+-      "${APACHE_MIRROR}/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz"
++      "${APACHE_MIRROR}/dist/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz"
+       )
+   endif()
+ 


### PR DESCRIPTION
Remove arrow benchmark because it no longer builds. It no longer
builds because the build process tries to download a file from
apache.org that the website no longer hosts.