### PR TITLE
Fix saving corpus for a cycle

### DIFF
--- a/experiment/resources/runner-startup-script-template.sh
+++ b/experiment/resources/runner-startup-script-template.sh
@@ -56,4 +56,4 @@ docker run \
 {% if not local_experiment %}--name=runner-container {% endif %}\
 --cap-add SYS_NICE --cap-add SYS_PTRACE \
 --security-opt seccomp=unconfined \
-{{docker_image_url}} 2>&1 | tee /tmp/runner-log.txt
+{{docker_image_url}} 2>&1 | tee /tmp/runner-log-{{trial_id}}.txt

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -337,14 +337,17 @@ class TrialRunner:  # pylint: disable=too-many-instance-attributes
                     continue
 
                 file_path = os.path.join(root, filename)
-                stat_info = os.stat(file_path)
-                last_modified_time = stat_info.st_mtime
-                # Warning: ctime means creation time on Win and may not work as
-                # expected.
-                last_changed_time = stat_info.st_ctime
-                file_tuple = File(file_path, last_modified_time,
-                                  last_changed_time)
-                self.corpus_dir_contents.add(file_tuple)
+                try:
+                    stat_info = os.stat(file_path)
+                    last_modified_time = stat_info.st_mtime
+                    # Warning: ctime means creation time on Win and
+                    # may not work as expected.
+                    last_changed_time = stat_info.st_ctime
+                    file_tuple = File(file_path, last_modified_time,
+                                      last_changed_time)
+                    self.corpus_dir_contents.add(file_tuple)
+                except Exception:  # pylint: disable=broad-except
+                    pass
 
     def is_corpus_dir_same(self):
         """Sets |self.corpus_dir_contents| to the current contents and returns

--- a/experiment/test_scheduler.py
+++ b/experiment/test_scheduler.py
@@ -128,7 +128,7 @@ docker run \\
 --name=runner-container \\
 --cap-add SYS_NICE --cap-add SYS_PTRACE \\
 --security-opt seccomp=unconfined \\
-{docker_image_url} 2>&1 | tee /tmp/runner-log.txt'''
+{docker_image_url} 2>&1 | tee /tmp/runner-log-9.txt'''
     with mock.patch('common.benchmark_utils.get_fuzz_target',
                     return_value=expected_target):
         _test_create_trial_instance(benchmark, expected_image, expected_target,
@@ -172,7 +172,7 @@ docker run \\
 \\
 --cap-add SYS_NICE --cap-add SYS_PTRACE \\
 --security-opt seccomp=unconfined \\
-{docker_image_url} 2>&1 | tee /tmp/runner-log.txt'''
+{docker_image_url} 2>&1 | tee /tmp/runner-log-9.txt'''
     _test_create_trial_instance(benchmark, expected_image, expected_target,
                                 expected_startup_script,
                                 local_experiment_config, False)


### PR DESCRIPTION
This PR fixes a problem with generating coverage reports for some libFuzzer-based experiments. The feature of the libFuzzer is that it quickly removes files from corpus, so it may be deleted at the time we access it in `_set_corpus_dir_contents`. As a result, the corpus for a specific cycle will not be archived and saved. Apparently, the coverage report generator awaits a corpus from every cycle in direct order, so HTML reports will stop updating even if the next cycle corpuses would be saved.