### PR TITLE
Adding fuzzers from First, Fuzz the Mutants paper for aflplusplus

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -24,6 +24,8 @@ jobs:
           - aflplusplus_optimal
           - aflplusplus_tracepc
           - aflplusplus_zafl
+          - aflplusplus_um_prioritize
+          - aflplusplus_um_random
           - aflsmart
           - centipede
           - entropic

--- a/fuzzers/aflplusplus_um_prioritize/builder.Dockerfile
+++ b/fuzzers/aflplusplus_um_prioritize/builder.Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN apt-get update && apt-get install -y python3
+RUN pip3 install --upgrade --force pip
+RUN pip install universalmutator
+
+# Install libstdc++ to use llvm_mode.
+RUN apt-get update && \
+    apt-get install -y wget libstdc++-5-dev libtool-bin automake flex bison \
+                       libglib2.0-dev libpixman-1-dev python3-setuptools unzip \
+                       apt-utils apt-transport-https ca-certificates
+
+# Download and compile afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
+    cd /afl && \
+    git checkout b847e0f414e7b310e1a68bc501d4e2453bfce70e
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && unset CFLAGS && unset CXXFLAGS && \
+    export CC=clang && export AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && make install && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /
+

--- a/fuzzers/aflplusplus_um_prioritize/description.md
+++ b/fuzzers/aflplusplus_um_prioritize/description.md
@@ -1,0 +1,14 @@
+# aflplusplus
+
+AFL++ fuzzer instance that has the following config active for all benchmarks:
+  - PCGUARD instrumentation 
+  - cmplog feature
+  - dict2file feature
+  - "fast" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_um_prioritize/fuzzer.py
+++ b/fuzzers/aflplusplus_um_prioritize/fuzzer.py
@@ -1,0 +1,204 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for AFLplusplus fuzzer."""
+
+# This optimized afl++ variant should always be run together with
+# "aflplusplus" to show the difference - a default configured afl++ vs.
+# a hand-crafted optimized one. afl++ is configured not to enable the good
+# stuff by default to be as close to vanilla afl as possible.
+# But this means that the good stuff is hidden away in this benchmark
+# otherwise.
+
+import glob
+import os
+from pathlib import Path
+import random
+import shutil
+import filecmp
+import time
+import math
+
+from cryptography import sys
+from fuzzers.aflplusplus import fuzzer as aflplusplus_fuzzer
+from fuzzers import utils
+
+import signal
+from contextlib import contextmanager
+
+class TimeoutException(Exception): pass
+
+TOTAL_FUZZING_TIME_DEFAULT = 82800 # 23 hours
+TOTAL_BUILD_TIME = 43200 # 12 hours
+FUZZ_PROP = 0.5
+DEFAULT_MUTANT_TIMEOUT = 300
+PRIORITIZE_MULTIPLIER = 5
+GRACE_TIME = 3600 # 1 hour in seconds
+
+@contextmanager
+def time_limit(seconds):
+    def signal_handler(signum, frame):
+        raise TimeoutException("Timed out!")
+    signal.signal(signal.SIGALRM, signal_handler)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+
+def build():  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    start_time = time.time()
+
+    out = os.getenv("OUT")
+    src = os.getenv("SRC")
+    work = os.getenv("WORK")
+    storage_dir = "/storage"
+    os.mkdir(storage_dir)
+    mutate_dir = f"{storage_dir}/mutant_files"
+    os.mkdir(mutate_dir)
+    mutate_bins = f"{storage_dir}/mutant_bins"
+    os.mkdir(mutate_bins)
+    mutate_scripts = f"{storage_dir}/mutant_scripts"
+    os.mkdir(mutate_scripts)
+
+    orig_fuzz_target = os.getenv("FUZZ_TARGET")
+    with utils.restore_directory(src), utils.restore_directory(work):
+        aflplusplus_fuzzer.build()
+        shutil.copy(f"{out}/{orig_fuzz_target}", f"{mutate_bins}/{orig_fuzz_target}")
+    benchmark = os.getenv("BENCHMARK")
+    TOTAL_FUZZING_TIME = int(os.getenv('MAX_TOTAL_TIME', str(TOTAL_FUZZING_TIME_DEFAULT))) 
+
+    SOURCE_EXTENSIONS = [".c"] #[".c", ".cc", ".cpp", ".cxx", ".h", ".hpp", ".hxx"]
+    NUM_MUTANTS = math.ceil((TOTAL_FUZZING_TIME * FUZZ_PROP) / DEFAULT_MUTANT_TIMEOUT) # 23 hours - half fuzzing mutants * 60 (convert to mins) * 60 (secs) / 5 mins/mutant
+    # Use heuristic to try to find benchmark directory, otherwise look for all files in the current directory.
+    subdirs = [name for name in os.listdir(src) if os.path.isdir(os.path.join(src, name))]
+    benchmark_src_dir = src
+    for directory in subdirs:
+        if directory in benchmark:
+            benchmark_src_dir = os.path.join(src, directory)
+            break
+
+    source_files = []
+    for extension in SOURCE_EXTENSIONS:  
+        source_files += glob.glob(f"{benchmark_src_dir}/**/*{extension}", recursive=True)
+
+    NUM_PRIORITIZED = math.ceil((NUM_MUTANTS * PRIORITIZE_MULTIPLIER) / len(source_files))
+    print(NUM_PRIORITIZED)
+
+    prioritize_map = {}
+    for source_file in source_files:
+        source_dir = os.path.dirname(source_file).split(src, 1)[1]
+        Path(f"{mutate_dir}/{source_dir}").mkdir(parents=True, exist_ok=True)
+        os.system(f"mutate {source_file} --mutantDir {mutate_dir}/{source_dir} --noCheck > /dev/null")
+        source_base = os.path.basename(source_file).split(".")[0]
+        mutants_glob = glob.glob(f"{mutate_dir}/{source_dir}/{source_base}.mutant.*")
+        mutants = [f"{source_dir}/{mutant.split('/')[-1]}"[1:] for mutant in mutants_glob]
+        with open(f"{mutate_dir}/mutants.txt", "w") as f:
+            f.writelines("%s\n" % l for l in mutants)
+        os.system(f"prioritize_mutants {mutate_dir}/mutants.txt {mutate_dir}/prioritize_mutants_sorted.txt {NUM_PRIORITIZED} --noSDPriority --sourceDir {src} --mutantDir {mutate_dir}")
+        prioritized_list = []
+        with open(f"{mutate_dir}/prioritize_mutants_sorted.txt", "r") as f:
+            prioritized_list = f.read().splitlines()
+            prioritize_map[source_file] = prioritized_list
+
+    prioritized_keys = list(prioritize_map.keys())
+    random.shuffle(prioritized_keys)
+    order = []
+    ind = 0
+    finished = False
+
+    while not finished:
+        finished = True
+        for key in prioritized_keys:
+            if ind < len(prioritize_map[key]):
+                finished = False
+                order.append((key, ind))
+        ind += 1
+    print(order)
+    curr_time = time.time()
+
+    # Add grace time for final build at end
+    remaining_time = int(TOTAL_BUILD_TIME - (start_time - curr_time) - GRACE_TIME)
+
+    try:
+        with time_limit(remaining_time):
+            num_non_buggy = 1
+            ind = 0
+            while num_non_buggy <= NUM_MUTANTS and ind < len(order):
+                with utils.restore_directory(src), utils.restore_directory(work):
+                    key, line = order[ind]
+                    mutant = prioritize_map[key][line] 
+                    print(mutant)
+                    suffix = "." + mutant.split(".")[-1]
+                    mpart = ".mutant." + mutant.split(".mutant.")[1]
+                    source_file = f"{src}/{mutant.replace(mpart, suffix)}"
+                    print(source_file)
+                    print(f"{mutate_dir}/{mutant}")
+                    os.system(f"cp {source_file} {mutate_dir}/orig")
+                    os.system(f"cp {mutate_dir}/{mutant} {source_file}")
+                    try:
+                        new_fuzz_target = f"{os.getenv('FUZZ_TARGET')}.{num_non_buggy}"
+                        os.system(f"rm -rf {out}/*")
+                        aflplusplus_fuzzer.build()
+                        if not filecmp.cmp(f'{mutate_bins}/{orig_fuzz_target}', f'{out}/{orig_fuzz_target}', shallow=False):
+                            print(f"{out}/{orig_fuzz_target}", f"{mutate_bins}/{new_fuzz_target}")
+                            shutil.copy(f"{out}/{orig_fuzz_target}", f"{mutate_bins}/{new_fuzz_target}")
+                            num_non_buggy += 1
+                            print(f"FOUND NOT EQUAL {num_non_buggy}, ind: {ind}")
+                        else:
+                            print(f"EQUAL {num_non_buggy}, ind: {ind}")
+                    except Exception as e:
+                        print(e)
+                        print(f"EXECEPTION {num_non_buggy}, ind: {ind}")
+                        pass
+                    os.system(f"cp {mutate_dir}/orig {source_file}")
+                ind += 1
+    except TimeoutException as e:
+        print(e)
+        pass
+    
+    os.system(f"rm -rf {out}/*")
+    aflplusplus_fuzzer.build()
+    os.system(f"cp {mutate_bins}/* {out}/")
+
+
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    TOTAL_FUZZING_TIME = int(os.getenv('MAX_TOTAL_TIME', str(TOTAL_FUZZING_TIME_DEFAULT))) 
+    TOTAL_MUTANT_TIME = int(FUZZ_PROP * TOTAL_FUZZING_TIME) 
+
+    mutants = glob.glob(f"{target_binary}.*")
+    random.shuffle(mutants)
+    TIMEOUT = int(TOTAL_MUTANT_TIME / max(len(mutants), 1))
+
+    input_corpus_dir = "/storage/input_corpus"
+    os.mkdir("/storage")
+    os.mkdir(input_corpus_dir)
+    os.environ['AFL_SKIP_CRASHES'] = "1"
+
+    for mutant in mutants:
+        os.system(f"cp -r {input_corpus_dir}/* {input_corpus}/*")
+        try:
+            with time_limit(TIMEOUT):
+                aflplusplus_fuzzer.fuzz(input_corpus,
+                                        output_corpus,
+                                        mutant)
+        except TimeoutException as e:
+            pass
+        os.system(f"cp -r {output_corpus}/* {input_corpus_dir}/*")
+
+    os.system(f"cp -r {input_corpus_dir}/* {input_corpus}/*")
+    aflplusplus_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/aflplusplus_um_prioritize/runner.Dockerfile
+++ b/fuzzers/aflplusplus_um_prioritize/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/fuzzers/aflplusplus_um_random/builder.Dockerfile
+++ b/fuzzers/aflplusplus_um_random/builder.Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN apt-get update && apt-get install -y python3
+RUN pip3 install --upgrade --force pip
+RUN pip install universalmutator
+
+# Install libstdc++ to use llvm_mode.
+RUN apt-get update && \
+    apt-get install -y wget libstdc++-5-dev libtool-bin automake flex bison \
+                       libglib2.0-dev libpixman-1-dev python3-setuptools unzip \
+                       apt-utils apt-transport-https ca-certificates
+
+# Download and compile afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
+    cd /afl && \
+    git checkout b847e0f414e7b310e1a68bc501d4e2453bfce70e
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && unset CFLAGS && unset CXXFLAGS && \
+    export CC=clang && export AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && make install && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /
+

--- a/fuzzers/aflplusplus_um_random/description.md
+++ b/fuzzers/aflplusplus_um_random/description.md
@@ -1,0 +1,14 @@
+# aflplusplus
+
+AFL++ fuzzer instance that has the following config active for all benchmarks:
+  - PCGUARD instrumentation 
+  - cmplog feature
+  - dict2file feature
+  - "fast" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_um_random/fuzzer.py
+++ b/fuzzers/aflplusplus_um_random/fuzzer.py
@@ -1,0 +1,180 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for AFLplusplus fuzzer."""
+
+# This optimized afl++ variant should always be run together with
+# "aflplusplus" to show the difference - a default configured afl++ vs.
+# a hand-crafted optimized one. afl++ is configured not to enable the good
+# stuff by default to be as close to vanilla afl as possible.
+# But this means that the good stuff is hidden away in this benchmark
+# otherwise.
+
+import glob
+import os
+from pathlib import Path
+import random
+import shutil
+import filecmp
+import time
+
+from cryptography import sys
+from fuzzers.aflplusplus import fuzzer as aflplusplus_fuzzer
+from fuzzers import utils
+
+import signal
+from contextlib import contextmanager
+
+class TimeoutException(Exception): pass
+
+TOTAL_FUZZING_TIME_DEFAULT = 82800 # 23 hours
+TOTAL_BUILD_TIME = 43200 # 12 hours
+FUZZ_PROP = 0.5
+DEFAULT_MUTANT_TIMEOUT = 300
+PRIORITIZE_MULTIPLIER = 3
+GRACE_TIME = 3600 # 1 hour in seconds
+
+@contextmanager
+def time_limit(seconds):
+    def signal_handler(signum, frame):
+        raise TimeoutException("Timed out!")
+    signal.signal(signal.SIGALRM, signal_handler)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+
+def build():  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    start_time = time.time()
+
+    out = os.getenv("OUT")
+    src = os.getenv("SRC")
+    work = os.getenv("WORK")
+    storage_dir = "/storage"
+    os.mkdir(storage_dir)
+    mutate_dir = f"{storage_dir}/mutant_files"
+    os.mkdir(mutate_dir)
+    mutate_bins = f"{storage_dir}/mutant_bins"
+    os.mkdir(mutate_bins)
+    mutate_scripts = f"{storage_dir}/mutant_scripts"
+    os.mkdir(mutate_scripts)
+
+    orig_fuzz_target = os.getenv("FUZZ_TARGET")
+    with utils.restore_directory(src), utils.restore_directory(work):
+        aflplusplus_fuzzer.build()
+        shutil.copy(f"{out}/{orig_fuzz_target}", f"{mutate_bins}/{orig_fuzz_target}")
+    benchmark = os.getenv("BENCHMARK")
+    TOTAL_FUZZING_TIME = int(os.getenv('MAX_TOTAL_TIME', str(TOTAL_FUZZING_TIME_DEFAULT))) 
+
+    SOURCE_EXTENSIONS = [".c"] #[".c", ".cc", ".cpp", ".cxx", ".h", ".hpp", ".hxx"]
+    NUM_MUTANTS = int((TOTAL_FUZZING_TIME * FUZZ_PROP) / DEFAULT_MUTANT_TIMEOUT) # 23 hours - half fuzzing mutants * 60 (convert to mins) * 60 (secs) / 5 mins/mutant
+    # Use heuristic to try to find benchmark directory, otherwise look for all files in the current directory.
+    subdirs = [name for name in os.listdir(src) if os.path.isdir(os.path.join(src, name))]
+    benchmark_src_dir = src
+    for directory in subdirs:
+        if directory in benchmark:
+            benchmark_src_dir = os.path.join(src, directory)
+            break
+
+    source_files = []
+    for extension in SOURCE_EXTENSIONS:  
+        source_files += glob.glob(f"{benchmark_src_dir}/**/*{extension}", recursive=True)
+
+    mutants = []
+    for source_file in source_files:
+        source_dir = os.path.dirname(source_file).split(src, 1)[1]
+        Path(f"{mutate_dir}/{source_dir}").mkdir(parents=True, exist_ok=True)
+        os.system(f"mutate {source_file} --mutantDir {mutate_dir}/{source_dir} --noCheck > /dev/null")
+        source_base = os.path.basename(source_file).split(".")[0]
+        mutants_glob = glob.glob(f"{mutate_dir}/{source_dir}/{source_base}.mutant.*")
+        mutants += [f"{source_dir}/{mutant.split('/')[-1]}"[1:] for mutant in mutants_glob]
+
+    random.shuffle(mutants)    
+    with open(f"{mutate_dir}/mutants.txt", "w") as f:
+        f.writelines("%s\n" % l for l in mutants)
+
+    curr_time = time.time()
+
+    # Add grace time for final build at end
+    remaining_time = int(TOTAL_BUILD_TIME - (start_time - curr_time) - GRACE_TIME)
+
+    try:
+        with time_limit(remaining_time):
+            num_non_buggy = 1
+            ind = 0
+            while num_non_buggy <= NUM_MUTANTS and ind < len(mutants):
+                with utils.restore_directory(src), utils.restore_directory(work):
+                    mutant = mutants[ind] 
+                    suffix = "." + mutant.split(".")[-1]
+                    mpart = ".mutant." + mutant.split(".mutant.")[1]
+                    source_file = f"{src}/{mutant.replace(mpart, suffix)}"
+                    print(source_file)
+                    print(f"{mutate_dir}/{mutant}")
+                    os.system(f"cp {source_file} {mutate_dir}/orig")
+                    os.system(f"cp {mutate_dir}/{mutant} {source_file}")
+
+                    try:
+                        new_fuzz_target = f"{os.getenv('FUZZ_TARGET')}.{num_non_buggy}"
+                        os.system(f"rm -rf {out}/*")
+                        aflplusplus_fuzzer.build()
+                        if not filecmp.cmp(f'{mutate_bins}/{orig_fuzz_target}', f'{out}/{orig_fuzz_target}', shallow=False):
+                            print(f"{out}/{orig_fuzz_target}", f"{mutate_bins}/{new_fuzz_target}")
+                            shutil.copy(f"{out}/{orig_fuzz_target}", f"{mutate_bins}/{new_fuzz_target}")
+                            num_non_buggy += 1
+                        else:
+                            print("EQUAL")
+                    except Exception as e:
+                        print(e)
+                        pass
+                    os.system(f"cp {mutate_dir}/orig {source_file}")
+                    ind += 1
+    except TimeoutException as e:
+        print(e)
+        pass
+    
+    os.system(f"rm -rf {out}/*")
+    aflplusplus_fuzzer.build()
+    os.system(f"cp {mutate_bins}/* {out}/")
+
+
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    TOTAL_FUZZING_TIME = int(os.getenv('MAX_TOTAL_TIME', str(TOTAL_FUZZING_TIME_DEFAULT))) 
+    TOTAL_MUTANT_TIME = int(FUZZ_PROP * TOTAL_FUZZING_TIME) 
+
+    mutants = glob.glob(f"{target_binary}.*")
+    random.shuffle(mutants)
+    TIMEOUT = int(TOTAL_MUTANT_TIME / max(len(mutants), 1))
+
+    input_corpus_dir = "/storage/input_corpus"
+    os.mkdir("/storage")
+    os.mkdir(input_corpus_dir)
+    os.environ['AFL_SKIP_CRASHES'] = "1"
+
+    for mutant in mutants:
+        os.system(f"cp -r {input_corpus_dir}/* {input_corpus}/*")
+        try:
+            with time_limit(TIMEOUT):
+                aflplusplus_fuzzer.fuzz(input_corpus,
+                                        output_corpus,
+                                        mutant)
+        except TimeoutException as e:
+            pass
+        os.system(f"cp -r {output_corpus}/* {input_corpus_dir}/*")
+
+    os.system(f"cp -r {input_corpus_dir}/* {input_corpus}/*")
+    aflplusplus_fuzzer.fuzz(input_corpus, output_corpus, target_binary)

