### PR TITLE
[centipede] Fix compilation flags

### DIFF
--- a/fuzzers/centipede/fuzzer.py
+++ b/fuzzers/centipede/fuzzer.py
@@ -26,7 +26,7 @@ def build():
         '-ldl',
         '-lrt',
         '-lpthread',
-        '-fsanitize-coverage=trace-loads',
+        '-fsanitize-coverage=trace-loads,trace-pc-guard,trace-cmp,pc-table',
     ]
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)

--- a/fuzzers/centipede/fuzzer.py
+++ b/fuzzers/centipede/fuzzer.py
@@ -23,6 +23,8 @@ def build():
     """Build benchmark."""
     # TODO(Dongge): Build targets with sanitizers.
     cflags = [
+        '-fno-builtin',
+        '-gline-tables-only',
         '-ldl',
         '-lrt',
         '-lpthread',

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -22,7 +22,6 @@
 
 - experiment: 2022-07-22-centipede
   description: "Test AFL with a new splicing as mutation"
-  type: bug
   fuzzers:
     - honggfuzz
     - aflplusplus

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -20,6 +20,22 @@
 # Please add new experiment requests towards the top of this file.
 #
 
+- experiment: 2022-07-22-centipede
+  description: "Test AFL with a new splicing as mutation"
+  type: bug
+  fuzzers:
+    - honggfuzz
+    - aflplusplus
+    - eclipser
+    - entropic
+    - libfuzzer
+    - lafintel
+    - afl
+    - mopt
+    - fairfuzz
+    - libfuzzer_dataflow
+    - centipede
+
 - experiment: 2022-07-21-afl-new-splicing
   description: "Test AFL with a new splicing as mutation"
   type: bug


### PR DESCRIPTION
Add compiler flags to instrument edges and comparisions.
Also do centipede experiment.