### PR TITLE
Handle exception when fail to check all trials ended

### DIFF
--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -19,6 +19,7 @@ import os
 import sys
 import random
 import time
+import sqlite3
 from typing import List, Dict
 
 import jinja2
@@ -103,7 +104,7 @@ def all_trials_ended(experiment: str) -> bool:
     try:
         return not get_experiment_trials(experiment).filter(
             models.Trial.time_ended.is_(None)).all()
-    except Exception:  # pylint: disable=broad-except
+    except sqlite3.OperationalError:
         logger.error('Failed to check whether all trials ended.')
         return False
 

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -16,10 +16,10 @@ import datetime
 import math
 import multiprocessing
 import os
+import sqlite3
 import sys
 import random
 import time
-import sqlite3
 from typing import List, Dict
 
 import jinja2

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -100,8 +100,12 @@ def get_expired_trials(experiment: str, max_total_time: int):
 def all_trials_ended(experiment: str) -> bool:
     """Return a bool if there are any trials in |experiment| that have not
     started."""
-    return not get_experiment_trials(experiment).filter(
-        models.Trial.time_ended.is_(None)).all()
+    try:
+        return not get_experiment_trials(experiment).filter(
+            models.Trial.time_ended.is_(None)).all()
+    except Exception:  # pylint: disable=broad-except
+        logger.error('Failed to check whether all trials ended.')
+        return False
 
 
 def delete_instances(instances, experiment_config):


### PR DESCRIPTION
This PR fixes https://github.com/google/fuzzbench/issues/1371. I often experienced database lock when running local experiment but not sure what caused this problem. In particular, the issue occurs when checking whether all trials end:

https://github.com/google/fuzzbench/blob/d8444f19e513ffa60bb09f231a6648c0147ef64f/experiment/scheduler.py#L100

This PR will return false if an exception thrown, so that the scheduler won't crash. 
