### PR TITLE
Fix a bug in libfuzzer_dataflow

### DIFF
--- a/fuzzers/libfuzzer_dataflow/Trace-store-and-load-commands.patch
+++ b/fuzzers/libfuzzer_dataflow/Trace-store-and-load-commands.patch
@@ -1,17 +1,17 @@
-From e7b02154a90480ed6bca8ba7203c70e7b5a27203 Mon Sep 17 00:00:00 2001
-From: Alan32Liu <donggeliu@google.com>
-Date: Wed, 23 Feb 2022 15:55:17 +1100
-Subject: [PATCH 1/3] Trace store and load commands
-
-Signed-off-by: Alan32Liu <donggeliu@google.com>
----
- compiler-rt/lib/fuzzer/FuzzerMain.cpp    |   2 +
- compiler-rt/lib/fuzzer/FuzzerTracePC.cpp | 108 +++++++++++++++++++++++
- compiler-rt/lib/fuzzer/FuzzerTracePC.h   |  15 ++++
- 3 files changed, 125 insertions(+)
-
+diff --git a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+index 6b007f2ad45c..23299e36b5e8 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+@@ -640,6 +640,7 @@ ReadCorpora(const std::vector<std::string> &CorpusDirs,
+ }
+ 
+ int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
++  fuzzer::TPC.InitializeMainObjectInformation();
+   using namespace fuzzer;
+   assert(argc && argv && "Argument pointers cannot be nullptr");
+   std::string Argv0((*argv)[0]);
 diff --git a/compiler-rt/lib/fuzzer/FuzzerMain.cpp b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
-index 75f2f8e75c9b..761bb82ff602 100644
+index 75f2f8e75c9b..120923992f9f 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerMain.cpp
 +++ b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
 @@ -10,6 +10,7 @@
@@ -22,15 +22,8 @@ index 75f2f8e75c9b..761bb82ff602 100644
  
  extern "C" {
  // This function should be defined by the user.
-@@ -17,5 +18,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
- }  // extern "C"
- 
- ATTRIBUTE_INTERFACE int main(int argc, char **argv) {
-+  fuzzer::TPC.InitializeMainObjectInformation();
-   return fuzzer::FuzzerDriver(&argc, &argv, LLVMFuzzerTestOneInput);
- }
 diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
-index f12f7aa61bc4..be01bc0c6510 100644
+index f12f7aa61bc4..c45178254383 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
 +++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
 @@ -27,6 +27,14 @@