--- a/fuzzers/aflplusplus_um_random/fuzzer.py
+++ b/fuzzers/aflplusplus_um_random/fuzzer.py
@@ -27,27 +27,33 @@ import random
 import shutil
 import filecmp
 import time
+import signal
+import math
+from contextlib import contextmanager
 
-from cryptography import sys
 from fuzzers.aflplusplus import fuzzer as aflplusplus_fuzzer
 from fuzzers import utils
 
-import signal
-from contextlib import contextmanager
 
-class TimeoutException(Exception): pass
+class TimeoutException(Exception):
+    """"Exception thrown when timeouts occur"""
 
-TOTAL_FUZZING_TIME_DEFAULT = 82800 # 23 hours
-TOTAL_BUILD_TIME = 43200 # 12 hours
+
+TOTAL_FUZZING_TIME_DEFAULT = 82800  # 23 hours
+TOTAL_BUILD_TIME = 43200  # 12 hours
 FUZZ_PROP = 0.5
 DEFAULT_MUTANT_TIMEOUT = 300
 PRIORITIZE_MULTIPLIER = 3
-GRACE_TIME = 3600 # 1 hour in seconds
+GRACE_TIME = 3600  # 1 hour in seconds
+
 
 @contextmanager
 def time_limit(seconds):
+    """Method to define a time limit before throwing exception"""
+
     def signal_handler(signum, frame):
         raise TimeoutException("Timed out!")
