### PR TITLE
Avoid hardcoding the FUZZER_LIB

### DIFF
--- a/benchmarks/openssl_x509/build.sh
+++ b/benchmarks/openssl_x509/build.sh
@@ -21,7 +21,14 @@ then
   CONFIGURE_FLAGS="no-asm"
 fi
 
-./config --debug enable-fuzz-libfuzzer -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION no-shared enable-tls1_3 enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-nextprotoneg enable-weak-ssl-ciphers --with-fuzzer-lib=$FUZZER_LIB $CFLAGS -fno-sanitize=alignment $CONFIGURE_FLAGS
+if [ "$FUZZER" = "centipede" ]
+then
+  WITH_FUZZER_LIB="$FUZZER_LIB"
+else
+  WITH_FUZZER_LIB='/usr/lib/libFuzzingEngine'
+fi
+
+./config --debug enable-fuzz-libfuzzer -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION no-shared enable-tls1_3 enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-nextprotoneg enable-weak-ssl-ciphers --with-fuzzer-lib=$WITH_FUZZER_LIB $CFLAGS -fno-sanitize=alignment $CONFIGURE_FLAGS
 
 make -j$(nproc) LDCMD="$CXX $CXXFLAGS"
 

--- a/benchmarks/openssl_x509/build.sh
+++ b/benchmarks/openssl_x509/build.sh
@@ -21,7 +21,7 @@ then
   CONFIGURE_FLAGS="no-asm"
 fi
 
-./config --debug enable-fuzz-libfuzzer -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION no-shared enable-tls1_3 enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-nextprotoneg enable-weak-ssl-ciphers --with-fuzzer-lib=/usr/lib/libFuzzingEngine $CFLAGS -fno-sanitize=alignment $CONFIGURE_FLAGS
+./config --debug enable-fuzz-libfuzzer -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION no-shared enable-tls1_3 enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-ssl3 enable-ssl3-method enable-nextprotoneg enable-weak-ssl-ciphers --with-fuzzer-lib=$FUZZER_LIB $CFLAGS -fno-sanitize=alignment $CONFIGURE_FLAGS
 
 make -j$(nproc) LDCMD="$CXX $CXXFLAGS"
 


### PR DESCRIPTION
The Dockerfile of benchmark `openssl` hardcodes `--with-fuzzer-lib=/usr/lib/libFuzzingEngine`.
This PR replaces `/usr/lib/libFuzzingEngine` with `$FUZZER_LIB`, as not all fuzzers save their lib to that path.