### PR TITLE
Pass snapshot period to runner

### DIFF
--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -43,6 +43,7 @@ docker run \
 -e EXPERIMENT={{experiment}} \
 -e TRIAL_ID={{trial_id}} \
 -e MAX_TOTAL_TIME={{max_total_time}} \
+-e SNAPSHOT_PERIOD={{snapshot_period}} \
 -e NO_SEEDS={{no_seeds}} \
 -e NO_DICTIONARIES={{no_dictionaries}} \
 -e OSS_FUZZ_CORPUS={{oss_fuzz_corpus}} \

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -731,6 +731,7 @@ def render_startup_script_template(  # pylint: disable=too-many-arguments
         'fuzzer': fuzzer,
         'trial_id': trial_id,
         'max_total_time': experiment_config['max_total_time'],
+        'snapshot_period': experiment_config['snapshot_period'],
         'experiment_filestore': experiment_config['experiment_filestore'],
         'report_filestore': experiment_config['report_filestore'],
         'fuzz_target': fuzz_target,

--- a/experiment/test_data/experiment-config.yaml
+++ b/experiment/test_data/experiment-config.yaml
@@ -15,6 +15,7 @@
 experiment: test-experiment
 trials: 4
 max_total_time: 86400
+snapshot_period: 900
 cloud_project: fuzzbench
 docker_registry: gcr.io/fuzzbench
 cloud_compute_zone: us-central1-a

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -115,6 +115,7 @@ docker run \\
 -e EXPERIMENT=test-experiment \\
 -e TRIAL_ID=9 \\
 -e MAX_TOTAL_TIME=86400 \\
+-e SNAPSHOT_PERIOD=900 \\
 -e NO_SEEDS=False \\
 -e NO_DICTIONARIES=False \\
 -e OSS_FUZZ_CORPUS=False \\


### PR DESCRIPTION
In https://github.com/google/fuzzbench/pull/1405 I requested an option to set snapshot period so the interval time to measure coverage could be adjustable, however I just noticed that the runner also [uses this value](https://github.com/google/fuzzbench/blob/master/experiment/runner.py#L305).

This small PR passes environment variable SNAPSHOT_PERIOD to the runner so that we have the same value throughout an experiment. 