+
     signal.signal(signal.SIGALRM, signal_handler)
     signal.alarm(seconds)
     try:
@@ -55,7 +61,8 @@ def time_limit(seconds):
     finally:
         signal.alarm(0)
 
-def build():  # pylint: disable=too-many-branches,too-many-statements
+
+def build():  # pylint: disable=too-many-locals,too-many-statements
     """Build benchmark."""
     start_time = time.time()
 
@@ -74,14 +81,17 @@ def build():  # pylint: disable=too-many-branches,too-many-statements
     orig_fuzz_target = os.getenv("FUZZ_TARGET")
     with utils.restore_directory(src), utils.restore_directory(work):
         aflplusplus_fuzzer.build()
-        shutil.copy(f"{out}/{orig_fuzz_target}", f"{mutate_bins}/{orig_fuzz_target}")
+        shutil.copy(f"{out}/{orig_fuzz_target}",
+                    f"{mutate_bins}/{orig_fuzz_target}")
     benchmark = os.getenv("BENCHMARK")
-    TOTAL_FUZZING_TIME = int(os.getenv('MAX_TOTAL_TIME', str(TOTAL_FUZZING_TIME_DEFAULT))) 
 
-    SOURCE_EXTENSIONS = [".c"] #[".c", ".cc", ".cpp", ".cxx", ".h", ".hpp", ".hxx"]
-    NUM_MUTANTS = int((TOTAL_FUZZING_TIME * FUZZ_PROP) / DEFAULT_MUTANT_TIMEOUT) # 23 hours - half fuzzing mutants * 60 (convert to mins) * 60 (secs) / 5 mins/mutant
-    # Use heuristic to try to find benchmark directory, otherwise look for all files in the current directory.
-    subdirs = [name for name in os.listdir(src) if os.path.isdir(os.path.join(src, name))]
+    source_extensions = [".c"]
+    # Use heuristic to try to find benchmark directory,
+    # otherwise look for all files in the current directory.
+    subdirs = [
+        name for name in os.listdir(src)
+        if os.path.isdir(os.path.join(src, name))
+    ]
     benchmark_src_dir = src
     for directory in subdirs:
         if directory in benchmark:
