### PR TITLE
New option for custom seed corpus

### DIFF
--- a/common/experiment_utils.py
+++ b/common/experiment_utils.py
@@ -72,6 +72,12 @@ def get_oss_fuzz_corpora_filestore_path():
     return posixpath.join(get_experiment_filestore_path(), 'oss_fuzz_corpora')
 
 
+def get_custom_seed_corpora_filestore_path():
+    """Returns path containing the user-provided seed corpora."""
+    return posixpath.join(get_experiment_filestore_path(),
+                          'custom_seed_corpora')
+
+
 def get_dispatcher_instance_name(experiment: str) -> str:
     """Returns a dispatcher instance name for an experiment."""
     return 'd-%s' % experiment

--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -46,6 +46,7 @@ docker run \
 -e NO_SEEDS={{no_seeds}} \
 -e NO_DICTIONARIES={{no_dictionaries}} \
 -e OSS_FUZZ_CORPUS={{oss_fuzz_corpus}} \
+-e CUSTOM_SEED_CORPUS_DIR={{custom_seed_corpus_dir}} \
 -e DOCKER_REGISTRY={{docker_registry}} {% if not local_experiment %}-e CLOUD_PROJECT={{cloud_project}} -e CLOUD_COMPUTE_ZONE={{cloud_compute_zone}} {% endif %}\
 -e EXPERIMENT_FILESTORE={{experiment_filestore}} {% if local_experiment %}-v {{experiment_filestore}}:{{experiment_filestore}} {% endif %}\
 -e REPORT_FILESTORE={{report_filestore}} {% if local_experiment %}-v {{report_filestore}}:{{report_filestore}} {% endif %}\

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -22,7 +22,6 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import zipfile
 from typing import Dict, List
 
 import jinja2
@@ -39,7 +38,6 @@ from common import logs
 from common import new_process
 from common import utils
 from common import yaml_utils
-from experiment import runner
 
 BENCHMARKS_DIR = os.path.join(utils.ROOT_DIR, 'benchmarks')
 FUZZERS_DIR = os.path.join(utils.ROOT_DIR, 'fuzzers')

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -150,6 +150,20 @@ def get_directories(parent_dir):
     ]
 
 
+def get_custom_corpus_valid_files(benchmark_corpus_dir: str):
+    """Walk through custom corpus and skip invalid files"""
+    valid_corpus_files = set()
+    for root, _, files in os.walk(benchmark_corpus_dir):
+        for filename in files:
+            file_path = os.path.join(root, filename)
+            file_size = os.path.getsize(file_path)
+
+            if file_size == 0 or file_size > runner.CORPUS_ELEMENT_BYTES_LIMIT:
+                continue
+            valid_corpus_files.add(file_path)
+    return valid_corpus_files
+
+
 # pylint: disable=too-many-locals
 def validate_and_pack_custom_seed_corpus(custom_seed_corpus_dir, benchmarks):
     """Validate and archive seed corpus provided by user"""
@@ -168,17 +182,7 @@ def validate_and_pack_custom_seed_corpus(custom_seed_corpus_dir, benchmarks):
         if not os.listdir(benchmark_corpus_dir):
             raise ValidationError('Seed corpus of benchmark "%s" is empty.' %
                                   benchmark)
-
-        valid_corpus_files = set()
-        for root, _, files in os.walk(benchmark_corpus_dir):
-            for filename in files:
-                file_path = os.path.join(root, filename)
-                file_size = os.path.getsize(file_path)
-
-                if file_size == 0 or file_size > runner.CORPUS_ELEMENT_BYTES_LIMIT:
-                    continue
-                valid_corpus_files.add(file_path)
-
+        valid_corpus_files = get_custom_corpus_valid_files(benchmark_corpus_dir)
         if not valid_corpus_files:
             raise ValidationError('No valid corpus files for "%s"' % benchmark)
 

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -121,11 +121,9 @@ def _copy_custom_seed_corpus(corpus_directory):
     benchmark = environment.get('BENCHMARK')
     benchmark_custom_corpus_dir = posixpath.join(
         experiment_utils.get_custom_seed_corpora_filestore_path(), benchmark)
-    idx = 0
     filestore_utils.cp(benchmark_custom_corpus_dir,
                        corpus_directory,
                        recursive=True)
-    logs.info('Unarchived %d files from custom seed corpus.', idx)
 
 
 def _unpack_clusterfuzz_seed_corpus(fuzz_target_path, corpus_directory):

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -115,6 +115,33 @@ def get_clusterfuzz_seed_corpus_path(fuzz_target_path):
     return seed_corpus_path if os.path.exists(seed_corpus_path) else None
 
 
