### PR TITLE
Fix CI failures

### DIFF
--- a/benchmarks/ffmpeg_ffmpeg_demuxer_fuzzer/Dockerfile
+++ b/benchmarks/ffmpeg_ffmpeg_demuxer_fuzzer/Dockerfile
@@ -30,7 +30,8 @@ RUN git clone -n https://gitlab.freedesktop.org/mesa/drm.git
 RUN cd drm; git checkout 5db0f7692d1fdf05f9f6c0c02ffa5a5f4379c1f3 
 RUN git clone --depth 1 https://github.com/mstorsjo/fdk-aac.git
 ADD https://sourceforge.net/projects/lame/files/latest/download lame.tar.gz
-RUN git clone --depth 1 git://anongit.freedesktop.org/xorg/lib/libXext
+RUN git clone --depth 2 git://anongit.freedesktop.org/xorg/lib/libXext
+RUN (cd /src/libXext; git checkout d965a1a8ce9331d2aaf1c697a29455ad55171b36)
 RUN git clone -n git://anongit.freedesktop.org/git/xorg/lib/libXfixes
 RUN cd libXfixes; git checkout 174a94975af710247719310cfc53bd13e1f3b44d
 RUN git clone --depth 1 https://github.com/intel/libva

--- a/benchmarks/libxml2-v2.9.2/Dockerfile
+++ b/benchmarks/libxml2-v2.9.2/Dockerfile
@@ -17,6 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
+    apt-get upgrade -y git && \
     apt-get install -y \
     make \
     wget \

--- a/benchmarks/libxml2-v2.9.2/Dockerfile
+++ b/benchmarks/libxml2-v2.9.2/Dockerfile
@@ -17,7 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder@sha256:1b6a6993690fa947df74ceabbf6a1f89a46d7e4277492addcd45a8525e34be5a
 
 RUN apt-get update && \
-    apt-get upgrade -y git && \
+    apt-get upgrade -y ca-certificates && \
     apt-get install -y \
     make \
     wget \

--- a/fuzzers/fafuzz/fuzzer.py
+++ b/fuzzers/fafuzz/fuzzer.py
@@ -100,7 +100,7 @@ def run_afl_fuzz(input_corpus,
     print('[run_afl_fuzz] Running target with afl-fuzz')
     command = [
         './afl-fuzz',
-        '-A',
+        '-A 1',
         #enable FA mode
         '-i',
         input_corpus,

--- a/fuzzers/libafl_aflpp/fuzzer.py
+++ b/fuzzers/libafl_aflpp/fuzzer.py
@@ -41,9 +41,9 @@ def prepare_fuzz_environment(input_corpus):
 def build():  # pylint: disable=too-many-branches,too-many-statements
     """Build benchmark."""
     os.environ[
-        'CC'] = '/libafl/fuzzers/fuzzbench_weighted/target/release/libafl_cc'
+        'CC'] = '/libafl/fuzzers/fuzzbench_aflpp/target/release/libafl_cc'
     os.environ[
-        'CXX'] = '/libafl/fuzzers/fuzzbench_weighted/target/release/libafl_cxx'
+        'CXX'] = '/libafl/fuzzers/fuzzbench_aflpp/target/release/libafl_cxx'
 
     os.environ['ASAN_OPTIONS'] = 'abort_on_error=0:allocator_may_return_null=1'
     os.environ['UBSAN_OPTIONS'] = 'abort_on_error=0'


### PR DESCRIPTION
# Failures fixed
# Benchmark failures
There are two CI failures related to `afl` respectively on benchmark `libxml2-v2.9.2` and `ffmpeg_ffmpeg_demuxer_fuzzer`:

## `libxml2-v2.9.2`
> fatal: unable to access 'https://gitlab.gnome.org/GNOME/libxml2.git/': server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none

I was not able to reproduce this locally, but fixed by updating `ca-certificates`.

## `ffmpeg_ffmpeg_demuxer_fuzzer`
> XEVI.c:150:16: error: implicit declaration of function 'reallocarray' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        temp_visual = Xmallocarray(n_visual, sz_VisualID32);
                      ^
./reallocarray.h:44:32: note: expanded from macro 'Xmallocarray'
#define Xmallocarray(n, size)           Xreallocarray(NULL, (n), (size))
                                        ^
./reallocarray.h:39:5: note: expanded from macro 'Xreallocarray'
    reallocarray((ptr), ((n) == 0 ? 1 : (n)), size)
    ^
XEVI.c:150:14: warning: incompatible integer to pointer conversion assigning to 'VisualID32 *' (aka 'unsigned int *') from 'int' [-Wint-conversion]
        temp_visual = Xmallocarray(n_visual, sz_VisualID32);

This is caused by the latest version of a dependency (`libXert`) and fixed by reverting to one commit earlier.
(Need to update it later once `libXert` is fixed)

# Fuzzer failures
## `fafuzz`
Fuzzer `fafuzz` failed because of invalid parameter `-A`, which requires an arg.
Fixed with `-A 1`, which enables FA mode as required.

## `libafl_aflpp`
Fuzzer `libafl_aflpp` failed because of incorrect location of required compilers (`libafl_cc` and `libafl_cxx`).
Fixed by correcting them.