@@ -89,34 +99,42 @@ def build():  # pylint: disable=too-many-branches,too-many-statements
             break
 
     source_files = []
-    for extension in SOURCE_EXTENSIONS:  
-        source_files += glob.glob(f"{benchmark_src_dir}/**/*{extension}", recursive=True)
+    for extension in source_extensions:
+        source_files += glob.glob(f"{benchmark_src_dir}/**/*{extension}",
+                                  recursive=True)
 
     mutants = []
     for source_file in source_files:
         source_dir = os.path.dirname(source_file).split(src, 1)[1]
         Path(f"{mutate_dir}/{source_dir}").mkdir(parents=True, exist_ok=True)
-        os.system(f"mutate {source_file} --mutantDir {mutate_dir}/{source_dir} --noCheck > /dev/null")
+        os.system(f"mutate {source_file} --mutantDir \
+                {mutate_dir}/{source_dir} --noCheck > /dev/null")
         source_base = os.path.basename(source_file).split(".")[0]
-        mutants_glob = glob.glob(f"{mutate_dir}/{source_dir}/{source_base}.mutant.*")
-        mutants += [f"{source_dir}/{mutant.split('/')[-1]}"[1:] for mutant in mutants_glob]
+        mutants_glob = glob.glob(
+            f"{mutate_dir}/{source_dir}/{source_base}.mutant.*")
+        mutants += [
+            f"{source_dir}/{mutant.split('/')[-1]}"[1:]
+            for mutant in mutants_glob
+        ]
 