@@ -48,23 +41,21 @@ index f12f7aa61bc4..be01bc0c6510 100644
  namespace fuzzer {
  
  TracePC TPC;
-@@ -392,6 +400,15 @@ void TracePC::HandleCmp(uintptr_t PC, T Arg1, T Arg2) {
+@@ -392,6 +400,13 @@ void TracePC::HandleCmp(uintptr_t PC, T Arg1, T Arg2) {
    ValueProfileMap.AddValue(PC * 128 + 64 + AbsoluteDistance);
  }
  
 +ATTRIBUTE_TARGET_POPCNT ALWAYS_INLINE
 +ATTRIBUTE_NO_SANITIZE_ALL
 +void TracePC::HandleDf(uintptr_t PC, uintptr_t Addr, uintptr_t MaxPC) {
-+//fuzzer::Printf("[HandleDf] Instrumented : %lu\n", Addr);
 +  uintptr_t feature = PC * MaxPC + Addr;
-+//  fuzzer::Printf("[HandleDf] Feature value: %lu\n", feature);
 +  DataFlowMap.AddValue(feature);
 +}
 +
  ATTRIBUTE_NO_SANITIZE_MEMORY
  static size_t InternalStrnlen(const char *S, size_t MaxLen) {
    size_t Len = 0;
-@@ -616,6 +633,64 @@ void __sanitizer_cov_trace_gep(uintptr_t Idx) {
+@@ -616,6 +631,48 @@ void __sanitizer_cov_trace_gep(uintptr_t Idx) {
    fuzzer::TPC.HandleCmp(PC, Idx, (uintptr_t)0);
  }
  
@@ -77,14 +68,6 @@ index f12f7aa61bc4..be01bc0c6510 100644
 +
 +  uintptr_t PCOffset = PC - main_object_start_address;
 +  uintptr_t LoadOffset = LoadAddr - main_object_start_address;
-+//
-+//  fuzzer::Printf("[TraceLoad] PC                       : %lu\n", PCOffset);
-+//  fuzzer::Printf("[TraceLoad] LoadAddr                 : %lu\n", LoadAddr);
-+//  fuzzer::Printf("[TraceLoad] main_object_start_address: %lu\n",
-+//    main_object_start_address);
-+//  fuzzer::Printf("[TraceLoad] PCOffset                 : %lu\n", PCOffset);
-+//  fuzzer::Printf("[TraceLoad] LoadOffset               : %lu\n", LoadOffset);
-+//  fuzzer::Printf("[TraceLoad] main_object_size         : %lu\n", main_object_size);
 +
 +  if (PCOffset >= main_object_size) return;
 +  if (LoadOffset >= main_object_size) return;
@@ -105,14 +88,6 @@ index f12f7aa61bc4..be01bc0c6510 100644
 +  uintptr_t StoreAddr = reinterpret_cast<uintptr_t>(Addr);
 +  uintptr_t PCOffset = PC - main_object_start_address;
 +  uintptr_t StoreOffset = StoreAddr - main_object_start_address;
-+//
-+//  fuzzer::Printf("[TraceStore] PC                       : %lu\n", PCOffset);
-+//  fuzzer::Printf("[TraceStore] StoreAddr                : %lu\n", StoreAddr);
-+//  fuzzer::Printf("[TraceStore] main_object_start_address: %lu\n",
-+//    main_object_start_address);
-+//  fuzzer::Printf("[TraceStore] PCOffset                 : %lu\n", PCOffset);
-+//  fuzzer::Printf("[TraceStore] StoreOffset              : %lu\n", StoreOffset);
-+//  fuzzer::Printf("[TraceStore] main_object_size         : %lu\n", main_object_size);
 +
 +  if (PCOffset >= main_object_size) return;
 +  if (StoreOffset >= main_object_size) return;
@@ -129,7 +104,7 @@ index f12f7aa61bc4..be01bc0c6510 100644
  ATTRIBUTE_INTERFACE ATTRIBUTE_NO_SANITIZE_MEMORY
  void __sanitizer_weak_hook_memcmp(void *caller_pc, const void *s1,
                                    const void *s2, size_t n, int result) {
-@@ -682,4 +757,37 @@ void __sanitizer_weak_hook_memmem(void *called_pc, const void *s1, size_t len1,
+@@ -682,4 +739,22 @@ void __sanitizer_weak_hook_memmem(void *called_pc, const void *s1, size_t len1,
    if (!fuzzer::RunningUserCallback) return;
    fuzzer::TPC.MMT.Add(reinterpret_cast<const uint8_t *>(s2), len2);
  }
@@ -139,27 +114,12 @@ index f12f7aa61bc4..be01bc0c6510 100644
 +// The code assumes that the main binary is the the first one to be iterated on.
 +int dl_iterate_phdr_callback(struct dl_phdr_info *info, size_t size,
 +                                    void *data) {
-+//  PrintErrorAndExitIf(main_object_start_address != kInvalidStartAddress,
-+//                      "main_object_start_address is already set");
-+//  fuzzer::Printf("[INIT] main_object_start_address: %lu\n", main_object_start_address);
-+//  fuzzer::Printf("[INIT] main_object_size         : %lu\n", main_object_size);
 +  main_object_start_address = info->dlpi_addr;
-+//  fuzzer::Printf("[UPDT] main_object_start_address: %lu\n", main_object_start_address);
 +  for (int j = 0; j < info->dlpi_phnum; j++) {
 +    uintptr_t end_offset =
 +        info->dlpi_phdr[j].p_vaddr + info->dlpi_phdr[j].p_memsz;
 +    if (main_object_size < end_offset) main_object_size = end_offset;
-+//    fuzzer::Printf("[UPDT] main_object_size         : %lu\n", main_object_size);
 +  }
-+//  fuzzer::Printf("[FINL] main_object_start_address: %lu\n", main_object_start_address);
-+//  fuzzer::Printf("[FINL] main_object_size         : %lu\n", main_object_size);
-+//  uintptr_t some_code_address =
-+//      reinterpret_cast<uintptr_t>(&dl_iterate_phdr_callback);
-+//  PrintErrorAndExitIf(main_object_start_address > some_code_address,
-+//                      "main_object_start_address is above the code");
-+//  PrintErrorAndExitIf(
-+//      main_object_start_address + main_object_size < some_code_address,
-+//      "main_object_start_address + main_object_size is below the code");
 +  return 1;  // we need only the first header, so return 1.
 +}
 +
@@ -168,7 +128,7 @@ index f12f7aa61bc4..be01bc0c6510 100644
 +}
  }  // extern "C"
 diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.h b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
-index af1f9d81e950..d9e82f1a92b3 100644
+index af1f9d81e950..ac0976276bdf 100644
 --- a/compiler-rt/lib/fuzzer/FuzzerTracePC.h
 +++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
 @@ -11,6 +11,8 @@
@@ -212,160 +172,16 @@ index af1f9d81e950..d9e82f1a92b3 100644
    uintptr_t InitialStack;
  };
  
-@@ -288,6 +294,15 @@ TracePC::CollectFeatures(Callback HandleFeature) const {
+@@ -288,6 +294,12 @@ TracePC::CollectFeatures(Callback HandleFeature) const {
      FirstFeature += StackDepthStepFunction(std::numeric_limits<size_t>::max());
    }
  
 +  // Data Flow feature
-+  //TODO: Need a flag for using DataFlowMap?
-+  if (UseValueProfileMask) {
-+    DataFlowMap.ForEach([&](size_t Idx) {
-+      HandleFeature(static_cast<uint32_t>(FirstFeature + Idx));
-+    });
-+    FirstFeature += DataFlowMap.SizeInBits();
-+  }
++  DataFlowMap.ForEach([&](size_t Idx) {
++    HandleFeature(static_cast<uint32_t>(FirstFeature + Idx));
++  });
++  FirstFeature += DataFlowMap.SizeInBits();
 +
    return FirstFeature;
  }
  
--- 
-2.35.1.894.gb6a874cedc-goog
-
-
-From 009c87895b13021fdcb0e28a57324621faa1a07d Mon Sep 17 00:00:00 2001
-From: Alan32Liu <donggeliu@google.com>
-Date: Wed, 23 Mar 2022 08:18:03 +1100
-Subject: [PATCH 2/3] Remove debug prints
-
-Signed-off-by: Alan32Liu <donggeliu@google.com>
----
- compiler-rt/lib/fuzzer/FuzzerTracePC.cpp | 33 ------------------------
- compiler-rt/lib/fuzzer/FuzzerTracePC.h   |  1 -
- 2 files changed, 34 deletions(-)
-
-diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
-index be01bc0c6510..c45178254383 100644
---- a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
-+++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
-@@ -403,9 +403,7 @@ void TracePC::HandleCmp(uintptr_t PC, T Arg1, T Arg2) {
- ATTRIBUTE_TARGET_POPCNT ALWAYS_INLINE
- ATTRIBUTE_NO_SANITIZE_ALL
- void TracePC::HandleDf(uintptr_t PC, uintptr_t Addr, uintptr_t MaxPC) {
--//fuzzer::Printf("[HandleDf] Instrumented : %lu\n", Addr);
-   uintptr_t feature = PC * MaxPC + Addr;
--//  fuzzer::Printf("[HandleDf] Feature value: %lu\n", feature);
-   DataFlowMap.AddValue(feature);
- }
- 
-@@ -642,14 +640,6 @@ void TraceLoad(void *Addr) {
- 
-   uintptr_t PCOffset = PC - main_object_start_address;
-   uintptr_t LoadOffset = LoadAddr - main_object_start_address;
--//
--//  fuzzer::Printf("[TraceLoad] PC                       : %lu\n", PCOffset);
--//  fuzzer::Printf("[TraceLoad] LoadAddr                 : %lu\n", LoadAddr);
--//  fuzzer::Printf("[TraceLoad] main_object_start_address: %lu\n",
--//    main_object_start_address);
--//  fuzzer::Printf("[TraceLoad] PCOffset                 : %lu\n", PCOffset);
--//  fuzzer::Printf("[TraceLoad] LoadOffset               : %lu\n", LoadOffset);
--//  fuzzer::Printf("[TraceLoad] main_object_size         : %lu\n", main_object_size);
- 
-   if (PCOffset >= main_object_size) return;
-   if (LoadOffset >= main_object_size) return;
-@@ -670,14 +660,6 @@ void TraceStore(void *Addr) {
-   uintptr_t StoreAddr = reinterpret_cast<uintptr_t>(Addr);
-   uintptr_t PCOffset = PC - main_object_start_address;
-   uintptr_t StoreOffset = StoreAddr - main_object_start_address;
--//
--//  fuzzer::Printf("[TraceStore] PC                       : %lu\n", PCOffset);
--//  fuzzer::Printf("[TraceStore] StoreAddr                : %lu\n", StoreAddr);
--//  fuzzer::Printf("[TraceStore] main_object_start_address: %lu\n",
--//    main_object_start_address);
--//  fuzzer::Printf("[TraceStore] PCOffset                 : %lu\n", PCOffset);
--//  fuzzer::Printf("[TraceStore] StoreOffset              : %lu\n", StoreOffset);
--//  fuzzer::Printf("[TraceStore] main_object_size         : %lu\n", main_object_size);
- 
-   if (PCOffset >= main_object_size) return;
-   if (StoreOffset >= main_object_size) return;
-@@ -763,27 +745,12 @@ void __sanitizer_weak_hook_memmem(void *called_pc, const void *s1, size_t len1,
- // The code assumes that the main binary is the the first one to be iterated on.
- int dl_iterate_phdr_callback(struct dl_phdr_info *info, size_t size,
-                                     void *data) {
--//  PrintErrorAndExitIf(main_object_start_address != kInvalidStartAddress,
--//                      "main_object_start_address is already set");
--//  fuzzer::Printf("[INIT] main_object_start_address: %lu\n", main_object_start_address);
--//  fuzzer::Printf("[INIT] main_object_size         : %lu\n", main_object_size);
-   main_object_start_address = info->dlpi_addr;
--//  fuzzer::Printf("[UPDT] main_object_start_address: %lu\n", main_object_start_address);
-   for (int j = 0; j < info->dlpi_phnum; j++) {
-     uintptr_t end_offset =
-         info->dlpi_phdr[j].p_vaddr + info->dlpi_phdr[j].p_memsz;
-     if (main_object_size < end_offset) main_object_size = end_offset;
--//    fuzzer::Printf("[UPDT] main_object_size         : %lu\n", main_object_size);
-   }
--//  fuzzer::Printf("[FINL] main_object_start_address: %lu\n", main_object_start_address);
--//  fuzzer::Printf("[FINL] main_object_size         : %lu\n", main_object_size);
--//  uintptr_t some_code_address =
--//      reinterpret_cast<uintptr_t>(&dl_iterate_phdr_callback);
--//  PrintErrorAndExitIf(main_object_start_address > some_code_address,
--//                      "main_object_start_address is above the code");
--//  PrintErrorAndExitIf(
--//      main_object_start_address + main_object_size < some_code_address,
--//      "main_object_start_address + main_object_size is below the code");
-   return 1;  // we need only the first header, so return 1.
- }
- 
-diff --git a/compiler-rt/lib/fuzzer/FuzzerTracePC.h b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
-index d9e82f1a92b3..67eab7425097 100644
---- a/compiler-rt/lib/fuzzer/FuzzerTracePC.h
-+++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.h
-@@ -295,7 +295,6 @@ TracePC::CollectFeatures(Callback HandleFeature) const {
-   }
- 
-   // Data Flow feature
--  //TODO: Need a flag for using DataFlowMap?
-   if (UseValueProfileMask) {
-     DataFlowMap.ForEach([&](size_t Idx) {
-       HandleFeature(static_cast<uint32_t>(FirstFeature + Idx));
--- 
-2.35.1.894.gb6a874cedc-goog
-
-
-From a5e8d90b5054270936a197797924795fadfef9f5 Mon Sep 17 00:00:00 2001
-From: Alan32Liu <donggeliu@google.com>
-Date: Thu, 24 Mar 2022 16:29:12 +1100
-Subject: [PATCH 3/3] Move Initialisation to DuzzerDriver to make it more
- generalise
-
-Signed-off-by: Alan32Liu <donggeliu@google.com>
----
- compiler-rt/lib/fuzzer/FuzzerDriver.cpp | 1 +
- compiler-rt/lib/fuzzer/FuzzerMain.cpp   | 1 -
- 2 files changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
-index 6b007f2ad45c..23299e36b5e8 100644
---- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
-+++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
-@@ -640,6 +640,7 @@ ReadCorpora(const std::vector<std::string> &CorpusDirs,
- }
- 
- int FuzzerDriver(int *argc, char ***argv, UserCallback Callback) {
-+  fuzzer::TPC.InitializeMainObjectInformation();
-   using namespace fuzzer;
-   assert(argc && argv && "Argument pointers cannot be nullptr");
-   std::string Argv0((*argv)[0]);
-diff --git a/compiler-rt/lib/fuzzer/FuzzerMain.cpp b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
-index 761bb82ff602..120923992f9f 100644
---- a/compiler-rt/lib/fuzzer/FuzzerMain.cpp
-+++ b/compiler-rt/lib/fuzzer/FuzzerMain.cpp
-@@ -18,6 +18,5 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
- }  // extern "C"
- 
- ATTRIBUTE_INTERFACE int main(int argc, char **argv) {
--  fuzzer::TPC.InitializeMainObjectInformation();
-   return fuzzer::FuzzerDriver(&argc, &argv, LLVMFuzzerTestOneInput);
- }
--- 
-2.35.1.894.gb6a874cedc-goog
-


### PR DESCRIPTION
Enable dataflow tracing without setting `UseValueProfileMask`.
This is an old bug that was fixed locally a long time ago but was not updated here.