### PR TITLE
Add variations of LibFuzzer to trace data flow signals

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -31,6 +31,10 @@ jobs:
           - lafintel
           - klee
           - libfuzzer
+          - libfuzzer_dataflow
+          - libfuzzer_dataflow_load
+          - libfuzzer_dataflow_store
+          - libfuzzer_dataflow_pre
           - mopt
           - neuzz
           - libafl

--- a/fuzzers/libfuzzer_dataflow/Trace-store-and-load-commands.patch
+++ b/fuzzers/libfuzzer_dataflow/Trace-store-and-load-commands.patch
@@ -1,8 +1,9 @@
-From 89cf0427a4b6195f7366a51e9e1beb92e50bb38d Mon Sep 17 00:00:00 2001
+From e7b02154a90480ed6bca8ba7203c70e7b5a27203 Mon Sep 17 00:00:00 2001
 From: Alan32Liu <donggeliu@google.com>
 Date: Wed, 23 Feb 2022 15:55:17 +1100
-Subject: [PATCH] Trace store and load commands
+Subject: [PATCH 1/2] Trace store and load commands
 
+Signed-off-by: Alan32Liu <donggeliu@google.com>
 ---
  compiler-rt/lib/fuzzer/FuzzerMain.cpp    |   2 +
  compiler-rt/lib/fuzzer/FuzzerTracePC.cpp | 108 +++++++++++++++++++++++
@@ -228,5 +229,104 @@ index af1f9d81e950..d9e82f1a92b3 100644
  }
  
 -- 