-    random.shuffle(mutants)    
-    with open(f"{mutate_dir}/mutants.txt", "w") as f:
-        f.writelines("%s\n" % l for l in mutants)
+    random.shuffle(mutants)
+    with open(f"{mutate_dir}/mutants.txt", "w", encoding="utf-8") as f_name:
+        f_name.writelines(f"{l}\n" for l in mutants)
 
     curr_time = time.time()
 
     # Add grace time for final build at end
-    remaining_time = int(TOTAL_BUILD_TIME - (start_time - curr_time) - GRACE_TIME)
+    remaining_time = int(TOTAL_BUILD_TIME - (start_time - curr_time) -
+                         GRACE_TIME)
 
     try:
         with time_limit(remaining_time):
             num_non_buggy = 1
             ind = 0
-            while num_non_buggy <= NUM_MUTANTS and ind < len(mutants):
-                with utils.restore_directory(src), utils.restore_directory(work):
-                    mutant = mutants[ind] 
+            while ind < len(mutants):
+                with utils.restore_directory(src), utils.restore_directory(
+                        work):
+                    mutant = mutants[ind]
                     suffix = "." + mutant.split(".")[-1]
                     mpart = ".mutant." + mutant.split(".mutant.")[1]
                     source_file = f"{src}/{mutant.replace(mpart, suffix)}"
