### PR TITLE
AFL splicing mutation experiment

### DIFF
--- a/fuzzers/afl_splicing_mutation/builder.Dockerfile
+++ b/fuzzers/afl_splicing_mutation/builder.Dockerfile
@@ -19,7 +19,7 @@ FROM $parent_image
 # Set AFL_NO_X86 to skip flaky tests.
 RUN git clone https://github.com/andreafioraldi/AFL-exp.git /afl && \
     cd /afl && \
-    git checkout f2b1e59aff2c952235fd791edcaf7deb7ee29af2 && \
+    git checkout de4433fdb0c894aa305ea142c1efd4215b96b2c5 && \
     CFLAGS="-DSPLICING_MUTATION=1" AFL_NO_X86=1 make
 
 # Use afl_driver.cpp from LLVM as our fuzzing library.

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -20,6 +20,13 @@
 # Please add new experiment requests towards the top of this file.
 #
 
+- experiment: 2022-06-09-afl-splicing
+  description: "Test AFL with splicing as mutation"
+  type: bug
+  fuzzers:
+    - afl
+    - afl_splicing_mutation
+
 - experiment: 2022-06-08-dissecting
   description: "Dissecting AFL paper (scheduling)"
   type: bug


### PR DESCRIPTION
Benchmark AFL vs AFL with splicing as mutation.

This is another rerun from https://www.fuzzbench.com/reports/experimental/2022-05-06-dissecting/index.html
It seems that many fuzzers in the big experiment have less than 20 trials while small experiments like the one I requested about scheduling run with a subset of the fuzzers used in the big one and it is all ok.

Ty as usual.