### PR TITLE
Add aflplusplus_two_instances and libfuzzer_two_workers fuzzer setups

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -71,6 +71,7 @@ jobs:
           - aflplusplus_cmplog
           - aflplusplus_311
           - aflplusplus_314
+          - aflplusplus_two_instances
           - afl_two_instances
           - afl_random_favored
           - aflpp_random_default
@@ -83,6 +84,7 @@ jobs:
           - aflplusplus_classic
           - entropic_execute_final
           - libfuzzer_exeute_final
+          - libfuzzer_two_workers
           - afl_no_favored
           - afl_collision_free
           - afl_double_timeout

--- a/fuzzers/aflplusplus_two_instances/builder.Dockerfile
+++ b/fuzzers/aflplusplus_two_instances/builder.Dockerfile
@@ -1,0 +1,46 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Install libstdc++ to use llvm_mode.
+RUN apt-get update && \
+    apt-get install -y wget libstdc++-5-dev libtool-bin automake flex bison \
+                       libglib2.0-dev libpixman-1-dev python3-setuptools unzip \
+                       apt-utils apt-transport-https ca-certificates
+
+# Download and compile afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /out/AFLplusplus && \
+    cd /out/AFLplusplus && \
+    git checkout 8fc249d210ad49e3dd88d1409877ca64d9884690
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /out/AFLplusplus && \
+    unset CFLAGS && unset CXXFLAGS && \
+    export AFL_NO_X86=1 && \
+    export CC=clang && export CXX=clang++ && \
+    PYTHON_INCLUDE=/ make && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a / && \
+    make install
+
+RUN cd / && git clone https://github.com/vanhauser-thc/qemu_driver && \
+    cd /qemu_driver && \
+    git checkout 8ad9ad589b4881552fa7ef8b7d29cd9aeb5071bd && \
+    unset CFLAGS && unset CXXFLAGS && \
+    export CC=clang && export CXX=clang++ && \
+    make && \
+    cp -fv libQEMU.a /libStandaloneFuzzTarget.a

--- a/fuzzers/aflplusplus_two_instances/description.md
+++ b/fuzzers/aflplusplus_two_instances/description.md
@@ -1,0 +1,9 @@
+# aflplusplus 
+
+Two AFL++ fuzzer instances running together
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_two_instances/fuzzer.py
+++ b/fuzzers/aflplusplus_two_instances/fuzzer.py
@@ -1,0 +1,76 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for Fuzzolic fuzzer. Note that starting from v2.0, Fuzzolic
+relies on AFL to perform random-based fuzzing."""
+
+import shutil
+import os
+import threading
+import time
+
+from fuzzers import utils
+from fuzzers.afl import fuzzer as afl_fuzzer
+
+
+def get_uninstrumented_outdir(target_directory):
+    """Return path to uninstrumented target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
+
+
+def build():
+    """Build benchmark."""
+
+    # First, build an instrumented binary for AFL.
+    os.environ['CC'] = '/out/AFLplusplus/afl-clang-fast'
+    os.environ['CXX'] = '/out/AFLplusplus/afl-clang-fast++'
+    os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+    os.environ['AFL_PATH'] = '/out/AFLplusplus/'
+    #afl_fuzzer.prepare_build_environment()
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+    with utils.restore_directory(src), utils.restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        utils.build_benchmark()
+    print('[build] Copying afl-fuzz to $OUT directory')
+    shutil.copy('/out/AFLplusplus/afl-fuzz', os.environ['OUT'])
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    #utils.create_seed_file_for_empty_corpus(input_corpus)
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+    os.environ['AFL_DISABLE_TRIM'] = "1"
+
+    # Main instance
+    print('[fuzz] Running main AFL worker')
+    afl_main_thread = threading.Thread(target=afl_fuzzer.run_afl_fuzz,
+                                       args=(input_corpus, output_corpus,
+                                             target_binary, ['-M', 'afl-main']))
+    afl_main_thread.start()
+    time.sleep(5)
+
+    # Secondary instance
+    print('[fuzz] Running secondary AFL worker')
+    afl_secondary_thread = threading.Thread(target=afl_fuzzer.run_afl_fuzz,
+                                            args=(input_corpus, output_corpus,
+                                                  target_binary,
+                                                  ['-S',
+                                                   'afl-secondary'], True))
+    afl_secondary_thread.start()
+
+    print('[fuzz] Now waiting for threads to finish...')
+    afl_main_thread.join()
+    afl_secondary_thread.join()