@@ -126,53 +144,56 @@ def build():  # pylint: disable=too-many-branches,too-many-statements
                     os.system(f"cp {mutate_dir}/{mutant} {source_file}")
 
                     try:
-                        new_fuzz_target = f"{os.getenv('FUZZ_TARGET')}.{num_non_buggy}"
+                        new_fuzz_target = f"{os.getenv('FUZZ_TARGET')}\
+                            .{num_non_buggy}"
+
                         os.system(f"rm -rf {out}/*")
                         aflplusplus_fuzzer.build()
-                        if not filecmp.cmp(f'{mutate_bins}/{orig_fuzz_target}', f'{out}/{orig_fuzz_target}', shallow=False):
-                            print(f"{out}/{orig_fuzz_target}", f"{mutate_bins}/{new_fuzz_target}")
-                            shutil.copy(f"{out}/{orig_fuzz_target}", f"{mutate_bins}/{new_fuzz_target}")
+                        if not filecmp.cmp(f'{mutate_bins}/{orig_fuzz_target}',
+                                           f'{out}/{orig_fuzz_target}',
+                                           shallow=False):
+                            print(f"{out}/{orig_fuzz_target}",
+                                  f"{mutate_bins}/{new_fuzz_target}")
+                            shutil.copy(f"{out}/{orig_fuzz_target}",
+                                        f"{mutate_bins}/{new_fuzz_target}")
                             num_non_buggy += 1
                         else:
                             print("EQUAL")
