### PR TITLE
Upgrade `ca-certificates` in `honggfuzz_qemu`

### DIFF
--- a/fuzzers/honggfuzz_qemu/builder.Dockerfile
+++ b/fuzzers/honggfuzz_qemu/builder.Dockerfile
@@ -17,6 +17,7 @@ FROM $parent_image
 
 # Honggfuzz requires libbfd and libunwid.
 RUN apt-get update -y && \
+    apt-get upgrade -y ca-certificates && \
     apt-get install -y \
     libbfd-dev \
     libunwind-dev \


### PR DESCRIPTION
Upgrade `ca-certificates` in `honggfuzz_qemu` to fix this [CI failure](https://github.com/google/fuzzbench/runs/7314918364?check_suite_focus=true).