### PR TITLE
Update curl's unsupported fuzzers

### DIFF
--- a/benchmarks/curl_curl_fuzzer_http/benchmark.yaml
+++ b/benchmarks/curl_curl_fuzzer_http/benchmark.yaml
@@ -21,3 +21,4 @@ unsupported_fuzzers:
   - libfuzzer_dataflow
   - libfuzzer_dataflow_load
   - libfuzzer_dataflow_store
+  - centipede_function_filter


### PR DESCRIPTION
Add `centipede_function_filter` to the list of unsupported fuzzers.