-                    except Exception as e:
-                        print(e)
+                    except RuntimeError:
                         pass
                     os.system(f"cp {mutate_dir}/orig {source_file}")
                     ind += 1
-    except TimeoutException as e:
-        print(e)
+    except TimeoutException:
         pass
-    
+
     os.system(f"rm -rf {out}/*")
     aflplusplus_fuzzer.build()
     os.system(f"cp {mutate_bins}/* {out}/")
 
 
-
-
 def fuzz(input_corpus, output_corpus, target_binary):
     """Run fuzzer."""
-    TOTAL_FUZZING_TIME = int(os.getenv('MAX_TOTAL_TIME', str(TOTAL_FUZZING_TIME_DEFAULT))) 
-    TOTAL_MUTANT_TIME = int(FUZZ_PROP * TOTAL_FUZZING_TIME) 
+    total_fuzzing_time = int(
+        os.getenv('MAX_TOTAL_TIME', str(TOTAL_FUZZING_TIME_DEFAULT)))
+    total_mutant_time = int(FUZZ_PROP * total_fuzzing_time)
 
     mutants = glob.glob(f"{target_binary}.*")
     random.shuffle(mutants)
-    TIMEOUT = int(TOTAL_MUTANT_TIME / max(len(mutants), 1))
+    timeout = max(DEFAULT_MUTANT_TIMEOUT,
+                  int(total_mutant_time / max(len(mutants), 1)))
+    num_mutants = min(math.ceil(total_mutant_time / timeout), len(mutants))
 
     input_corpus_dir = "/storage/input_corpus"
     os.mkdir("/storage")
     os.mkdir(input_corpus_dir)
     os.environ['AFL_SKIP_CRASHES'] = "1"
 
