### PR TITLE
Set LIB_FUZZING_ENGINE for arrow_parquet-arrow-fuzz

### DIFF
--- a/fuzzers/centipede/fuzzer.py
+++ b/fuzzers/centipede/fuzzer.py
@@ -33,8 +33,10 @@ def build():
 
     os.environ['CC'] = '/clang/bin/clang'
     os.environ['CXX'] = '/clang/bin/clang++'
-    os.environ[
-        'FUZZER_LIB'] = '/src/centipede/bazel-bin/libcentipede_runner.pic.a'
+
+    centipede_lib = '/src/centipede/bazel-bin/libcentipede_runner.pic.a'
+    os.environ['FUZZER_LIB'] = centipede_lib
+    os.environ['LIB_FUZZING_ENGINE'] = centipede_lib
 
     utils.build_benchmark()
 


### PR DESCRIPTION
Link env variable `LIB_FUZZING_ENGINE` to Centipede's lib file, as required by benchmark `arrow_parquet-arrow-fuzz`.
Unfortunately, this does not solve the `undefined reference to '__sanitizer_cov_load8'` error.