-2.35.1.574.g5d30c73bfb-goog
+2.35.1.894.gb6a874cedc-goog
+
+
+From 009c87895b13021fdcb0e28a57324621faa1a07d Mon Sep 17 00:00:00 2001
+From: Alan32Liu <donggeliu@google.com>
+Date: Wed, 23 Mar 2022 08:18:03 +1100
+Subject: [PATCH 2/2] Remove debug prints
+
+Signed-off-by: Alan32Liu <donggeliu@google.com>
+---
+ compiler-rt/lib/fuzzer/FuzzerTracePC.cpp | 33 ------------------------
+ compiler-rt/lib/fuzzer/FuzzerTracePC.h   |  1 -
+ 2 files changed, 34 deletions(-)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+index be01bc0c6510..c45178254383 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+@@ -403,9 +403,7 @@ void TracePC::HandleCmp(uintptr_t PC, T Arg1, T Arg2) {
+ ATTRIBUTE_TARGET_POPCNT ALWAYS_INLINE
+ ATTRIBUTE_NO_SANITIZE_ALL
+ void TracePC::HandleDf(uintptr_t PC, uintptr_t Addr, uintptr_t MaxPC) {
+-//fuzzer::Printf("[HandleDf] Instrumented : %lu\n", Addr);
+   uintptr_t feature = PC * MaxPC + Addr;
+-//  fuzzer::Printf("[HandleDf] Feature value: %lu\n", feature);
+   DataFlowMap.AddValue(feature);
+ }
+ 
+@@ -642,14 +640,6 @@ void TraceLoad(void *Addr) {
+ 
+   uintptr_t PCOffset = PC - main_object_start_address;
+   uintptr_t LoadOffset = LoadAddr - main_object_start_address;
+-//
+-//  fuzzer::Printf("[TraceLoad] PC                       : %lu\n", PCOffset);
+-//  fuzzer::Printf("[TraceLoad] LoadAddr                 : %lu\n", LoadAddr);
+-//  fuzzer::Printf("[TraceLoad] main_object_start_address: %lu\n",
+-//    main_object_start_address);
+-//  fuzzer::Printf("[TraceLoad] PCOffset                 : %lu\n", PCOffset);
+-//  fuzzer::Printf("[TraceLoad] LoadOffset               : %lu\n", LoadOffset);
+-//  fuzzer::Printf("[TraceLoad] main_object_size         : %lu\n", main_object_size);
+ 
+   if (PCOffset >= main_object_size) return;
+   if (LoadOffset >= main_object_size) return;
+@@ -670,14 +660,6 @@ void TraceStore(void *Addr) {
+   uintptr_t StoreAddr = reinterpret_cast<uintptr_t>(Addr);
+   uintptr_t PCOffset = PC - main_object_start_address;
+   uintptr_t StoreOffset = StoreAddr - main_object_start_address;
+-//
+-//  fuzzer::Printf("[TraceStore] PC                       : %lu\n", PCOffset);
+-//  fuzzer::Printf("[TraceStore] StoreAddr                : %lu\n", StoreAddr);
+-//  fuzzer::Printf("[TraceStore] main_object_start_address: %lu\n",
+-//    main_object_start_address);
+-//  fuzzer::Printf("[TraceStore] PCOffset                 : %lu\n", PCOffset);
+-//  fuzzer::Printf("[TraceStore] StoreOffset              : %lu\n", StoreOffset);
+-//  fuzzer::Printf("[TraceStore] main_object_size         : %lu\n", main_object_size);
+ 
+   if (PCOffset >= main_object_size) return;
+   if (StoreOffset >= main_object_size) return;
+@@ -763,27 +745,12 @@ void __sanitizer_weak_hook_memmem(void *called_pc, const void *s1, size_t len1,
+ // The code assumes that the main binary is the the first one to be iterated on.
+ int dl_iterate_phdr_callback(struct dl_phdr_info *info, size_t size,
+                                     void *data) {
+-//  PrintErrorAndExitIf(main_object_start_address != kInvalidStartAddress,
+-//                      "main_object_start_address is already set");
+-//  fuzzer::Printf("[INIT] main_object_start_address: %lu\n", main_object_start_address);
+-//  fuzzer::Printf("[INIT] main_object_size         : %lu\n", main_object_size);
+   main_object_start_address = info->dlpi_addr;
+-//  fuzzer::Printf("[UPDT] main_object_start_address: %lu\n", main_object_start_address);
+   for (int j = 0; j < info->dlpi_phnum; j++) {
+     uintptr_t end_offset =
+         info->dlpi_phdr[j].p_vaddr + info->dlpi_phdr[j].p_memsz;
+     if (main_object_size < end_offset) main_object_size = end_offset;
+-//    fuzzer::Printf("[UPDT] main_object_size         : %lu\n", main_object_size);
+   }
+-//  fuzzer::Printf("[FINL] main_object_start_address: %lu\n", main_object_start_address);
+-//  fuzzer::Printf("[FINL] main_object_size         : %lu\n", main_object_size);
+-//  uintptr_t some_code_address =
+-//      reinterpret_cast<uintptr_t>(&dl_iterate_phdr_callback);
+-//  PrintErrorAndExitIf(main_object_start_address > some_code_address,
+-//                      "main_object_start_address is above the code");
+-//  PrintErrorAndExitIf(
+-//      main_object_start_address + main_object_size < some_code_address,
+-//      "main_object_start_address + main_object_size is below the code");
+   return 1;  // we need only the first header, so return 1.
+ }
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.h b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+index d9e82f1a92b3..67eab7425097 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.h
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+@@ -295,7 +295,6 @@ TracePC::CollectFeatures(Callback HandleFeature) const {
+   }
+ 
+   // Data Flow feature
+-  //TODO: Need a flag for using DataFlowMap?
+   if (UseValueProfileMask) {
+     DataFlowMap.ForEach([&](size_t Idx) {
+       HandleFeature(static_cast<uint32_t>(FirstFeature + Idx));
+-- 
+2.35.1.894.gb6a874cedc-goog
 

--- a/fuzzers/libfuzzer_dataflow/Trace-store-and-load-commands.patch
+++ b/fuzzers/libfuzzer_dataflow/Trace-store-and-load-commands.patch
@@ -1,7 +1,7 @@
 From e7b02154a90480ed6bca8ba7203c70e7b5a27203 Mon Sep 17 00:00:00 2001
 From: Alan32Liu <donggeliu@google.com>
 Date: Wed, 23 Feb 2022 15:55:17 +1100
-Subject: [PATCH 1/2] Trace store and load commands
+Subject: [PATCH 1/3] Trace store and load commands
 
 Signed-off-by: Alan32Liu <donggeliu@google.com>
 ---
@@ -235,7 +235,7 @@ index af1f9d81e950..d9e82f1a92b3 100644
 From 009c87895b13021fdcb0e28a57324621faa1a07d Mon Sep 17 00:00:00 2001
 From: Alan32Liu <donggeliu@google.com>
 Date: Wed, 23 Mar 2022 08:18:03 +1100
-Subject: [PATCH 2/2] Remove debug prints
+Subject: [PATCH 2/3] Remove debug prints
 
 Signed-off-by: Alan32Liu <donggeliu@google.com>
 ---
@@ -327,6 +327,45 @@ index d9e82f1a92b3..67eab7425097 100644
    if (UseValueProfileMask) {
      DataFlowMap.ForEach([&](size_t Idx) {
        HandleFeature(static_cast<uint32_t>(FirstFeature + Idx));
+-- 
+2.35.1.894.gb6a874cedc-goog
+
+
+From a5e8d90b5054270936a197797924795fadfef9f5 Mon Sep 17 00:00:00 2001
+From: Alan32Liu <donggeliu@google.com>
+Date: Thu, 24 Mar 2022 16:29:12 +1100
+Subject: [PATCH 3/3] Move Initialisation to DuzzerDriver to make it more
+ generalise
+
+Signed-off-by: Alan32Liu <donggeliu@google.com>
+---
+ compiler-rt/lib/fuzzer/FuzzerDriver.cpp | 1 +
+ compiler-rt/lib/fuzzer/FuzzerMain.cpp   | 1 -
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+index 6b007f2ad45c..23299e36b5e8 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+@@ -640,6 +640,7 @@ ReadCorpora(const std::vector<std::string> &CorpusDirs,
+ }
+ 
+ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
++  fuzzer::TPC.InitializeMainObjectInformation();
+   using namespace fuzzer;
+   assert(argc && argv && "Argument pointers cannot be nullptr");
+   std::string Argv0((*argv)[0]);
+diff --git a/compiler-rt/lib/fuzzer/FuzzerMain.cpp b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
+index 761bb82ff602..120923992f9f 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerMain.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
+@@ -18,6 +18,5 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
+ }  // extern "C"
+ 
+ ATTRIBUTE_INTERFACE int main(int argc, char **argv) {
+-  fuzzer::TPC.InitializeMainObjectInformation();
+   return fuzzer::FuzzerDriver(&argc, &argv, LLVMFuzzerTestOneInput);
+ }
 -- 
 2.35.1.894.gb6a874cedc-goog
 

--- a/fuzzers/libfuzzer_dataflow/Trace-store-and-load-commands.patch
+++ b/fuzzers/libfuzzer_dataflow/Trace-store-and-load-commands.patch
@@ -1,0 +1,232 @@
+From 89cf0427a4b6195f7366a51e9e1beb92e50bb38d Mon Sep 17 00:00:00 2001
+From: Alan32Liu <donggeliu@google.com>
+Date: Wed, 23 Feb 2022 15:55:17 +1100
+Subject: [PATCH] Trace store and load commands
+
+---
+ compiler-rt/lib/fuzzer/FuzzerMain.cpp    |   2 +
+ compiler-rt/lib/fuzzer/FuzzerTracePC.cpp | 108 +++++++++++++++++++++++
+ compiler-rt/lib/fuzzer/FuzzerTracePC.h   |  15 ++++
+ 3 files changed, 125 insertions(+)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerMain.cpp b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
+index 75f2f8e75c9b..761bb82ff602 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerMain.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
+@@ -10,6 +10,7 @@
+ 
+ #include "FuzzerDefs.h"
+ #include "FuzzerPlatform.h"
++#include "FuzzerTracePC.h"
+ 
+ extern "C" {
+ // This function should be defined by the user.
+@@ -17,5 +18,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
+ }  // extern "C"
+ 
+ ATTRIBUTE_INTERFACE int main(int argc, char **argv) {
++  fuzzer::TPC.InitializeMainObjectInformation();
+   return fuzzer::FuzzerDriver(&argc, &argv, LLVMFuzzerTestOneInput);
+ }
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+index f12f7aa61bc4..be01bc0c6510 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+@@ -27,6 +27,14 @@
+ // Used by -fsanitize-coverage=stack-depth to track stack depth
+ ATTRIBUTES_INTERFACE_TLS_INITIAL_EXEC uintptr_t __sancov_lowest_stack;
+ 
++// The variables below are computed by dl_iterate_phdr_callback.
++// Main object is the executable binary containing main()
++// and most of the executable code (we assume that the target is
++// built in mostly-static mode, i.e. -dynamic_mode=off).
++const uintptr_t kInvalidStartAddress = -1;
++uintptr_t main_object_start_address = kInvalidStartAddress;
++uintptr_t main_object_size = 0;
++
+ namespace fuzzer {
+ 
+ TracePC TPC;
+@@ -392,6 +400,15 @@ void TracePC::HandleCmp(uintptr_t PC, T Arg1, T Arg2) {
+   ValueProfileMap.AddValue(PC * 128 + 64 + AbsoluteDistance);
+ }
+ 
++ATTRIBUTE_TARGET_POPCNT ALWAYS_INLINE
++ATTRIBUTE_NO_SANITIZE_ALL
++void TracePC::HandleDf(uintptr_t PC, uintptr_t Addr, uintptr_t MaxPC) {
++//fuzzer::Printf("[HandleDf] Instrumented : %lu\n", Addr);
++  uintptr_t feature = PC * MaxPC + Addr;
++//  fuzzer::Printf("[HandleDf] Feature value: %lu\n", feature);
++  DataFlowMap.AddValue(feature);
++}
++
+ ATTRIBUTE_NO_SANITIZE_MEMORY
+ static size_t InternalStrnlen(const char *S, size_t MaxLen) {
+   size_t Len = 0;
+@@ -616,6 +633,64 @@ void __sanitizer_cov_trace_gep(uintptr_t Idx) {
+   fuzzer::TPC.HandleCmp(PC, Idx, (uintptr_t)0);
+ }
+ 
++ATTRIBUTE_INTERFACE
++ATTRIBUTE_NO_SANITIZE_MEMORY
++ATTRIBUTE_TARGET_POPCNT
++void TraceLoad(void *Addr) {
++  uintptr_t PC = reinterpret_cast<uintptr_t>(GET_CALLER_PC());
++  uintptr_t LoadAddr = reinterpret_cast<uintptr_t>(Addr);
++
++  uintptr_t PCOffset = PC - main_object_start_address;
++  uintptr_t LoadOffset = LoadAddr - main_object_start_address;
++//
++//  fuzzer::Printf("[TraceLoad] PC                       : %lu\n", PCOffset);
++//  fuzzer::Printf("[TraceLoad] LoadAddr                 : %lu\n", LoadAddr);
++//  fuzzer::Printf("[TraceLoad] main_object_start_address: %lu\n",
++//    main_object_start_address);
++//  fuzzer::Printf("[TraceLoad] PCOffset                 : %lu\n", PCOffset);
++//  fuzzer::Printf("[TraceLoad] LoadOffset               : %lu\n", LoadOffset);
++//  fuzzer::Printf("[TraceLoad] main_object_size         : %lu\n", main_object_size);
++
++  if (PCOffset >= main_object_size) return;
++  if (LoadOffset >= main_object_size) return;
++  fuzzer::TPC.HandleDf(PCOffset, LoadOffset, main_object_size);
++}
++
++void __sanitizer_cov_load1(uint8_t *addr) { TraceLoad(addr); }
++void __sanitizer_cov_load2(uint16_t *addr) { TraceLoad(addr); }
++void __sanitizer_cov_load4(uint32_t *addr) { TraceLoad(addr); }
++void __sanitizer_cov_load8(uint64_t *addr) { TraceLoad(addr); }
++void __sanitizer_cov_load16(__uint128_t *addr) { TraceLoad(addr); }
++
++ATTRIBUTE_INTERFACE
++ATTRIBUTE_NO_SANITIZE_MEMORY
++ATTRIBUTE_TARGET_POPCNT
++void TraceStore(void *Addr) {
++  uintptr_t PC = reinterpret_cast<uintptr_t>(GET_CALLER_PC());
++  uintptr_t StoreAddr = reinterpret_cast<uintptr_t>(Addr);
++  uintptr_t PCOffset = PC - main_object_start_address;
++  uintptr_t StoreOffset = StoreAddr - main_object_start_address;
++//
++//  fuzzer::Printf("[TraceStore] PC                       : %lu\n", PCOffset);
++//  fuzzer::Printf("[TraceStore] StoreAddr                : %lu\n", StoreAddr);
++//  fuzzer::Printf("[TraceStore] main_object_start_address: %lu\n",
++//    main_object_start_address);
++//  fuzzer::Printf("[TraceStore] PCOffset                 : %lu\n", PCOffset);
++//  fuzzer::Printf("[TraceStore] StoreOffset              : %lu\n", StoreOffset);
++//  fuzzer::Printf("[TraceStore] main_object_size         : %lu\n", main_object_size);
++
++  if (PCOffset >= main_object_size) return;
++  if (StoreOffset >= main_object_size) return;
++
++  fuzzer::TPC.HandleDf(PCOffset, StoreOffset, main_object_size);
++}
++
++void __sanitizer_cov_store1(uint8_t *addr) { TraceStore(addr); }
++void __sanitizer_cov_store2(uint16_t *addr) { TraceStore(addr); }
++void __sanitizer_cov_store4(uint32_t *addr) { TraceStore(addr); }
++void __sanitizer_cov_store8(uint64_t *addr) { TraceStore(addr); }
++void __sanitizer_cov_store16(__uint128_t *addr) { TraceStore(addr); }
++
+ ATTRIBUTE_INTERFACE ATTRIBUTE_NO_SANITIZE_MEMORY
+ void __sanitizer_weak_hook_memcmp(void *caller_pc, const void *s1,
+                                   const void *s2, size_t n, int result) {
+@@ -682,4 +757,37 @@ void __sanitizer_weak_hook_memmem(void *called_pc, const void *s1, size_t len1,
+   if (!fuzzer::RunningUserCallback) return;
+   fuzzer::TPC.MMT.Add(reinterpret_cast<const uint8_t *>(s2), len2);
+ }
++
++// See man dl_iterate_phdr.
++// Sets main_object_start_address and main_object_size.
++// The code assumes that the main binary is the the first one to be iterated on.
++int dl_iterate_phdr_callback(struct dl_phdr_info *info, size_t size,
++                                    void *data) {
++//  PrintErrorAndExitIf(main_object_start_address != kInvalidStartAddress,
++//                      "main_object_start_address is already set");
++//  fuzzer::Printf("[INIT] main_object_start_address: %lu\n", main_object_start_address);
++//  fuzzer::Printf("[INIT] main_object_size         : %lu\n", main_object_size);
++  main_object_start_address = info->dlpi_addr;
++//  fuzzer::Printf("[UPDT] main_object_start_address: %lu\n", main_object_start_address);
++  for (int j = 0; j < info->dlpi_phnum; j++) {
++    uintptr_t end_offset =
++        info->dlpi_phdr[j].p_vaddr + info->dlpi_phdr[j].p_memsz;
++    if (main_object_size < end_offset) main_object_size = end_offset;
++//    fuzzer::Printf("[UPDT] main_object_size         : %lu\n", main_object_size);
++  }
++//  fuzzer::Printf("[FINL] main_object_start_address: %lu\n", main_object_start_address);
++//  fuzzer::Printf("[FINL] main_object_size         : %lu\n", main_object_size);
++//  uintptr_t some_code_address =
++//      reinterpret_cast<uintptr_t>(&dl_iterate_phdr_callback);
++//  PrintErrorAndExitIf(main_object_start_address > some_code_address,
++//                      "main_object_start_address is above the code");
++//  PrintErrorAndExitIf(
++//      main_object_start_address + main_object_size < some_code_address,
++//      "main_object_start_address + main_object_size is below the code");
++  return 1;  // we need only the first header, so return 1.
++}
++
++void fuzzer::TracePC::InitializeMainObjectInformation() {
++  dl_iterate_phdr(dl_iterate_phdr_callback, nullptr);
++}
+ }  // extern "C"
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.h b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+index af1f9d81e950..d9e82f1a92b3 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.h
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+@@ -11,6 +11,8 @@
+ #ifndef LLVM_FUZZER_TRACE_PC
+ #define LLVM_FUZZER_TRACE_PC
+ 
++#include <link.h>
++
+ #include "FuzzerDefs.h"
+ #include "FuzzerDictionary.h"
+ #include "FuzzerValueBitMap.h"
+@@ -73,6 +75,7 @@ class TracePC {
+   void HandlePCsInit(const uintptr_t *Start, const uintptr_t *Stop);
+   void HandleCallerCallee(uintptr_t Caller, uintptr_t Callee);
+   template <class T> void HandleCmp(uintptr_t PC, T Arg1, T Arg2);
++  void HandleDf(uintptr_t PC, uintptr_t Addr, uintptr_t MaxPC);
+   size_t GetTotalPCCoverage();
+   void SetUseCounters(bool UC) { UseCounters = UC; }
+   void SetUseValueProfileMask(uint32_t VPMask) { UseValueProfileMask = VPMask; }
+@@ -83,6 +86,7 @@ class TracePC {
+ 
+   void ResetMaps() {
+     ValueProfileMap.Reset();
++    DataFlowMap.Reset();
+     ClearExtraCounters();
+     ClearInlineCounters();
+   }
+@@ -127,6 +131,7 @@ class TracePC {
+   const PCTableEntry *PCTableEntryByIdx(uintptr_t Idx);
+   static uintptr_t GetNextInstructionPc(uintptr_t PC);
+   bool PcIsFuncEntry(const PCTableEntry *TE) { return TE->PCFlags & 1; }
++  void InitializeMainObjectInformation();
+ 
+ private:
+   bool UseCounters = false;
+@@ -175,6 +180,7 @@ private:
+   uint8_t *FocusFunctionCounterPtr = nullptr;
+ 
+   ValueBitMap ValueProfileMap;
++  ValueBitMap DataFlowMap;  // For tracing dataflow, i.e. stores and loads
+   uintptr_t InitialStack;
+ };
+ 
+@@ -288,6 +294,15 @@ TracePC::CollectFeatures(Callback HandleFeature) const {
+     FirstFeature += StackDepthStepFunction(std::numeric_limits<size_t>::max());
+   }
+ 
++  // Data Flow feature
++  //TODO: Need a flag for using DataFlowMap?
++  if (UseValueProfileMask) {
++    DataFlowMap.ForEach([&](size_t Idx) {
++      HandleFeature(static_cast<uint32_t>(FirstFeature + Idx));
++    });
++    FirstFeature += DataFlowMap.SizeInBits();
++  }
++
+   return FirstFeature;
+ }
+ 
+-- 
+2.35.1.574.g5d30c73bfb-goog
+

--- a/fuzzers/libfuzzer_dataflow/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow/builder.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fuzzers/libfuzzer_dataflow/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow/builder.Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /clang && \
 
 RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
     cd /llvm-project/ && \
-    git checkout f5153d9e72622ac83005e8bf82c4456db6f66689 && \
+    git checkout f4037650e0c74454e12b4eabd94fec06d678505f && \
     git apply /Trace-store-and-load-commands.patch && \
     cd compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \

--- a/fuzzers/libfuzzer_dataflow/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow/builder.Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+COPY Trace-store-and-load-commands.patch /
+
+ADD https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz /
+RUN mkdir /clang && \
+    tar zxvf /clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz -C /clang
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/ && \
+    git checkout f5153d9e72622ac83005e8bf82c4456db6f66689 && \
+    git apply /Trace-store-and-load-commands.patch && \
+    cd compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      /clang/bin/clang -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_dataflow/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow/fuzzer.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fuzzers/libfuzzer_dataflow/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow/fuzzer.py
@@ -24,7 +24,10 @@ def build():
     # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
     # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
     # allows us to link against a version of LibFuzzer that we specify.
-    cflags = ['-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-loads,trace-stores', '/weak.o']
+    cflags = [
+        '-fsanitize=fuzzer-no-link',
+        '-fsanitize-coverage=trace-loads,trace-stores', '/weak.o'
+    ]
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 

--- a/fuzzers/libfuzzer_dataflow/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow/fuzzer.py
@@ -24,13 +24,14 @@ def build():
     # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
     # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
     # allows us to link against a version of LibFuzzer that we specify.
-    cflags = ['-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-loads,trace-stores']
+    cflags = ['-fsanitize=fuzzer-no-link']
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 
     os.environ['CC'] = '/clang/bin/clang'
     os.environ['CXX'] = '/clang/bin/clang++'
-    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
+    os.environ['FUZZER_LIB'] = \
+        '-fsanitize-coverage=trace-loads,trace-stores /usr/lib/libFuzzer.a'
 
     utils.build_benchmark()
 

--- a/fuzzers/libfuzzer_dataflow/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow/fuzzer.py
@@ -24,14 +24,13 @@ def build():
     # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
     # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
     # allows us to link against a version of LibFuzzer that we specify.
-    cflags = ['-fsanitize=fuzzer-no-link']
+    cflags = ['-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-loads,trace-stores', '/weak.o']
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 
     os.environ['CC'] = '/clang/bin/clang'
     os.environ['CXX'] = '/clang/bin/clang++'
-    os.environ['FUZZER_LIB'] = \
-        '-fsanitize-coverage=trace-loads,trace-stores /usr/lib/libFuzzer.a'
+    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
 
     utils.build_benchmark()
 

--- a/fuzzers/libfuzzer_dataflow/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow/fuzzer.py
@@ -1,0 +1,86 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+import subprocess
+import os
+
+from fuzzers import utils
+
+
+def build():
+    """Build benchmark."""
+    # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
+    # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
+    # allows us to link against a version of LibFuzzer that we specify.
+    cflags = ['-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-loads,trace-stores']
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cflags)
+
+    os.environ['CC'] = '/clang/bin/clang'
+    os.environ['CXX'] = '/clang/bin/clang++'
+    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
+
+    utils.build_benchmark()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling
+    run_fuzzer."""
+    run_fuzzer(input_corpus,
+               output_corpus,
+               target_binary,
+               extra_flags=['-keep_seed=1', '-cross_over_uniform_dist=1'])
+
+
+def run_fuzzer(input_corpus, output_corpus, target_binary, extra_flags=None):
+    """Run fuzzer."""
+    if extra_flags is None:
+        extra_flags = []
+
+    # Seperate out corpus and crash directories as sub-directories of
+    # |output_corpus| to avoid conflicts when corpus directory is reloaded.
+    crashes_dir = os.path.join(output_corpus, 'crashes')
+    output_corpus = os.path.join(output_corpus, 'corpus')
+    os.makedirs(crashes_dir)
+    os.makedirs(output_corpus)
+
+    flags = [
+        '-print_final_stats=1',
+        # `close_fd_mask` to prevent too much logging output from the target.
+        '-close_fd_mask=3',
+        # Run in fork mode to allow ignoring ooms, timeouts, crashes and
+        # continue fuzzing indefinitely.
+        '-fork=1',
+        '-ignore_ooms=1',
+        '-ignore_timeouts=1',
+        '-ignore_crashes=1',
+
+        # Don't use LSAN's leak detection. Other fuzzers won't be using it and
+        # using it will cause libFuzzer to find "crashes" no one cares about.
+        '-detect_leaks=0',
+
+        # Store crashes along with corpus for bug based benchmarking.
+        f'-artifact_prefix={crashes_dir}/',
+    ]
+    flags += extra_flags
+    if 'ADDITIONAL_ARGS' in os.environ:
+        flags += os.environ['ADDITIONAL_ARGS'].split(' ')
+    dictionary_path = utils.get_dictionary_path(target_binary)
+    if dictionary_path:
+        flags.append('-dict=' + dictionary_path)
+
+    command = [target_binary] + flags + [output_corpus, input_corpus]
+    print('[run_fuzzer] Running command: ' + ' '.join(command))
+    subprocess.check_call(command)

--- a/fuzzers/libfuzzer_dataflow/runner.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/libfuzzer_dataflow/runner.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow/runner.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fuzzers/libfuzzer_dataflow/weak.c
+++ b/fuzzers/libfuzzer_dataflow/weak.c
@@ -1,0 +1,14 @@
+#include <stdint.h>
+
+__attribute__((weak)) void __sanitizer_cov_load1(uint8_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load2(uint16_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load4(uint32_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load8(uint64_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load16(__uint128_t *addr) {}
+
+__attribute__((weak)) void __sanitizer_cov_store1(uint8_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store2(uint16_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store4(uint32_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store8(uint64_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store16(__uint128_t *addr) {}
+

--- a/fuzzers/libfuzzer_dataflow/weak.c
+++ b/fuzzers/libfuzzer_dataflow/weak.c
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <stdint.h>
 
 __attribute__((weak)) void __sanitizer_cov_load1(uint8_t *addr) {}

--- a/fuzzers/libfuzzer_dataflow_load/Trace-store-and-load-commands.patch
+++ b/fuzzers/libfuzzer_dataflow_load/Trace-store-and-load-commands.patch
@@ -1,8 +1,9 @@
-From 89cf0427a4b6195f7366a51e9e1beb92e50bb38d Mon Sep 17 00:00:00 2001
+From e7b02154a90480ed6bca8ba7203c70e7b5a27203 Mon Sep 17 00:00:00 2001
 From: Alan32Liu <donggeliu@google.com>
 Date: Wed, 23 Feb 2022 15:55:17 +1100
-Subject: [PATCH] Trace store and load commands
+Subject: [PATCH 1/2] Trace store and load commands
 
+Signed-off-by: Alan32Liu <donggeliu@google.com>
 ---
  compiler-rt/lib/fuzzer/FuzzerMain.cpp    |   2 +
  compiler-rt/lib/fuzzer/FuzzerTracePC.cpp | 108 +++++++++++++++++++++++
@@ -228,5 +229,104 @@ index af1f9d81e950..d9e82f1a92b3 100644
  }
  
 -- 
-2.35.1.574.g5d30c73bfb-goog
+2.35.1.894.gb6a874cedc-goog
+
+
+From 009c87895b13021fdcb0e28a57324621faa1a07d Mon Sep 17 00:00:00 2001
+From: Alan32Liu <donggeliu@google.com>
+Date: Wed, 23 Mar 2022 08:18:03 +1100
+Subject: [PATCH 2/2] Remove debug prints
+
+Signed-off-by: Alan32Liu <donggeliu@google.com>
+---
+ compiler-rt/lib/fuzzer/FuzzerTracePC.cpp | 33 ------------------------
+ compiler-rt/lib/fuzzer/FuzzerTracePC.h   |  1 -
+ 2 files changed, 34 deletions(-)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+index be01bc0c6510..c45178254383 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+@@ -403,9 +403,7 @@ void TracePC::HandleCmp(uintptr_t PC, T Arg1, T Arg2) {
+ ATTRIBUTE_TARGET_POPCNT ALWAYS_INLINE
+ ATTRIBUTE_NO_SANITIZE_ALL
+ void TracePC::HandleDf(uintptr_t PC, uintptr_t Addr, uintptr_t MaxPC) {
+-//fuzzer::Printf("[HandleDf] Instrumented : %lu\n", Addr);
+   uintptr_t feature = PC * MaxPC + Addr;
+-//  fuzzer::Printf("[HandleDf] Feature value: %lu\n", feature);
+   DataFlowMap.AddValue(feature);
+ }
+ 
+@@ -642,14 +640,6 @@ void TraceLoad(void *Addr) {
+ 
+   uintptr_t PCOffset = PC - main_object_start_address;
+   uintptr_t LoadOffset = LoadAddr - main_object_start_address;
+-//
+-//  fuzzer::Printf("[TraceLoad] PC                       : %lu\n", PCOffset);
+-//  fuzzer::Printf("[TraceLoad] LoadAddr                 : %lu\n", LoadAddr);
+-//  fuzzer::Printf("[TraceLoad] main_object_start_address: %lu\n",
+-//    main_object_start_address);
+-//  fuzzer::Printf("[TraceLoad] PCOffset                 : %lu\n", PCOffset);
+-//  fuzzer::Printf("[TraceLoad] LoadOffset               : %lu\n", LoadOffset);
+-//  fuzzer::Printf("[TraceLoad] main_object_size         : %lu\n", main_object_size);
+ 
+   if (PCOffset >= main_object_size) return;
+   if (LoadOffset >= main_object_size) return;
+@@ -670,14 +660,6 @@ void TraceStore(void *Addr) {
+   uintptr_t StoreAddr = reinterpret_cast<uintptr_t>(Addr);
+   uintptr_t PCOffset = PC - main_object_start_address;
+   uintptr_t StoreOffset = StoreAddr - main_object_start_address;
+-//
+-//  fuzzer::Printf("[TraceStore] PC                       : %lu\n", PCOffset);
+-//  fuzzer::Printf("[TraceStore] StoreAddr                : %lu\n", StoreAddr);
+-//  fuzzer::Printf("[TraceStore] main_object_start_address: %lu\n",
+-//    main_object_start_address);
+-//  fuzzer::Printf("[TraceStore] PCOffset                 : %lu\n", PCOffset);
+-//  fuzzer::Printf("[TraceStore] StoreOffset              : %lu\n", StoreOffset);
+-//  fuzzer::Printf("[TraceStore] main_object_size         : %lu\n", main_object_size);
+ 
+   if (PCOffset >= main_object_size) return;
+   if (StoreOffset >= main_object_size) return;
+@@ -763,27 +745,12 @@ void __sanitizer_weak_hook_memmem(void *called_pc, const void *s1, size_t len1,
+ // The code assumes that the main binary is the the first one to be iterated on.
+ int dl_iterate_phdr_callback(struct dl_phdr_info *info, size_t size,
+                                     void *data) {
+-//  PrintErrorAndExitIf(main_object_start_address != kInvalidStartAddress,
+-//                      "main_object_start_address is already set");
+-//  fuzzer::Printf("[INIT] main_object_start_address: %lu\n", main_object_start_address);
+-//  fuzzer::Printf("[INIT] main_object_size         : %lu\n", main_object_size);
+   main_object_start_address = info->dlpi_addr;
+-//  fuzzer::Printf("[UPDT] main_object_start_address: %lu\n", main_object_start_address);
+   for (int j = 0; j < info->dlpi_phnum; j++) {
+     uintptr_t end_offset =
+         info->dlpi_phdr[j].p_vaddr + info->dlpi_phdr[j].p_memsz;
+     if (main_object_size < end_offset) main_object_size = end_offset;
+-//    fuzzer::Printf("[UPDT] main_object_size         : %lu\n", main_object_size);
+   }
+-//  fuzzer::Printf("[FINL] main_object_start_address: %lu\n", main_object_start_address);
+-//  fuzzer::Printf("[FINL] main_object_size         : %lu\n", main_object_size);
+-//  uintptr_t some_code_address =
+-//      reinterpret_cast<uintptr_t>(&dl_iterate_phdr_callback);
+-//  PrintErrorAndExitIf(main_object_start_address > some_code_address,
+-//                      "main_object_start_address is above the code");
+-//  PrintErrorAndExitIf(
+-//      main_object_start_address + main_object_size < some_code_address,
+-//      "main_object_start_address + main_object_size is below the code");
+   return 1;  // we need only the first header, so return 1.
+ }
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.h b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+index d9e82f1a92b3..67eab7425097 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.h
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+@@ -295,7 +295,6 @@ TracePC::CollectFeatures(Callback HandleFeature) const {
+   }
+ 
+   // Data Flow feature
+-  //TODO: Need a flag for using DataFlowMap?
+   if (UseValueProfileMask) {
+     DataFlowMap.ForEach([&](size_t Idx) {
+       HandleFeature(static_cast<uint32_t>(FirstFeature + Idx));
+-- 
+2.35.1.894.gb6a874cedc-goog
 

--- a/fuzzers/libfuzzer_dataflow_load/Trace-store-and-load-commands.patch
+++ b/fuzzers/libfuzzer_dataflow_load/Trace-store-and-load-commands.patch
@@ -1,7 +1,7 @@
 From e7b02154a90480ed6bca8ba7203c70e7b5a27203 Mon Sep 17 00:00:00 2001
 From: Alan32Liu <donggeliu@google.com>
 Date: Wed, 23 Feb 2022 15:55:17 +1100
-Subject: [PATCH 1/2] Trace store and load commands
+Subject: [PATCH 1/3] Trace store and load commands
 
 Signed-off-by: Alan32Liu <donggeliu@google.com>
 ---
@@ -235,7 +235,7 @@ index af1f9d81e950..d9e82f1a92b3 100644
 From 009c87895b13021fdcb0e28a57324621faa1a07d Mon Sep 17 00:00:00 2001
 From: Alan32Liu <donggeliu@google.com>
 Date: Wed, 23 Mar 2022 08:18:03 +1100
-Subject: [PATCH 2/2] Remove debug prints
+Subject: [PATCH 2/3] Remove debug prints
 
 Signed-off-by: Alan32Liu <donggeliu@google.com>
 ---
@@ -327,6 +327,45 @@ index d9e82f1a92b3..67eab7425097 100644
    if (UseValueProfileMask) {
      DataFlowMap.ForEach([&](size_t Idx) {
        HandleFeature(static_cast<uint32_t>(FirstFeature + Idx));
+-- 
+2.35.1.894.gb6a874cedc-goog
+
+
+From a5e8d90b5054270936a197797924795fadfef9f5 Mon Sep 17 00:00:00 2001
+From: Alan32Liu <donggeliu@google.com>
+Date: Thu, 24 Mar 2022 16:29:12 +1100
+Subject: [PATCH 3/3] Move Initialisation to DuzzerDriver to make it more
+ generalise
+
+Signed-off-by: Alan32Liu <donggeliu@google.com>
+---
+ compiler-rt/lib/fuzzer/FuzzerDriver.cpp | 1 +
+ compiler-rt/lib/fuzzer/FuzzerMain.cpp   | 1 -
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+index 6b007f2ad45c..23299e36b5e8 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+@@ -640,6 +640,7 @@ ReadCorpora(const std::vector<std::string> &CorpusDirs,
+ }
+ 
+ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
++  fuzzer::TPC.InitializeMainObjectInformation();
+   using namespace fuzzer;
+   assert(argc && argv && "Argument pointers cannot be nullptr");
+   std::string Argv0((*argv)[0]);
+diff --git a/compiler-rt/lib/fuzzer/FuzzerMain.cpp b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
+index 761bb82ff602..120923992f9f 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerMain.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
+@@ -18,6 +18,5 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
+ }  // extern "C"
+ 
+ ATTRIBUTE_INTERFACE int main(int argc, char **argv) {
+-  fuzzer::TPC.InitializeMainObjectInformation();
+   return fuzzer::FuzzerDriver(&argc, &argv, LLVMFuzzerTestOneInput);
+ }
 -- 
 2.35.1.894.gb6a874cedc-goog
 

--- a/fuzzers/libfuzzer_dataflow_load/Trace-store-and-load-commands.patch
+++ b/fuzzers/libfuzzer_dataflow_load/Trace-store-and-load-commands.patch
@@ -1,0 +1,232 @@
+From 89cf0427a4b6195f7366a51e9e1beb92e50bb38d Mon Sep 17 00:00:00 2001
+From: Alan32Liu <donggeliu@google.com>
+Date: Wed, 23 Feb 2022 15:55:17 +1100
+Subject: [PATCH] Trace store and load commands
+
+---
+ compiler-rt/lib/fuzzer/FuzzerMain.cpp    |   2 +
+ compiler-rt/lib/fuzzer/FuzzerTracePC.cpp | 108 +++++++++++++++++++++++
+ compiler-rt/lib/fuzzer/FuzzerTracePC.h   |  15 ++++
+ 3 files changed, 125 insertions(+)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerMain.cpp b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
+index 75f2f8e75c9b..761bb82ff602 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerMain.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
+@@ -10,6 +10,7 @@
+ 
+ #include "FuzzerDefs.h"
+ #include "FuzzerPlatform.h"
++#include "FuzzerTracePC.h"
+ 
+ extern "C" {
+ // This function should be defined by the user.
+@@ -17,5 +18,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
+ }  // extern "C"
+ 
+ ATTRIBUTE_INTERFACE int main(int argc, char **argv) {
++  fuzzer::TPC.InitializeMainObjectInformation();
+   return fuzzer::FuzzerDriver(&argc, &argv, LLVMFuzzerTestOneInput);
+ }
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+index f12f7aa61bc4..be01bc0c6510 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+@@ -27,6 +27,14 @@
+ // Used by -fsanitize-coverage=stack-depth to track stack depth
+ ATTRIBUTES_INTERFACE_TLS_INITIAL_EXEC uintptr_t __sancov_lowest_stack;
+ 
++// The variables below are computed by dl_iterate_phdr_callback.
++// Main object is the executable binary containing main()
++// and most of the executable code (we assume that the target is
++// built in mostly-static mode, i.e. -dynamic_mode=off).
++const uintptr_t kInvalidStartAddress = -1;
++uintptr_t main_object_start_address = kInvalidStartAddress;
++uintptr_t main_object_size = 0;
++
+ namespace fuzzer {
+ 
+ TracePC TPC;
+@@ -392,6 +400,15 @@ void TracePC::HandleCmp(uintptr_t PC, T Arg1, T Arg2) {
+   ValueProfileMap.AddValue(PC * 128 + 64 + AbsoluteDistance);
+ }
+ 
++ATTRIBUTE_TARGET_POPCNT ALWAYS_INLINE
++ATTRIBUTE_NO_SANITIZE_ALL
++void TracePC::HandleDf(uintptr_t PC, uintptr_t Addr, uintptr_t MaxPC) {
++//fuzzer::Printf("[HandleDf] Instrumented : %lu\n", Addr);
++  uintptr_t feature = PC * MaxPC + Addr;
++//  fuzzer::Printf("[HandleDf] Feature value: %lu\n", feature);
++  DataFlowMap.AddValue(feature);
++}
++
+ ATTRIBUTE_NO_SANITIZE_MEMORY
+ static size_t InternalStrnlen(const char *S, size_t MaxLen) {
+   size_t Len = 0;
+@@ -616,6 +633,64 @@ void __sanitizer_cov_trace_gep(uintptr_t Idx) {
+   fuzzer::TPC.HandleCmp(PC, Idx, (uintptr_t)0);
+ }
+ 
++ATTRIBUTE_INTERFACE
++ATTRIBUTE_NO_SANITIZE_MEMORY
++ATTRIBUTE_TARGET_POPCNT
++void TraceLoad(void *Addr) {
++  uintptr_t PC = reinterpret_cast<uintptr_t>(GET_CALLER_PC());
++  uintptr_t LoadAddr = reinterpret_cast<uintptr_t>(Addr);
++
++  uintptr_t PCOffset = PC - main_object_start_address;
++  uintptr_t LoadOffset = LoadAddr - main_object_start_address;
++//
++//  fuzzer::Printf("[TraceLoad] PC                       : %lu\n", PCOffset);
++//  fuzzer::Printf("[TraceLoad] LoadAddr                 : %lu\n", LoadAddr);
++//  fuzzer::Printf("[TraceLoad] main_object_start_address: %lu\n",
++//    main_object_start_address);
++//  fuzzer::Printf("[TraceLoad] PCOffset                 : %lu\n", PCOffset);
++//  fuzzer::Printf("[TraceLoad] LoadOffset               : %lu\n", LoadOffset);
++//  fuzzer::Printf("[TraceLoad] main_object_size         : %lu\n", main_object_size);
++
++  if (PCOffset >= main_object_size) return;
++  if (LoadOffset >= main_object_size) return;
++  fuzzer::TPC.HandleDf(PCOffset, LoadOffset, main_object_size);
++}
++
++void __sanitizer_cov_load1(uint8_t *addr) { TraceLoad(addr); }
++void __sanitizer_cov_load2(uint16_t *addr) { TraceLoad(addr); }
++void __sanitizer_cov_load4(uint32_t *addr) { TraceLoad(addr); }
++void __sanitizer_cov_load8(uint64_t *addr) { TraceLoad(addr); }
++void __sanitizer_cov_load16(__uint128_t *addr) { TraceLoad(addr); }
++
++ATTRIBUTE_INTERFACE
++ATTRIBUTE_NO_SANITIZE_MEMORY
++ATTRIBUTE_TARGET_POPCNT
++void TraceStore(void *Addr) {
++  uintptr_t PC = reinterpret_cast<uintptr_t>(GET_CALLER_PC());
++  uintptr_t StoreAddr = reinterpret_cast<uintptr_t>(Addr);
++  uintptr_t PCOffset = PC - main_object_start_address;
++  uintptr_t StoreOffset = StoreAddr - main_object_start_address;
++//
++//  fuzzer::Printf("[TraceStore] PC                       : %lu\n", PCOffset);
++//  fuzzer::Printf("[TraceStore] StoreAddr                : %lu\n", StoreAddr);
++//  fuzzer::Printf("[TraceStore] main_object_start_address: %lu\n",
++//    main_object_start_address);
++//  fuzzer::Printf("[TraceStore] PCOffset                 : %lu\n", PCOffset);
++//  fuzzer::Printf("[TraceStore] StoreOffset              : %lu\n", StoreOffset);
++//  fuzzer::Printf("[TraceStore] main_object_size         : %lu\n", main_object_size);
++
++  if (PCOffset >= main_object_size) return;
++  if (StoreOffset >= main_object_size) return;
++
++  fuzzer::TPC.HandleDf(PCOffset, StoreOffset, main_object_size);
++}
++
++void __sanitizer_cov_store1(uint8_t *addr) { TraceStore(addr); }
++void __sanitizer_cov_store2(uint16_t *addr) { TraceStore(addr); }
++void __sanitizer_cov_store4(uint32_t *addr) { TraceStore(addr); }
++void __sanitizer_cov_store8(uint64_t *addr) { TraceStore(addr); }
++void __sanitizer_cov_store16(__uint128_t *addr) { TraceStore(addr); }
++
+ ATTRIBUTE_INTERFACE ATTRIBUTE_NO_SANITIZE_MEMORY
+ void __sanitizer_weak_hook_memcmp(void *caller_pc, const void *s1,
+                                   const void *s2, size_t n, int result) {
+@@ -682,4 +757,37 @@ void __sanitizer_weak_hook_memmem(void *called_pc, const void *s1, size_t len1,
+   if (!fuzzer::RunningUserCallback) return;
+   fuzzer::TPC.MMT.Add(reinterpret_cast<const uint8_t *>(s2), len2);
+ }
++
++// See man dl_iterate_phdr.
++// Sets main_object_start_address and main_object_size.
++// The code assumes that the main binary is the the first one to be iterated on.
++int dl_iterate_phdr_callback(struct dl_phdr_info *info, size_t size,
++                                    void *data) {
++//  PrintErrorAndExitIf(main_object_start_address != kInvalidStartAddress,
++//                      "main_object_start_address is already set");
++//  fuzzer::Printf("[INIT] main_object_start_address: %lu\n", main_object_start_address);
++//  fuzzer::Printf("[INIT] main_object_size         : %lu\n", main_object_size);
++  main_object_start_address = info->dlpi_addr;
++//  fuzzer::Printf("[UPDT] main_object_start_address: %lu\n", main_object_start_address);
++  for (int j = 0; j < info->dlpi_phnum; j++) {
++    uintptr_t end_offset =
++        info->dlpi_phdr[j].p_vaddr + info->dlpi_phdr[j].p_memsz;
++    if (main_object_size < end_offset) main_object_size = end_offset;
++//    fuzzer::Printf("[UPDT] main_object_size         : %lu\n", main_object_size);
++  }
++//  fuzzer::Printf("[FINL] main_object_start_address: %lu\n", main_object_start_address);
++//  fuzzer::Printf("[FINL] main_object_size         : %lu\n", main_object_size);
++//  uintptr_t some_code_address =
++//      reinterpret_cast<uintptr_t>(&dl_iterate_phdr_callback);
++//  PrintErrorAndExitIf(main_object_start_address > some_code_address,
++//                      "main_object_start_address is above the code");
++//  PrintErrorAndExitIf(
++//      main_object_start_address + main_object_size < some_code_address,
++//      "main_object_start_address + main_object_size is below the code");
++  return 1;  // we need only the first header, so return 1.
++}
++
++void fuzzer::TracePC::InitializeMainObjectInformation() {
++  dl_iterate_phdr(dl_iterate_phdr_callback, nullptr);
++}
+ }  // extern "C"
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.h b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+index af1f9d81e950..d9e82f1a92b3 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.h
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+@@ -11,6 +11,8 @@
+ #ifndef LLVM_FUZZER_TRACE_PC
+ #define LLVM_FUZZER_TRACE_PC
+ 
++#include <link.h>
++
+ #include "FuzzerDefs.h"
+ #include "FuzzerDictionary.h"
+ #include "FuzzerValueBitMap.h"
+@@ -73,6 +75,7 @@ class TracePC {
+   void HandlePCsInit(const uintptr_t *Start, const uintptr_t *Stop);
+   void HandleCallerCallee(uintptr_t Caller, uintptr_t Callee);
+   template <class T> void HandleCmp(uintptr_t PC, T Arg1, T Arg2);
++  void HandleDf(uintptr_t PC, uintptr_t Addr, uintptr_t MaxPC);
+   size_t GetTotalPCCoverage();
+   void SetUseCounters(bool UC) { UseCounters = UC; }
+   void SetUseValueProfileMask(uint32_t VPMask) { UseValueProfileMask = VPMask; }
+@@ -83,6 +86,7 @@ class TracePC {
+ 
+   void ResetMaps() {
+     ValueProfileMap.Reset();
++    DataFlowMap.Reset();
+     ClearExtraCounters();
+     ClearInlineCounters();
+   }
+@@ -127,6 +131,7 @@ class TracePC {
+   const PCTableEntry *PCTableEntryByIdx(uintptr_t Idx);
+   static uintptr_t GetNextInstructionPc(uintptr_t PC);
+   bool PcIsFuncEntry(const PCTableEntry *TE) { return TE->PCFlags & 1; }
++  void InitializeMainObjectInformation();
+ 
+ private:
+   bool UseCounters = false;
+@@ -175,6 +180,7 @@ private:
+   uint8_t *FocusFunctionCounterPtr = nullptr;
+ 
+   ValueBitMap ValueProfileMap;
++  ValueBitMap DataFlowMap;  // For tracing dataflow, i.e. stores and loads
+   uintptr_t InitialStack;
+ };
+ 
+@@ -288,6 +294,15 @@ TracePC::CollectFeatures(Callback HandleFeature) const {
+     FirstFeature += StackDepthStepFunction(std::numeric_limits<size_t>::max());
+   }
+ 
++  // Data Flow feature
++  //TODO: Need a flag for using DataFlowMap?
++  if (UseValueProfileMask) {
++    DataFlowMap.ForEach([&](size_t Idx) {
++      HandleFeature(static_cast<uint32_t>(FirstFeature + Idx));
++    });
++    FirstFeature += DataFlowMap.SizeInBits();
++  }
++
+   return FirstFeature;
+ }
+ 
+-- 
+2.35.1.574.g5d30c73bfb-goog
+

--- a/fuzzers/libfuzzer_dataflow_load/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_load/builder.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fuzzers/libfuzzer_dataflow_load/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_load/builder.Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /clang && \
 
 RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
     cd /llvm-project/ && \
-    git checkout f5153d9e72622ac83005e8bf82c4456db6f66689 && \
+    git checkout f4037650e0c74454e12b4eabd94fec06d678505f && \
     git apply /Trace-store-and-load-commands.patch && \
     cd compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \

--- a/fuzzers/libfuzzer_dataflow_load/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_load/builder.Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+COPY Trace-store-and-load-commands.patch /
+
+ADD https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz /
+RUN mkdir /clang && \
+    tar zxvf /clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz -C /clang
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/ && \
+    git checkout f5153d9e72622ac83005e8bf82c4456db6f66689 && \
+    git apply /Trace-store-and-load-commands.patch && \
+    cd compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      /clang/bin/clang -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_dataflow_load/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow_load/fuzzer.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fuzzers/libfuzzer_dataflow_load/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow_load/fuzzer.py
@@ -24,13 +24,14 @@ def build():
     # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
     # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
     # allows us to link against a version of LibFuzzer that we specify.
-    cflags = ['-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-loads']
+    cflags = ['-fsanitize=fuzzer-no-link']
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 
     os.environ['CC'] = '/clang/bin/clang'
     os.environ['CXX'] = '/clang/bin/clang++'
-    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
+    os.environ['FUZZER_LIB'] = \
+        '-fsanitize-coverage=trace-loads /usr/lib/libFuzzer.a'
 
     utils.build_benchmark()
 

--- a/fuzzers/libfuzzer_dataflow_load/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow_load/fuzzer.py
@@ -1,0 +1,86 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+import subprocess
+import os
+
+from fuzzers import utils
+
+
+def build():
+    """Build benchmark."""
+    # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
+    # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
+    # allows us to link against a version of LibFuzzer that we specify.
+    cflags = ['-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-loads']
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cflags)
+
+    os.environ['CC'] = '/clang/bin/clang'
+    os.environ['CXX'] = '/clang/bin/clang++'
+    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
+
+    utils.build_benchmark()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling
+    run_fuzzer."""
+    run_fuzzer(input_corpus,
+               output_corpus,
+               target_binary,
+               extra_flags=['-keep_seed=1', '-cross_over_uniform_dist=1'])
+
+
+def run_fuzzer(input_corpus, output_corpus, target_binary, extra_flags=None):
+    """Run fuzzer."""
+    if extra_flags is None:
+        extra_flags = []
+
+    # Seperate out corpus and crash directories as sub-directories of
+    # |output_corpus| to avoid conflicts when corpus directory is reloaded.
+    crashes_dir = os.path.join(output_corpus, 'crashes')
+    output_corpus = os.path.join(output_corpus, 'corpus')
+    os.makedirs(crashes_dir)
+    os.makedirs(output_corpus)
+
+    flags = [
+        '-print_final_stats=1',
+        # `close_fd_mask` to prevent too much logging output from the target.
+        '-close_fd_mask=3',
+        # Run in fork mode to allow ignoring ooms, timeouts, crashes and
+        # continue fuzzing indefinitely.
+        '-fork=1',
+        '-ignore_ooms=1',
+        '-ignore_timeouts=1',
+        '-ignore_crashes=1',
+
+        # Don't use LSAN's leak detection. Other fuzzers won't be using it and
+        # using it will cause libFuzzer to find "crashes" no one cares about.
+        '-detect_leaks=0',
+
+        # Store crashes along with corpus for bug based benchmarking.
+        f'-artifact_prefix={crashes_dir}/',
+    ]
+    flags += extra_flags
+    if 'ADDITIONAL_ARGS' in os.environ:
+        flags += os.environ['ADDITIONAL_ARGS'].split(' ')
+    dictionary_path = utils.get_dictionary_path(target_binary)
+    if dictionary_path:
+        flags.append('-dict=' + dictionary_path)
+
+    command = [target_binary] + flags + [output_corpus, input_corpus]
+    print('[run_fuzzer] Running command: ' + ' '.join(command))
+    subprocess.check_call(command)

--- a/fuzzers/libfuzzer_dataflow_load/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow_load/fuzzer.py
@@ -24,7 +24,10 @@ def build():
     # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
     # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
     # allows us to link against a version of LibFuzzer that we specify.
-    cflags = ['-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-loads', '/weak.o']
+    cflags = [
+        '-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-loads',
+        '/weak.o'
+    ]
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 

--- a/fuzzers/libfuzzer_dataflow_load/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow_load/fuzzer.py
@@ -24,14 +24,13 @@ def build():
     # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
     # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
     # allows us to link against a version of LibFuzzer that we specify.
-    cflags = ['-fsanitize=fuzzer-no-link']
+    cflags = ['-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-loads', '/weak.o']
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 
     os.environ['CC'] = '/clang/bin/clang'
     os.environ['CXX'] = '/clang/bin/clang++'
-    os.environ['FUZZER_LIB'] = \
-        '-fsanitize-coverage=trace-loads /usr/lib/libFuzzer.a'
+    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
 
     utils.build_benchmark()
 

--- a/fuzzers/libfuzzer_dataflow_load/runner.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_load/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/libfuzzer_dataflow_load/runner.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_load/runner.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fuzzers/libfuzzer_dataflow_load/weak.c
+++ b/fuzzers/libfuzzer_dataflow_load/weak.c
@@ -1,0 +1,14 @@
+#include <stdint.h>
+
+__attribute__((weak)) void __sanitizer_cov_load1(uint8_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load2(uint16_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load4(uint32_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load8(uint64_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load16(__uint128_t *addr) {}
+
+__attribute__((weak)) void __sanitizer_cov_store1(uint8_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store2(uint16_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store4(uint32_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store8(uint64_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store16(__uint128_t *addr) {}
+

--- a/fuzzers/libfuzzer_dataflow_load/weak.c
+++ b/fuzzers/libfuzzer_dataflow_load/weak.c
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <stdint.h>
 
 __attribute__((weak)) void __sanitizer_cov_load1(uint8_t *addr) {}

--- a/fuzzers/libfuzzer_dataflow_pre/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_pre/builder.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fuzzers/libfuzzer_dataflow_pre/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_pre/builder.Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+ADD https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz /
+RUN mkdir /clang && \
+    tar zxvf /clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz -C /clang
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/ && \
+    git checkout f5153d9e72622ac83005e8bf82c4456db6f66689 && \
+    cd compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      /clang/bin/clang -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_dataflow_pre/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_pre/builder.Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /clang && \
 
 RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
     cd /llvm-project/ && \
-    git checkout f5153d9e72622ac83005e8bf82c4456db6f66689 && \
+    git checkout f4037650e0c74454e12b4eabd94fec06d678505f && \
     cd compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
       /clang/bin/clang -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \

--- a/fuzzers/libfuzzer_dataflow_pre/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow_pre/fuzzer.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fuzzers/libfuzzer_dataflow_pre/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow_pre/fuzzer.py
@@ -1,0 +1,86 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+import subprocess
+import os
+
+from fuzzers import utils
+
+
+def build():
+    """Build benchmark."""
+    # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
+    # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
+    # allows us to link against a version of LibFuzzer that we specify.
+    cflags = ['-fsanitize=fuzzer-no-link']
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cflags)
+
+    os.environ['CC'] = '/clang/bin/clang'
+    os.environ['CXX'] = '/clang/bin/clang++'
+    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
+
+    utils.build_benchmark()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling
+    run_fuzzer."""
+    run_fuzzer(input_corpus,
+               output_corpus,
+               target_binary,
+               extra_flags=['-keep_seed=1', '-cross_over_uniform_dist=1'])
+
+
+def run_fuzzer(input_corpus, output_corpus, target_binary, extra_flags=None):
+    """Run fuzzer."""
+    if extra_flags is None:
+        extra_flags = []
+
+    # Seperate out corpus and crash directories as sub-directories of
+    # |output_corpus| to avoid conflicts when corpus directory is reloaded.
+    crashes_dir = os.path.join(output_corpus, 'crashes')
+    output_corpus = os.path.join(output_corpus, 'corpus')
+    os.makedirs(crashes_dir)
+    os.makedirs(output_corpus)
+
+    flags = [
+        '-print_final_stats=1',
+        # `close_fd_mask` to prevent too much logging output from the target.
+        '-close_fd_mask=3',
+        # Run in fork mode to allow ignoring ooms, timeouts, crashes and
+        # continue fuzzing indefinitely.
+        '-fork=1',
+        '-ignore_ooms=1',
+        '-ignore_timeouts=1',
+        '-ignore_crashes=1',
+
+        # Don't use LSAN's leak detection. Other fuzzers won't be using it and
+        # using it will cause libFuzzer to find "crashes" no one cares about.
+        '-detect_leaks=0',
+
+        # Store crashes along with corpus for bug based benchmarking.
+        f'-artifact_prefix={crashes_dir}/',
+    ]
+    flags += extra_flags
+    if 'ADDITIONAL_ARGS' in os.environ:
+        flags += os.environ['ADDITIONAL_ARGS'].split(' ')
+    dictionary_path = utils.get_dictionary_path(target_binary)
+    if dictionary_path:
+        flags.append('-dict=' + dictionary_path)
+
+    command = [target_binary] + flags + [output_corpus, input_corpus]
+    print('[run_fuzzer] Running command: ' + ' '.join(command))
+    subprocess.check_call(command)

--- a/fuzzers/libfuzzer_dataflow_pre/patch.diff
+++ b/fuzzers/libfuzzer_dataflow_pre/patch.diff
@@ -1,0 +1,100 @@
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFork.cpp b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+index 84725d2..4e1a506 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFork.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+@@ -26,6 +26,8 @@
+ #include <queue>
+ #include <sstream>
+ #include <thread>
++#include <sys/stat.h>
++#include <iostream>
+ 
+ namespace fuzzer {
+ 
+@@ -70,6 +72,8 @@ struct FuzzJob {
+   std::string SeedListPath;
+   std::string CFPath;
+   size_t      JobId;
++  bool        Executing = false;
++  Vector<std::string> CopiedSeeds;
+ 
+   int         DftTimeInSeconds = 0;
+ 
+@@ -124,7 +128,6 @@ struct GlobalEnv {
+     Cmd.addFlag("reload", "0");  // working in an isolated dir, no reload.
+     Cmd.addFlag("print_final_stats", "1");
+     Cmd.addFlag("print_funcs", "0");  // no need to spend time symbolizing.
+-    Cmd.addFlag("max_total_time", std::to_string(std::min((size_t)300, JobId)));
+     Cmd.addFlag("stop_file", StopFile());
+     if (!DataFlowBinary.empty()) {
+       Cmd.addFlag("data_flow_trace", DFTDir);
+@@ -133,11 +136,10 @@ struct GlobalEnv {
+     }
+     auto Job = new FuzzJob;
+     std::string Seeds;
+-    if (size_t CorpusSubsetSize =
+-            std::min(Files.size(), (size_t)sqrt(Files.size() + 2))) {
++    if (size_t CorpusSubsetSize = Files.size()) {
+       auto Time1 = std::chrono::system_clock::now();
+       for (size_t i = 0; i < CorpusSubsetSize; i++) {
+-        auto &SF = Files[Rand->SkewTowardsLast(Files.size())];
++        auto &SF = Files[i];
+         Seeds += (Seeds.empty() ? "" : ",") + SF;
+         CollectDFT(SF);
+       }
+@@ -213,11 +215,20 @@ struct GlobalEnv {
+     Set<uint32_t> NewFeatures, NewCov;
+     CrashResistantMerge(Args, {}, MergeCandidates, &FilesToAdd, Features,
+                         &NewFeatures, Cov, &NewCov, Job->CFPath, false);
++    RemoveFile(Job->CFPath);
+     for (auto &Path : FilesToAdd) {
+-      auto U = FileToVector(Path);
+-      auto NewPath = DirPlusFile(MainCorpusDir, Hash(U));
+-      WriteToFile(U, NewPath);
+-      Files.push_back(NewPath);
++      // Only merge files that have not been merged already.
++      if (std::find(Job->CopiedSeeds.begin(), Job->CopiedSeeds.end(), Path) == Job->CopiedSeeds.end()) {
++        // NOT THREAD SAFE: Fast check whether file still exists.
++        struct stat buffer;
++        if (stat (Path.c_str(), &buffer) == 0) {
++          auto U = FileToVector(Path);
++          auto NewPath = DirPlusFile(MainCorpusDir, Hash(U));
++          WriteToFile(U, NewPath);
++          Files.push_back(NewPath);
++          Job->CopiedSeeds.push_back(Path);
++        }
++      }
+     }
+     Features.insert(NewFeatures.begin(), NewFeatures.end());
+     Cov.insert(NewCov.begin(), NewCov.end());
+@@ -271,10 +282,19 @@ struct JobQueue {
+   }
+ };
+ 
+-void WorkerThread(JobQueue *FuzzQ, JobQueue *MergeQ) {
++void WorkerThread(GlobalEnv *Env, JobQueue *FuzzQ, JobQueue *MergeQ) {
+   while (auto Job = FuzzQ->Pop()) {
+-    // Printf("WorkerThread: job %p\n", Job);
++    Job->Executing = true;
++    int Sleep_ms = 5 * 60 * 1000;
++    std::thread([=]() {
++      std::this_thread::sleep_for(std::chrono::milliseconds(Sleep_ms / 5));
++      while (Job->Executing) {
++        Env->RunOneMergeJob(Job);
++        std::this_thread::sleep_for(std::chrono::milliseconds(Sleep_ms));
++      }
++    }).detach();
+     Job->ExitCode = ExecuteCommand(Job->Cmd);
++    Job->Executing = false;
+     MergeQ->Push(Job);
+   }
+ }
+@@ -335,7 +355,7 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
+   size_t JobId = 1;
+   Vector<std::thread> Threads;
+   for (int t = 0; t < NumJobs; t++) {
+-    Threads.push_back(std::thread(WorkerThread, &FuzzQ, &MergeQ));
++    Threads.push_back(std::thread(WorkerThread, &Env, &FuzzQ, &MergeQ));
+     FuzzQ.Push(Env.CreateNewJob(JobId++));
+   }
+ 

--- a/fuzzers/libfuzzer_dataflow_pre/runner.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_pre/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/libfuzzer_dataflow_pre/runner.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_pre/runner.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/fuzzers/libfuzzer_dataflow_store/Trace-store-and-load-commands.patch
+++ b/fuzzers/libfuzzer_dataflow_store/Trace-store-and-load-commands.patch
@@ -1,8 +1,9 @@
-From 89cf0427a4b6195f7366a51e9e1beb92e50bb38d Mon Sep 17 00:00:00 2001
+From e7b02154a90480ed6bca8ba7203c70e7b5a27203 Mon Sep 17 00:00:00 2001
 From: Alan32Liu <donggeliu@google.com>
 Date: Wed, 23 Feb 2022 15:55:17 +1100
-Subject: [PATCH] Trace store and load commands
+Subject: [PATCH 1/2] Trace store and load commands
 
+Signed-off-by: Alan32Liu <donggeliu@google.com>
 ---
  compiler-rt/lib/fuzzer/FuzzerMain.cpp    |   2 +
  compiler-rt/lib/fuzzer/FuzzerTracePC.cpp | 108 +++++++++++++++++++++++
@@ -228,5 +229,104 @@ index af1f9d81e950..d9e82f1a92b3 100644
  }
  
 -- 
-2.35.1.574.g5d30c73bfb-goog
+2.35.1.894.gb6a874cedc-goog
+
+
+From 009c87895b13021fdcb0e28a57324621faa1a07d Mon Sep 17 00:00:00 2001
+From: Alan32Liu <donggeliu@google.com>
+Date: Wed, 23 Mar 2022 08:18:03 +1100
+Subject: [PATCH 2/2] Remove debug prints
+
+Signed-off-by: Alan32Liu <donggeliu@google.com>
+---
+ compiler-rt/lib/fuzzer/FuzzerTracePC.cpp | 33 ------------------------
+ compiler-rt/lib/fuzzer/FuzzerTracePC.h   |  1 -
+ 2 files changed, 34 deletions(-)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+index be01bc0c6510..c45178254383 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+@@ -403,9 +403,7 @@ void TracePC::HandleCmp(uintptr_t PC, T Arg1, T Arg2) {
+ ATTRIBUTE_TARGET_POPCNT ALWAYS_INLINE
+ ATTRIBUTE_NO_SANITIZE_ALL
+ void TracePC::HandleDf(uintptr_t PC, uintptr_t Addr, uintptr_t MaxPC) {
+-//fuzzer::Printf("[HandleDf] Instrumented : %lu\n", Addr);
+   uintptr_t feature = PC * MaxPC + Addr;
+-//  fuzzer::Printf("[HandleDf] Feature value: %lu\n", feature);
+   DataFlowMap.AddValue(feature);
+ }
+ 
+@@ -642,14 +640,6 @@ void TraceLoad(void *Addr) {
+ 
+   uintptr_t PCOffset = PC - main_object_start_address;
+   uintptr_t LoadOffset = LoadAddr - main_object_start_address;
+-//
+-//  fuzzer::Printf("[TraceLoad] PC                       : %lu\n", PCOffset);
+-//  fuzzer::Printf("[TraceLoad] LoadAddr                 : %lu\n", LoadAddr);
+-//  fuzzer::Printf("[TraceLoad] main_object_start_address: %lu\n",
+-//    main_object_start_address);
+-//  fuzzer::Printf("[TraceLoad] PCOffset                 : %lu\n", PCOffset);
+-//  fuzzer::Printf("[TraceLoad] LoadOffset               : %lu\n", LoadOffset);
+-//  fuzzer::Printf("[TraceLoad] main_object_size         : %lu\n", main_object_size);
+ 
+   if (PCOffset >= main_object_size) return;
+   if (LoadOffset >= main_object_size) return;
+@@ -670,14 +660,6 @@ void TraceStore(void *Addr) {
+   uintptr_t StoreAddr = reinterpret_cast<uintptr_t>(Addr);
+   uintptr_t PCOffset = PC - main_object_start_address;
+   uintptr_t StoreOffset = StoreAddr - main_object_start_address;
+-//
+-//  fuzzer::Printf("[TraceStore] PC                       : %lu\n", PCOffset);
+-//  fuzzer::Printf("[TraceStore] StoreAddr                : %lu\n", StoreAddr);
+-//  fuzzer::Printf("[TraceStore] main_object_start_address: %lu\n",
+-//    main_object_start_address);
+-//  fuzzer::Printf("[TraceStore] PCOffset                 : %lu\n", PCOffset);
+-//  fuzzer::Printf("[TraceStore] StoreOffset              : %lu\n", StoreOffset);
+-//  fuzzer::Printf("[TraceStore] main_object_size         : %lu\n", main_object_size);
+ 
+   if (PCOffset >= main_object_size) return;
+   if (StoreOffset >= main_object_size) return;
+@@ -763,27 +745,12 @@ void __sanitizer_weak_hook_memmem(void *called_pc, const void *s1, size_t len1,
+ // The code assumes that the main binary is the the first one to be iterated on.
+ int dl_iterate_phdr_callback(struct dl_phdr_info *info, size_t size,
+                                     void *data) {
+-//  PrintErrorAndExitIf(main_object_start_address != kInvalidStartAddress,
+-//                      "main_object_start_address is already set");
+-//  fuzzer::Printf("[INIT] main_object_start_address: %lu\n", main_object_start_address);
+-//  fuzzer::Printf("[INIT] main_object_size         : %lu\n", main_object_size);
+   main_object_start_address = info->dlpi_addr;
+-//  fuzzer::Printf("[UPDT] main_object_start_address: %lu\n", main_object_start_address);
+   for (int j = 0; j < info->dlpi_phnum; j++) {
+     uintptr_t end_offset =
+         info->dlpi_phdr[j].p_vaddr + info->dlpi_phdr[j].p_memsz;
+     if (main_object_size < end_offset) main_object_size = end_offset;
+-//    fuzzer::Printf("[UPDT] main_object_size         : %lu\n", main_object_size);
+   }
+-//  fuzzer::Printf("[FINL] main_object_start_address: %lu\n", main_object_start_address);
+-//  fuzzer::Printf("[FINL] main_object_size         : %lu\n", main_object_size);
+-//  uintptr_t some_code_address =
+-//      reinterpret_cast<uintptr_t>(&dl_iterate_phdr_callback);
+-//  PrintErrorAndExitIf(main_object_start_address > some_code_address,
+-//                      "main_object_start_address is above the code");
+-//  PrintErrorAndExitIf(
+-//      main_object_start_address + main_object_size < some_code_address,
+-//      "main_object_start_address + main_object_size is below the code");
+   return 1;  // we need only the first header, so return 1.
+ }
+ 
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.h b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+index d9e82f1a92b3..67eab7425097 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.h
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+@@ -295,7 +295,6 @@ TracePC::CollectFeatures(Callback HandleFeature) const {
+   }
+ 
+   // Data Flow feature
+-  //TODO: Need a flag for using DataFlowMap?
+   if (UseValueProfileMask) {
+     DataFlowMap.ForEach([&](size_t Idx) {
+       HandleFeature(static_cast<uint32_t>(FirstFeature + Idx));
+-- 
+2.35.1.894.gb6a874cedc-goog
 

--- a/fuzzers/libfuzzer_dataflow_store/Trace-store-and-load-commands.patch
+++ b/fuzzers/libfuzzer_dataflow_store/Trace-store-and-load-commands.patch
@@ -1,7 +1,7 @@
 From e7b02154a90480ed6bca8ba7203c70e7b5a27203 Mon Sep 17 00:00:00 2001
 From: Alan32Liu <donggeliu@google.com>
 Date: Wed, 23 Feb 2022 15:55:17 +1100
-Subject: [PATCH 1/2] Trace store and load commands
+Subject: [PATCH 1/3] Trace store and load commands
 
 Signed-off-by: Alan32Liu <donggeliu@google.com>
 ---
@@ -235,7 +235,7 @@ index af1f9d81e950..d9e82f1a92b3 100644
 From 009c87895b13021fdcb0e28a57324621faa1a07d Mon Sep 17 00:00:00 2001
 From: Alan32Liu <donggeliu@google.com>
 Date: Wed, 23 Mar 2022 08:18:03 +1100
-Subject: [PATCH 2/2] Remove debug prints
+Subject: [PATCH 2/3] Remove debug prints
 
 Signed-off-by: Alan32Liu <donggeliu@google.com>
 ---
@@ -327,6 +327,45 @@ index d9e82f1a92b3..67eab7425097 100644
    if (UseValueProfileMask) {
      DataFlowMap.ForEach([&](size_t Idx) {
        HandleFeature(static_cast<uint32_t>(FirstFeature + Idx));
+-- 
+2.35.1.894.gb6a874cedc-goog
+
+
+From a5e8d90b5054270936a197797924795fadfef9f5 Mon Sep 17 00:00:00 2001
+From: Alan32Liu <donggeliu@google.com>
+Date: Thu, 24 Mar 2022 16:29:12 +1100
+Subject: [PATCH 3/3] Move Initialisation to DuzzerDriver to make it more
+ generalise
+
+Signed-off-by: Alan32Liu <donggeliu@google.com>
+---
+ compiler-rt/lib/fuzzer/FuzzerDriver.cpp | 1 +
+ compiler-rt/lib/fuzzer/FuzzerMain.cpp   | 1 -
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+index 6b007f2ad45c..23299e36b5e8 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+@@ -640,6 +640,7 @@ ReadCorpora(const std::vector<std::string> &CorpusDirs,
+ }
+ 
+ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
++  fuzzer::TPC.InitializeMainObjectInformation();
+   using namespace fuzzer;
+   assert(argc && argv && "Argument pointers cannot be nullptr");
+   std::string Argv0((*argv)[0]);
+diff --git a/compiler-rt/lib/fuzzer/FuzzerMain.cpp b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
+index 761bb82ff602..120923992f9f 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerMain.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
+@@ -18,6 +18,5 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
+ }  // extern "C"
+ 
+ ATTRIBUTE_INTERFACE int main(int argc, char **argv) {
+-  fuzzer::TPC.InitializeMainObjectInformation();
+   return fuzzer::FuzzerDriver(&argc, &argv, LLVMFuzzerTestOneInput);
+ }
 -- 
 2.35.1.894.gb6a874cedc-goog
 

--- a/fuzzers/libfuzzer_dataflow_store/Trace-store-and-load-commands.patch
+++ b/fuzzers/libfuzzer_dataflow_store/Trace-store-and-load-commands.patch
@@ -1,0 +1,232 @@
+From 89cf0427a4b6195f7366a51e9e1beb92e50bb38d Mon Sep 17 00:00:00 2001
+From: Alan32Liu <donggeliu@google.com>
+Date: Wed, 23 Feb 2022 15:55:17 +1100
+Subject: [PATCH] Trace store and load commands
+
+---
+ compiler-rt/lib/fuzzer/FuzzerMain.cpp    |   2 +
+ compiler-rt/lib/fuzzer/FuzzerTracePC.cpp | 108 +++++++++++++++++++++++
+ compiler-rt/lib/fuzzer/FuzzerTracePC.h   |  15 ++++
+ 3 files changed, 125 insertions(+)
+
+diff --git a/compiler-rt/lib/fuzzer/FuzzerMain.cpp b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
+index 75f2f8e75c9b..761bb82ff602 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerMain.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
+@@ -10,6 +10,7 @@
+ 
+ #include "FuzzerDefs.h"
+ #include "FuzzerPlatform.h"
++#include "FuzzerTracePC.h"
+ 
+ extern "C" {
+ // This function should be defined by the user.
+@@ -17,5 +18,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
+ }  // extern "C"
+ 
+ ATTRIBUTE_INTERFACE int main(int argc, char **argv) {
++  fuzzer::TPC.InitializeMainObjectInformation();
+   return fuzzer::FuzzerDriver(&argc, &argv, LLVMFuzzerTestOneInput);
+ }
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+index f12f7aa61bc4..be01bc0c6510 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+@@ -27,6 +27,14 @@
+ // Used by -fsanitize-coverage=stack-depth to track stack depth
+ ATTRIBUTES_INTERFACE_TLS_INITIAL_EXEC uintptr_t __sancov_lowest_stack;
+ 
++// The variables below are computed by dl_iterate_phdr_callback.
++// Main object is the executable binary containing main()
++// and most of the executable code (we assume that the target is
++// built in mostly-static mode, i.e. -dynamic_mode=off).
++const uintptr_t kInvalidStartAddress = -1;
++uintptr_t main_object_start_address = kInvalidStartAddress;
++uintptr_t main_object_size = 0;
++
+ namespace fuzzer {
+ 
+ TracePC TPC;
+@@ -392,6 +400,15 @@ void TracePC::HandleCmp(uintptr_t PC, T Arg1, T Arg2) {
+   ValueProfileMap.AddValue(PC * 128 + 64 + AbsoluteDistance);
+ }
+ 
++ATTRIBUTE_TARGET_POPCNT ALWAYS_INLINE
++ATTRIBUTE_NO_SANITIZE_ALL
++void TracePC::HandleDf(uintptr_t PC, uintptr_t Addr, uintptr_t MaxPC) {
++//fuzzer::Printf("[HandleDf] Instrumented : %lu\n", Addr);
++  uintptr_t feature = PC * MaxPC + Addr;
++//  fuzzer::Printf("[HandleDf] Feature value: %lu\n", feature);
++  DataFlowMap.AddValue(feature);
++}
++
+ ATTRIBUTE_NO_SANITIZE_MEMORY
+ static size_t InternalStrnlen(const char *S, size_t MaxLen) {
+   size_t Len = 0;
+@@ -616,6 +633,64 @@ void __sanitizer_cov_trace_gep(uintptr_t Idx) {
+   fuzzer::TPC.HandleCmp(PC, Idx, (uintptr_t)0);
+ }
+ 
++ATTRIBUTE_INTERFACE
++ATTRIBUTE_NO_SANITIZE_MEMORY
++ATTRIBUTE_TARGET_POPCNT
++void TraceLoad(void *Addr) {
++  uintptr_t PC = reinterpret_cast<uintptr_t>(GET_CALLER_PC());
++  uintptr_t LoadAddr = reinterpret_cast<uintptr_t>(Addr);
++
++  uintptr_t PCOffset = PC - main_object_start_address;
++  uintptr_t LoadOffset = LoadAddr - main_object_start_address;
++//
++//  fuzzer::Printf("[TraceLoad] PC                       : %lu\n", PCOffset);
++//  fuzzer::Printf("[TraceLoad] LoadAddr                 : %lu\n", LoadAddr);
++//  fuzzer::Printf("[TraceLoad] main_object_start_address: %lu\n",
++//    main_object_start_address);
++//  fuzzer::Printf("[TraceLoad] PCOffset                 : %lu\n", PCOffset);
++//  fuzzer::Printf("[TraceLoad] LoadOffset               : %lu\n", LoadOffset);
++//  fuzzer::Printf("[TraceLoad] main_object_size         : %lu\n", main_object_size);
++
++  if (PCOffset >= main_object_size) return;
++  if (LoadOffset >= main_object_size) return;
++  fuzzer::TPC.HandleDf(PCOffset, LoadOffset, main_object_size);
++}
++
++void __sanitizer_cov_load1(uint8_t *addr) { TraceLoad(addr); }
++void __sanitizer_cov_load2(uint16_t *addr) { TraceLoad(addr); }
++void __sanitizer_cov_load4(uint32_t *addr) { TraceLoad(addr); }
++void __sanitizer_cov_load8(uint64_t *addr) { TraceLoad(addr); }
++void __sanitizer_cov_load16(__uint128_t *addr) { TraceLoad(addr); }
++
++ATTRIBUTE_INTERFACE
++ATTRIBUTE_NO_SANITIZE_MEMORY
++ATTRIBUTE_TARGET_POPCNT
++void TraceStore(void *Addr) {
++  uintptr_t PC = reinterpret_cast<uintptr_t>(GET_CALLER_PC());
++  uintptr_t StoreAddr = reinterpret_cast<uintptr_t>(Addr);
++  uintptr_t PCOffset = PC - main_object_start_address;
++  uintptr_t StoreOffset = StoreAddr - main_object_start_address;
++//
++//  fuzzer::Printf("[TraceStore] PC                       : %lu\n", PCOffset);
++//  fuzzer::Printf("[TraceStore] StoreAddr                : %lu\n", StoreAddr);
++//  fuzzer::Printf("[TraceStore] main_object_start_address: %lu\n",
++//    main_object_start_address);
++//  fuzzer::Printf("[TraceStore] PCOffset                 : %lu\n", PCOffset);
++//  fuzzer::Printf("[TraceStore] StoreOffset              : %lu\n", StoreOffset);
++//  fuzzer::Printf("[TraceStore] main_object_size         : %lu\n", main_object_size);
++
++  if (PCOffset >= main_object_size) return;
++  if (StoreOffset >= main_object_size) return;
++
++  fuzzer::TPC.HandleDf(PCOffset, StoreOffset, main_object_size);
++}
++
++void __sanitizer_cov_store1(uint8_t *addr) { TraceStore(addr); }
++void __sanitizer_cov_store2(uint16_t *addr) { TraceStore(addr); }
++void __sanitizer_cov_store4(uint32_t *addr) { TraceStore(addr); }
++void __sanitizer_cov_store8(uint64_t *addr) { TraceStore(addr); }
++void __sanitizer_cov_store16(__uint128_t *addr) { TraceStore(addr); }
++
+ ATTRIBUTE_INTERFACE ATTRIBUTE_NO_SANITIZE_MEMORY
+ void __sanitizer_weak_hook_memcmp(void *caller_pc, const void *s1,
+                                   const void *s2, size_t n, int result) {
+@@ -682,4 +757,37 @@ void __sanitizer_weak_hook_memmem(void *called_pc, const void *s1, size_t len1,
+   if (!fuzzer::RunningUserCallback) return;
+   fuzzer::TPC.MMT.Add(reinterpret_cast<const uint8_t *>(s2), len2);
+ }
++
++// See man dl_iterate_phdr.
++// Sets main_object_start_address and main_object_size.
++// The code assumes that the main binary is the the first one to be iterated on.
++int dl_iterate_phdr_callback(struct dl_phdr_info *info, size_t size,
++                                    void *data) {
++//  PrintErrorAndExitIf(main_object_start_address != kInvalidStartAddress,
++//                      "main_object_start_address is already set");
++//  fuzzer::Printf("[INIT] main_object_start_address: %lu\n", main_object_start_address);
++//  fuzzer::Printf("[INIT] main_object_size         : %lu\n", main_object_size);
++  main_object_start_address = info->dlpi_addr;
++//  fuzzer::Printf("[UPDT] main_object_start_address: %lu\n", main_object_start_address);
++  for (int j = 0; j < info->dlpi_phnum; j++) {
++    uintptr_t end_offset =
++        info->dlpi_phdr[j].p_vaddr + info->dlpi_phdr[j].p_memsz;
++    if (main_object_size < end_offset) main_object_size = end_offset;
++//    fuzzer::Printf("[UPDT] main_object_size         : %lu\n", main_object_size);
++  }
++//  fuzzer::Printf("[FINL] main_object_start_address: %lu\n", main_object_start_address);
++//  fuzzer::Printf("[FINL] main_object_size         : %lu\n", main_object_size);
++//  uintptr_t some_code_address =
++//      reinterpret_cast<uintptr_t>(&dl_iterate_phdr_callback);
++//  PrintErrorAndExitIf(main_object_start_address > some_code_address,
++//                      "main_object_start_address is above the code");
++//  PrintErrorAndExitIf(
++//      main_object_start_address + main_object_size < some_code_address,
++//      "main_object_start_address + main_object_size is below the code");
++  return 1;  // we need only the first header, so return 1.
++}
++
++void fuzzer::TracePC::InitializeMainObjectInformation() {
++  dl_iterate_phdr(dl_iterate_phdr_callback, nullptr);
++}
+ }  // extern "C"
+diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.h b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+index af1f9d81e950..d9e82f1a92b3 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.h
++++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
+@@ -11,6 +11,8 @@
+ #ifndef LLVM_FUZZER_TRACE_PC
+ #define LLVM_FUZZER_TRACE_PC
+ 
++#include <link.h>
++
+ #include "FuzzerDefs.h"
+ #include "FuzzerDictionary.h"
+ #include "FuzzerValueBitMap.h"
+@@ -73,6 +75,7 @@ class TracePC {
+   void HandlePCsInit(const uintptr_t *Start, const uintptr_t *Stop);
+   void HandleCallerCallee(uintptr_t Caller, uintptr_t Callee);
+   template <class T> void HandleCmp(uintptr_t PC, T Arg1, T Arg2);
++  void HandleDf(uintptr_t PC, uintptr_t Addr, uintptr_t MaxPC);
+   size_t GetTotalPCCoverage();
+   void SetUseCounters(bool UC) { UseCounters = UC; }
+   void SetUseValueProfileMask(uint32_t VPMask) { UseValueProfileMask = VPMask; }
+@@ -83,6 +86,7 @@ class TracePC {
+ 
+   void ResetMaps() {
+     ValueProfileMap.Reset();
++    DataFlowMap.Reset();
+     ClearExtraCounters();
+     ClearInlineCounters();
+   }
+@@ -127,6 +131,7 @@ class TracePC {
+   const PCTableEntry *PCTableEntryByIdx(uintptr_t Idx);
+   static uintptr_t GetNextInstructionPc(uintptr_t PC);
+   bool PcIsFuncEntry(const PCTableEntry *TE) { return TE->PCFlags & 1; }
++  void InitializeMainObjectInformation();
+ 
+ private:
+   bool UseCounters = false;
+@@ -175,6 +180,7 @@ private:
+   uint8_t *FocusFunctionCounterPtr = nullptr;
+ 
+   ValueBitMap ValueProfileMap;
++  ValueBitMap DataFlowMap;  // For tracing dataflow, i.e. stores and loads
+   uintptr_t InitialStack;
+ };
+ 
+@@ -288,6 +294,15 @@ TracePC::CollectFeatures(Callback HandleFeature) const {
+     FirstFeature += StackDepthStepFunction(std::numeric_limits<size_t>::max());
+   }
+ 
++  // Data Flow feature
++  //TODO: Need a flag for using DataFlowMap?
++  if (UseValueProfileMask) {
++    DataFlowMap.ForEach([&](size_t Idx) {
++      HandleFeature(static_cast<uint32_t>(FirstFeature + Idx));
++    });
++    FirstFeature += DataFlowMap.SizeInBits();
++  }
++
+   return FirstFeature;
+ }
+ 
+-- 
+2.35.1.574.g5d30c73bfb-goog
+

--- a/fuzzers/libfuzzer_dataflow_store/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_store/builder.Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /clang && \
 
 RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
     cd /llvm-project/ && \
-    git checkout f5153d9e72622ac83005e8bf82c4456db6f66689 && \
+    git checkout f4037650e0c74454e12b4eabd94fec06d678505f && \
     git apply /Trace-store-and-load-commands.patch && \
     cd compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \

--- a/fuzzers/libfuzzer_dataflow_store/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_store/builder.Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+COPY Trace-store-and-load-commands.patch /
+
+ADD https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz /
+RUN mkdir /clang && \
+    tar zxvf /clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz -C /clang
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/ && \
+    git checkout f5153d9e72622ac83005e8bf82c4456db6f66689 && \
+    git apply /Trace-store-and-load-commands.patch && \
+    cd compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      /clang/bin/clang -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_dataflow_store/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow_store/fuzzer.py
@@ -24,14 +24,13 @@ def build():
     # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
     # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
     # allows us to link against a version of LibFuzzer that we specify.
-    cflags = ['-fsanitize=fuzzer-no-link']
+    cflags = ['-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-stores', '/weak.o']
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 
     os.environ['CC'] = '/clang/bin/clang'
     os.environ['CXX'] = '/clang/bin/clang++'
-    os.environ['FUZZER_LIB'] = \
-        '-fsanitize-coverage=trace-stores /usr/lib/libFuzzer.a'
+    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
 
     utils.build_benchmark()
 

--- a/fuzzers/libfuzzer_dataflow_store/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow_store/fuzzer.py
@@ -24,7 +24,10 @@ def build():
     # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
     # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
     # allows us to link against a version of LibFuzzer that we specify.
-    cflags = ['-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-stores', '/weak.o']
+    cflags = [
+        '-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-stores',
+        '/weak.o'
+    ]
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 

--- a/fuzzers/libfuzzer_dataflow_store/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow_store/fuzzer.py
@@ -24,13 +24,14 @@ def build():
     # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
     # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
     # allows us to link against a version of LibFuzzer that we specify.
-    cflags = ['-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-stores']
+    cflags = ['-fsanitize=fuzzer-no-link']
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 
     os.environ['CC'] = '/clang/bin/clang'
     os.environ['CXX'] = '/clang/bin/clang++'
-    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
+    os.environ['FUZZER_LIB'] = \
+        '-fsanitize-coverage=trace-stores /usr/lib/libFuzzer.a'
 
     utils.build_benchmark()
 

--- a/fuzzers/libfuzzer_dataflow_store/fuzzer.py
+++ b/fuzzers/libfuzzer_dataflow_store/fuzzer.py
@@ -1,0 +1,86 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+import subprocess
+import os
+
+from fuzzers import utils
+
+
+def build():
+    """Build benchmark."""
+    # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
+    # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
+    # allows us to link against a version of LibFuzzer that we specify.
+    cflags = ['-fsanitize=fuzzer-no-link', '-fsanitize-coverage=trace-stores']
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cflags)
+
+    os.environ['CC'] = '/clang/bin/clang'
+    os.environ['CXX'] = '/clang/bin/clang++'
+    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
+
+    utils.build_benchmark()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling
+    run_fuzzer."""
+    run_fuzzer(input_corpus,
+               output_corpus,
+               target_binary,
+               extra_flags=['-keep_seed=1', '-cross_over_uniform_dist=1'])
+
+
+def run_fuzzer(input_corpus, output_corpus, target_binary, extra_flags=None):
+    """Run fuzzer."""
+    if extra_flags is None:
+        extra_flags = []
+
+    # Seperate out corpus and crash directories as sub-directories of
+    # |output_corpus| to avoid conflicts when corpus directory is reloaded.
+    crashes_dir = os.path.join(output_corpus, 'crashes')
+    output_corpus = os.path.join(output_corpus, 'corpus')
+    os.makedirs(crashes_dir)
+    os.makedirs(output_corpus)
+
+    flags = [
+        '-print_final_stats=1',
+        # `close_fd_mask` to prevent too much logging output from the target.
+        '-close_fd_mask=3',
+        # Run in fork mode to allow ignoring ooms, timeouts, crashes and
+        # continue fuzzing indefinitely.
+        '-fork=1',
+        '-ignore_ooms=1',
+        '-ignore_timeouts=1',
+        '-ignore_crashes=1',
+
+        # Don't use LSAN's leak detection. Other fuzzers won't be using it and
+        # using it will cause libFuzzer to find "crashes" no one cares about.
+        '-detect_leaks=0',
+
+        # Store crashes along with corpus for bug based benchmarking.
+        f'-artifact_prefix={crashes_dir}/',
+    ]
+    flags += extra_flags
+    if 'ADDITIONAL_ARGS' in os.environ:
+        flags += os.environ['ADDITIONAL_ARGS'].split(' ')
+    dictionary_path = utils.get_dictionary_path(target_binary)
+    if dictionary_path:
+        flags.append('-dict=' + dictionary_path)
+
+    command = [target_binary] + flags + [output_corpus, input_corpus]
+    print('[run_fuzzer] Running command: ' + ' '.join(command))
+    subprocess.check_call(command)

--- a/fuzzers/libfuzzer_dataflow_store/runner.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_store/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image

--- a/fuzzers/libfuzzer_dataflow_store/weak.c
+++ b/fuzzers/libfuzzer_dataflow_store/weak.c
@@ -1,0 +1,14 @@
+#include <stdint.h>
+
+__attribute__((weak)) void __sanitizer_cov_load1(uint8_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load2(uint16_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load4(uint32_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load8(uint64_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load16(__uint128_t *addr) {}
+
+__attribute__((weak)) void __sanitizer_cov_store1(uint8_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store2(uint16_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store4(uint32_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store8(uint64_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store16(__uint128_t *addr) {}
+

--- a/fuzzers/libfuzzer_dataflow_store/weak.c
+++ b/fuzzers/libfuzzer_dataflow_store/weak.c
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <stdint.h>
 
 __attribute__((weak)) void __sanitizer_cov_load1(uint8_t *addr) {}


### PR DESCRIPTION
This PR allows private experiments on four new variations of `LibFuzzer` related to dataflow signal tracing:

1. `LibFuzzer_dataflow` traces both `store` and `load` signals;
2. `LibFuzzer_dataflow_store` traces `store` signals only;
3. `LibFuzzer_dataflow_load` traces `load` signals only;
4. `LibFuzzer_dataflow_pre` is the version of `LibFuzzer` (from `llvm-project`) right before applying the patch (i.e. a control group).

All patch files (`fuzzers/libfuzzer_dataflow*/Trace-store-and-load-commands.patch`) are identical: They are the changes from the [`trace_data_flow` PR in `llvm-project`](https://github.com/Alan32Liu/llvm-llvm-project/pull/1).
The only difference between these variations is the `-fsanitize-coverage` param they use (e.g. `-fsanitize-coverage=trace-loads,trace-stores`)

Note that all of them only tracks dataflow of global variables for now.