-    for mutant in mutants:
+    for mutant in mutants[:num_mutants]:
         os.system(f"cp -r {input_corpus_dir}/* {input_corpus}/*")
         try:
-            with time_limit(TIMEOUT):
-                aflplusplus_fuzzer.fuzz(input_corpus,
-                                        output_corpus,
-                                        mutant)
-        except TimeoutException as e:
+            with time_limit(timeout):
+                aflplusplus_fuzzer.fuzz(input_corpus, output_corpus, mutant)
+        except TimeoutException:
             pass
         os.system(f"cp -r {output_corpus}/* {input_corpus_dir}/*")
 

--- a/fuzzers/aflplusplus_um_random/runner.Dockerfile
+++ b/fuzzers/aflplusplus_um_random/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -20,6 +20,13 @@
 # Please add new experiment requests towards the top of this file.
 #
 
+- experiment: 2022-08-25-aflpp-um
+  description: "afl++ um coverage experiments (compare our fuzzers against afl++)"
+  fuzzers:
+    - aflplusplus_um_prioritize
+    - aflplusplus_um_random
+    - aflplusplus
+
 - experiment: 2022-08-18-libfuzzer-focus
   description: "Testing with focus function driven by fuzz introspector results"
   fuzzers:


### PR DESCRIPTION
Adding 2 new fuzzers to try out that first mutate the source code and then run fuzzing as normal for aflplusplus. These fuzzers are from our paper: https://www.ndss-symposium.org/wp-content/uploads/fuzzing2022_23002_paper.pdf. 

The two fuzzers added are as follows: 
1. aflplusplus_um_prioritize - run aflplusplus by first spending half the budget generating mutants that build and do not generate equivalent binaries, then afterwards randomly selecting mutants and running aflplusplus on the mutated binaries for half the budget. 
2. aflplusplus_um_random - run aflplusplus by first spending half the budget generating mutants that build and do not generate equivalent binaries, then afterwards running FPF to prioritize the mutants and running aflplusplus on the prioritized mutated binaries for half the budget.