--- a/fuzzers/aflplusplus_two_instances/runner.Dockerfile
+++ b/fuzzers/aflplusplus_two_instances/runner.Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+RUN apt-get update  && \
+    apt-get install -y gcc-multilib python3-toml
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_PATH=/out/AFLplusplus

--- a/fuzzers/libfuzzer_two_workers/builder.Dockerfile
+++ b/fuzzers/libfuzzer_two_workers/builder.Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/ && \
+    git checkout de5b16d8ca2d14ff0d9b6be9cf40566bc7eb5a01 && \
+    cd compiler-rt/lib/fuzzer && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+    done && wait) && \
+    ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_two_workers/fuzzer.py
+++ b/fuzzers/libfuzzer_two_workers/fuzzer.py
@@ -1,0 +1,83 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for libFuzzer fuzzer."""
+
+import subprocess
+import os
+
+from fuzzers import utils
+
+
+def build():
+    """Build benchmark."""
+    # With LibFuzzer we use -fsanitize=fuzzer-no-link for build CFLAGS and then
+    # /usr/lib/libFuzzer.a as the FUZZER_LIB for the main fuzzing binary. This
+    # allows us to link against a version of LibFuzzer that we specify.
+    cflags = ['-fsanitize=fuzzer-no-link']
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cflags)
+
+    os.environ['CC'] = 'clang'
+    os.environ['CXX'] = 'clang++'
+    os.environ['FUZZER_LIB'] = '/usr/lib/libFuzzer.a'
+
+    utils.build_benchmark()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling
+    run_fuzzer."""
+    run_fuzzer(input_corpus,
+               output_corpus,
+               target_binary,
+               extra_flags=['-keep_seed=1', '-cross_over_uniform_dist=1'])
+
+
+def run_fuzzer(input_corpus, output_corpus, target_binary, extra_flags=None):
+    """Run fuzzer."""
+    if extra_flags is None:
+        extra_flags = []
+
+    # Seperate out corpus and crash directories as sub-directories of
+    # |output_corpus| to avoid conflicts when corpus directory is reloaded.
+    crashes_dir = os.path.join(output_corpus, 'crashes')
+    output_corpus = os.path.join(output_corpus, 'corpus')
+    os.makedirs(crashes_dir)
+    os.makedirs(output_corpus)
+
+    flags = [
+        '-print_final_stats=1',
+        # `close_fd_mask` to prevent too much logging output from the target.
+        '-close_fd_mask=3',
+        '-jobs=1000',
+        '-workers=2',
+        '-rss_limit_mb=8192',
+
+        # Don't use LSAN's leak detection. Other fuzzers won't be using it and
+        # using it will cause libFuzzer to find "crashes" no one cares about.
+        '-detect_leaks=0',
+
+        # Store crashes along with corpus for bug based benchmarking.
+        f'-artifact_prefix={crashes_dir}/',
+    ]
+    flags += extra_flags
+    if 'ADDITIONAL_ARGS' in os.environ:
+        flags += os.environ['ADDITIONAL_ARGS'].split(' ')
+    dictionary_path = utils.get_dictionary_path(target_binary)
+    if dictionary_path:
+        flags.append('-dict=' + dictionary_path)
+
+    command = [target_binary] + flags + [output_corpus, input_corpus]
+    print('[run_fuzzer] Running command: ' + ' '.join(command))
+    subprocess.check_call(command)

--- a/fuzzers/libfuzzer_two_workers/fuzzer.yaml
+++ b/fuzzers/libfuzzer_two_workers/fuzzer.yaml
@@ -1,0 +1,3 @@
+languages:
+  - go
+  - c++