+def _unpack_custom_seed_corpus(corpus_directory):
+    "Unpack seed corpus provided by user"
+    # remove initial seed corpus
+    shutil.rmtree(corpus_directory)
+    os.mkdir(corpus_directory)
+    benchmark = environment.get('BENCHMARK')
+    corpus_archive_filename = posixpath.join(
+        experiment_utils.get_custom_seed_corpora_filestore_path(),
+        f'{benchmark}.zip')
+    idx = 0
+    with zipfile.ZipFile(corpus_archive_filename) as zip_file:
+        for seed_corpus_file in zip_file.infolist():
+            if seed_corpus_file.filename.endswith('/'):
+                # Ignore directories.
+                continue
+
+            if seed_corpus_file.file_size > CORPUS_ELEMENT_BYTES_LIMIT:
+                continue
+
+            output_filename = '%016d' % idx
+            output_file_path = os.path.join(corpus_directory, output_filename)
+            zip_file.extract(seed_corpus_file, output_file_path)
+            idx += 1
+
+    logs.info('Unarchived %d files from custom seed corpus.', idx)
+
+
 def _unpack_clusterfuzz_seed_corpus(fuzz_target_path, corpus_directory):
     """If a clusterfuzz seed corpus archive is available, unpack it into the
     corpus directory if it exists. Copied from unpack_seed_corpus in
@@ -172,7 +199,10 @@ def run_fuzzer(max_total_time, log_filename):
         logs.error('Fuzz target binary not found.')
         return
 
-    _unpack_clusterfuzz_seed_corpus(target_binary, input_corpus)
+    if environment.get('CUSTOM_SEED_CORPUS_DIR'):
+        _unpack_custom_seed_corpus(input_corpus)
+    else:
+        _unpack_clusterfuzz_seed_corpus(target_binary, input_corpus)
     _clean_seed_corpus(input_corpus)
 
     if max_total_time is None:

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -719,6 +719,7 @@ def render_startup_script_template(  # pylint: disable=too-many-arguments
         'oss_fuzz_corpus': experiment_config['oss_fuzz_corpus'],
         'num_cpu_cores': experiment_config['runner_num_cpu_cores'],
         'cpuset': cpuset,
+        'custom_seed_corpus_dir': experiment_config['custom_seed_corpus_dir'],
     }
 
     if not local_experiment:

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -718,7 +718,7 @@ def render_startup_script_template(  # pylint: disable=too-many-arguments
         'no_dictionaries': experiment_config['no_dictionaries'],
         'oss_fuzz_corpus': experiment_config['oss_fuzz_corpus'],
         'num_cpu_cores': experiment_config['runner_num_cpu_cores'],
-        'cpuset': CPUSET,
+        'cpuset': cpuset,
         'custom_seed_corpus_dir': experiment_config['custom_seed_corpus_dir'],
     }
 

--- a/experiment/test_data/experiment-config.yaml
+++ b/experiment/test_data/experiment-config.yaml
@@ -31,6 +31,7 @@ git_hash: "git-hash"
 no_seeds: false
 no_dictionaries: false
 oss_fuzz_corpus: false
+custom_seed_corpus_dir: null
 description: "Test experiment"
 concurrent_builds: null
 runners_cpus: null

--- a/experiment/test_run_experiment.py
+++ b/experiment/test_run_experiment.py
@@ -202,6 +202,7 @@ def test_copy_resources_to_bucket(tmp_path):
         'experiment': 'experiment',
         'benchmarks': ['libxslt_xpath'],
         'oss_fuzz_corpus': True,
+        'custom_seed_corpus_dir': None,
     }
     try:
         with mock.patch('common.filestore_utils.cp') as mocked_filestore_cp:

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -118,6 +118,7 @@ docker run \\
 -e NO_SEEDS=False \\
 -e NO_DICTIONARIES=False \\
 -e OSS_FUZZ_CORPUS=False \\
+-e CUSTOM_SEED_CORPUS_DIR=None \\
 -e DOCKER_REGISTRY=gcr.io/fuzzbench -e CLOUD_PROJECT=fuzzbench -e CLOUD_COMPUTE_ZONE=us-central1-a \\
 -e EXPERIMENT_FILESTORE=gs://experiment-data \\
 -e REPORT_FILESTORE=gs://web-reports \\


### PR DESCRIPTION
I'd like to add new experiment option `custom_seed_corpus_dir` to fuzzbench. This option enables users to run an experiment with custom seed corpus. To use this option, one has to set --custom-seed-corpus-dir to path that has input files for the running benchmarks.

For example:
```
PYTHONPATH=. python3 experiment/run_experiment.py  \
--experiment-config /tmp/local-experiment-config.yaml \
--experiment-name demo-exp \
--fuzzers  afl libfuzzer \
--benchmarks libjpeg-turbo-07-2017 sqlite3_ossfuzz \
--custom-seed-corpus-dir /local/my-custom-corpora 
```

and the `/local/my-custom-corpora` must have the following content:
```
|— my-custom-corpora 
|    |— sqlite3_ossfuzz  
|    |    |— fbeb1de0be72d83ed8dff924fd9df8cedb0a7497
|    |    |— fba1b82f6612e8e1d1786b757dfeecbbfabeeca5
|    |— libjpeg-turbo-07-2017
|    |    |— f78602c270b787d3e7e940f50f78365552d5a20b
|    |    |— ebc89a181d637f6bdfdcaa9d647cfd1f88d62675
|    |    |— ed0fbdb5c9f7d2fbb1c6c8e0665e80b110ba1e14
```

I'm not sure if there is already an option that does the similar thing. But If not, it think this new option would be useful to have as sometime we need to run experiment with some sort of special seed inputs. 