### PR TITLE
Fix `Centipede` integration

### DIFF
--- a/fuzzers/centipede/builder.Dockerfile
+++ b/fuzzers/centipede/builder.Dockerfile
@@ -26,8 +26,8 @@ RUN git clone \
     '--cxxopt=-stdlib=libc++ --linkopt=-lc++' >> ~/.bazelrc && \
   (cd "$CENTIPEDE_SRC" && \
   bazel build -c opt :all) && \
-  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede' && \
-  CENTIPEDE_FLAGS=`cat "$CENTIPEDE_SRC/clang-flags.txt"`
+  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede'
+
 
 COPY weak.c /src
 RUN /clang/bin/clang /src/weak.c -c -o /lib/weak.o

--- a/fuzzers/centipede/builder.Dockerfile
+++ b/fuzzers/centipede/builder.Dockerfile
@@ -15,35 +15,19 @@
 ARG parent_image
 FROM $parent_image
 
-# Add C++15.
-ADD https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz /
-RUN mkdir /clang && \
-    tar zxvf /clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz -C /clang
+ENV CENTIPEDE_SRC=/src/centipede
 
-# Install deps of centipede, clone&build centipede.
-RUN apt update && \
-  apt install -y apt-transport-https && \
-  curl -fsSL 'https://bazel.build/bazel-release.pub.gpg' \
-    | gpg --dearmor > '/etc/apt/trusted.gpg.d/bazel.gpg' && \
-  echo 'deb [arch=amd64] ' \
-    'https://storage.googleapis.com/bazel-apt stable jdk1.8' \
-    | tee '/etc/apt/sources.list.d/bazel.list' && \
-  apt update && \
-  apt install -y \
-    vim \
-    libssl-dev \
-    bazel && \
-  git clone \
+# Build centipede.
+RUN git clone \
     --depth 1 \
-    --branch main \
-    --single-branch \
-    'https://github.com/google/centipede.git' '/src/centipede/' && \
+    https://github.com/google/centipede.git "$CENTIPEDE_SRC" && \
+  "$CENTIPEDE_SRC/install_dependencies_debian.sh" && \
   echo 'build --client_env=CC=clang --cxxopt=-std=c++17 ' \
     '--cxxopt=-stdlib=libc++ --linkopt=-lc++' >> ~/.bazelrc && \
-  (cd '/src/centipede/' && \
+  (cd "$CENTIPEDE_SRC" && \
   bazel build -c opt :all) && \
-  cp '/src/centipede/bazel-bin/centipede' '/out/centipede' && \
-  CENTIPEDE_FLAGS=`cat /src/centipede/clang-flags.txt`
+  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede' && \
+  CENTIPEDE_FLAGS=`cat "$CENTIPEDE_SRC/clang-flags.txt"`
 
 ENV CFLAGS="$CFLAGS $CENTIPEDE_FLAGS"
 ENV CXXFLAGS="$CXXFLAGS $CENTIPEDE_FLAGS"

--- a/fuzzers/centipede/builder.Dockerfile
+++ b/fuzzers/centipede/builder.Dockerfile
@@ -29,5 +29,5 @@ RUN git clone \
   cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede' && \
   CENTIPEDE_FLAGS=`cat "$CENTIPEDE_SRC/clang-flags.txt"`
 
-ENV CFLAGS="$CFLAGS $CENTIPEDE_FLAGS"
-ENV CXXFLAGS="$CXXFLAGS $CENTIPEDE_FLAGS"
+COPY weak.c /src
+RUN /clang/bin/clang /src/weak.c -c -o /lib/weak.o

--- a/fuzzers/centipede/fuzzer.py
+++ b/fuzzers/centipede/fuzzer.py
@@ -21,16 +21,27 @@ from fuzzers import utils
 
 def build():
     """Build benchmark."""
-    # TODO(Dongge): Build targets with sanitizers.
-    cflags = [
-        '-fno-builtin',
-        '-gline-tables-only',
+    san_cflags = [
+        '-fsanitize-coverage=trace-loads'
+    ]
+
+    link_cflags = [
         '-ldl',
         '-lrt',
         '-lpthread',
-        '-fsanitize-coverage=trace-loads,trace-pc-guard,trace-cmp,pc-table',
         '/lib/weak.o',
     ]
+
+    # TODO(Dongge): Build targets with sanitizers.
+    try:
+        centipede_cflags = subprocess.run(
+            ['cat', '/src/centipede/clang-flags.txt'],
+            stdout=subprocess.PIPE,
+            check=True).stdout.decode('utf-8').split('\n')
+    except subprocess.CalledProcessError as err:
+        print(err)
+
+    cflags = san_cflags + centipede_cflags + link_cflags
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
 

--- a/fuzzers/centipede/fuzzer.py
+++ b/fuzzers/centipede/fuzzer.py
@@ -29,6 +29,7 @@ def build():
         '-lrt',
         '-lpthread',
         '-fsanitize-coverage=trace-loads,trace-pc-guard,trace-cmp,pc-table',
+        '/lib/weak.o',
     ]
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)

--- a/fuzzers/centipede/fuzzer.py
+++ b/fuzzers/centipede/fuzzer.py
@@ -21,9 +21,7 @@ from fuzzers import utils
 
 def build():
     """Build benchmark."""
-    san_cflags = [
-        '-fsanitize-coverage=trace-loads'
-    ]
+    san_cflags = ['-fsanitize-coverage=trace-loads']
 
     link_cflags = [
         '-ldl',

--- a/fuzzers/centipede/weak.c
+++ b/fuzzers/centipede/weak.c
@@ -1,0 +1,28 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+
+__attribute__((weak)) void __sanitizer_cov_load1(uint8_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load2(uint16_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load4(uint32_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load8(uint64_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_load16(__uint128_t *addr) {}
+
+__attribute__((weak)) void __sanitizer_cov_store1(uint8_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store2(uint16_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store4(uint32_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store8(uint64_t *addr) {}
+__attribute__((weak)) void __sanitizer_cov_store16(__uint128_t *addr) {}
+


### PR DESCRIPTION
Improve our adaptability to future changes in `Centipede` by using scripts/flags predefined by it:
* Install `Centipede`'s dependencies with its predefined script;
* Collect the `CFLAGS` needed to build `Centipede` from its predefined file.