--- a/fuzzers/libfuzzer_two_workers/patch.diff
+++ b/fuzzers/libfuzzer_two_workers/patch.diff
@@ -1,0 +1,100 @@
+diff --git a/compiler-rt/lib/fuzzer/FuzzerFork.cpp b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+index 84725d2..4e1a506 100644
+--- a/compiler-rt/lib/fuzzer/FuzzerFork.cpp
++++ b/compiler-rt/lib/fuzzer/FuzzerFork.cpp
+@@ -26,6 +26,8 @@
+ #include <queue>
+ #include <sstream>
+ #include <thread>
++#include <sys/stat.h>
++#include <iostream>
+ 
+ namespace fuzzer {
+ 
+@@ -70,6 +72,8 @@ struct FuzzJob {
+   std::string SeedListPath;
+   std::string CFPath;
+   size_t      JobId;
++  bool        Executing = false;
++  Vector<std::string> CopiedSeeds;
+ 
+   int         DftTimeInSeconds = 0;
+ 
+@@ -124,7 +128,6 @@ struct GlobalEnv {
+     Cmd.addFlag("reload", "0");  // working in an isolated dir, no reload.
+     Cmd.addFlag("print_final_stats", "1");
+     Cmd.addFlag("print_funcs", "0");  // no need to spend time symbolizing.
+-    Cmd.addFlag("max_total_time", std::to_string(std::min((size_t)300, JobId)));
+     Cmd.addFlag("stop_file", StopFile());
+     if (!DataFlowBinary.empty()) {
+       Cmd.addFlag("data_flow_trace", DFTDir);
+@@ -133,11 +136,10 @@ struct GlobalEnv {
+     }
+     auto Job = new FuzzJob;
+     std::string Seeds;
+-    if (size_t CorpusSubsetSize =
+-            std::min(Files.size(), (size_t)sqrt(Files.size() + 2))) {
++    if (size_t CorpusSubsetSize = Files.size()) {
+       auto Time1 = std::chrono::system_clock::now();
+       for (size_t i = 0; i < CorpusSubsetSize; i++) {
+-        auto &SF = Files[Rand->SkewTowardsLast(Files.size())];
++        auto &SF = Files[i];
+         Seeds += (Seeds.empty() ? "" : ",") + SF;
+         CollectDFT(SF);
+       }
+@@ -213,11 +215,20 @@ struct GlobalEnv {
+     Set<uint32_t> NewFeatures, NewCov;
+     CrashResistantMerge(Args, {}, MergeCandidates, &FilesToAdd, Features,
+                         &NewFeatures, Cov, &NewCov, Job->CFPath, false);
++    RemoveFile(Job->CFPath);
+     for (auto &Path : FilesToAdd) {
+-      auto U = FileToVector(Path);
+-      auto NewPath = DirPlusFile(MainCorpusDir, Hash(U));
+-      WriteToFile(U, NewPath);
+-      Files.push_back(NewPath);
++      // Only merge files that have not been merged already.
++      if (std::find(Job->CopiedSeeds.begin(), Job->CopiedSeeds.end(), Path) == Job->CopiedSeeds.end()) {
++        // NOT THREAD SAFE: Fast check whether file still exists.
++        struct stat buffer;
++        if (stat (Path.c_str(), &buffer) == 0) {
++          auto U = FileToVector(Path);
++          auto NewPath = DirPlusFile(MainCorpusDir, Hash(U));
++          WriteToFile(U, NewPath);
++          Files.push_back(NewPath);
++          Job->CopiedSeeds.push_back(Path);
++        }
++      }
+     }
+     Features.insert(NewFeatures.begin(), NewFeatures.end());
+     Cov.insert(NewCov.begin(), NewCov.end());
+@@ -271,10 +282,19 @@ struct JobQueue {
+   }
+ };
+ 
+-void WorkerThread(JobQueue *FuzzQ, JobQueue *MergeQ) {
++void WorkerThread(GlobalEnv *Env, JobQueue *FuzzQ, JobQueue *MergeQ) {
+   while (auto Job = FuzzQ->Pop()) {
+-    // Printf("WorkerThread: job %p\n", Job);
++    Job->Executing = true;
++    int Sleep_ms = 5 * 60 * 1000;
++    std::thread([=]() {
++      std::this_thread::sleep_for(std::chrono::milliseconds(Sleep_ms / 5));
++      while (Job->Executing) {
++        Env->RunOneMergeJob(Job);
++        std::this_thread::sleep_for(std::chrono::milliseconds(Sleep_ms));
++      }
++    }).detach();
+     Job->ExitCode = ExecuteCommand(Job->Cmd);
++    Job->Executing = false;
+     MergeQ->Push(Job);
+   }
+ }
+@@ -335,7 +355,7 @@ void FuzzWithFork(Random &Rand, const FuzzingOptions &Options,
+   size_t JobId = 1;
+   Vector<std::thread> Threads;
+   for (int t = 0; t < NumJobs; t++) {
+-    Threads.push_back(std::thread(WorkerThread, &FuzzQ, &MergeQ));
++    Threads.push_back(std::thread(WorkerThread, &Env, &FuzzQ, &MergeQ));
+     FuzzQ.Push(Env.CreateNewJob(JobId++));
+   }
+ 

--- a/fuzzers/libfuzzer_two_workers/runner.Dockerfile
+++ b/fuzzers/libfuzzer_two_workers/runner.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image


### PR DESCRIPTION
Add `libfuzzer_two_workers` fuzzing setup which launches two workers of libfuzzer without using fork mode.
Add `aflplusplus_two_instances` fuzzing setup which launches two simple AFL++ instances (main and secondary). Apply the same AFL++ settings that are used in fuzzolic/symqemu setups.