### PR TITLE
Centipede modes

### DIFF
--- a/fuzzers/centipede/runner.Dockerfile
+++ b/fuzzers/centipede/runner.Dockerfile
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 FROM gcr.io/fuzzbench/base-image
+
+COPY --from=base-clang /usr/local/bin/llvm-symbolizer /usr/local/bin/

--- a/fuzzers/centipede_corpus_1000/builder.Dockerfile
+++ b/fuzzers/centipede_corpus_1000/builder.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+ENV CENTIPEDE_SRC=/src/centipede
+
+# Build centipede.
+RUN git clone -n \
+    https://github.com/google/centipede.git "$CENTIPEDE_SRC" && \
+  echo 'build --client_env=CC=clang --cxxopt=-std=c++17 ' \
+    '--cxxopt=-stdlib=libc++ --linkopt=-lc++' >> ~/.bazelrc && \
+  (cd "$CENTIPEDE_SRC" && \
+    git checkout 2a2c78a2c161d99f5962b9710bce61feb00acc3d && \
+    ./install_dependencies_debian.sh && \
+    bazel build -c opt :all) && \
+  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede'
+
+RUN /clang/bin/clang "$CENTIPEDE_SRC/weak_sancov_stubs.cc" -c -o /lib/weak.o

--- a/fuzzers/centipede_corpus_1000/fuzzer.py
+++ b/fuzzers/centipede_corpus_1000/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for a mode of centipede fuzzer."""
+from fuzzers.centipede import fuzzer
+
+
+def build():
+    """Build benchmark."""
+    fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling run_fuzzer."""
+    # 1000 inputs in the in-memory corpus.
+    mode_flags = ['--max_corpus_size=1000']
+    fuzzer.run_fuzzer(input_corpus,
+                      output_corpus,
+                      target_binary,
+                      extra_flags=mode_flags)

--- a/fuzzers/centipede_corpus_1000/runner.Dockerfile
+++ b/fuzzers/centipede_corpus_1000/runner.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+COPY --from=base-clang /usr/local/bin/llvm-symbolizer /usr/local/bin/

--- a/fuzzers/centipede_corpus_10000/builder.Dockerfile
+++ b/fuzzers/centipede_corpus_10000/builder.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+ENV CENTIPEDE_SRC=/src/centipede
+
+# Build centipede.
+RUN git clone -n \
+    https://github.com/google/centipede.git "$CENTIPEDE_SRC" && \
+  echo 'build --client_env=CC=clang --cxxopt=-std=c++17 ' \
+    '--cxxopt=-stdlib=libc++ --linkopt=-lc++' >> ~/.bazelrc && \
+  (cd "$CENTIPEDE_SRC" && \
+    git checkout 2a2c78a2c161d99f5962b9710bce61feb00acc3d && \
+    ./install_dependencies_debian.sh && \
+    bazel build -c opt :all) && \
+  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede'
+
+RUN /clang/bin/clang "$CENTIPEDE_SRC/weak_sancov_stubs.cc" -c -o /lib/weak.o

--- a/fuzzers/centipede_corpus_10000/fuzzer.py
+++ b/fuzzers/centipede_corpus_10000/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for a mode of centipede fuzzer."""
+from fuzzers.centipede import fuzzer
+
+
+def build():
+    """Build benchmark."""
+    fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling run_fuzzer."""
+    # 10000 inputs in the in-memory corpus.
+    mode_flags = ['--max_corpus_size=10000']
+    fuzzer.run_fuzzer(input_corpus,
+                      output_corpus,
+                      target_binary,
+                      extra_flags=mode_flags)

--- a/fuzzers/centipede_corpus_10000/runner.Dockerfile
+++ b/fuzzers/centipede_corpus_10000/runner.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+COPY --from=base-clang /usr/local/bin/llvm-symbolizer /usr/local/bin/

--- a/fuzzers/centipede_counter/builder.Dockerfile
+++ b/fuzzers/centipede_counter/builder.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+ENV CENTIPEDE_SRC=/src/centipede
+
+# Build centipede.
+RUN git clone -n \
+    https://github.com/google/centipede.git "$CENTIPEDE_SRC" && \
+  echo 'build --client_env=CC=clang --cxxopt=-std=c++17 ' \
+    '--cxxopt=-stdlib=libc++ --linkopt=-lc++' >> ~/.bazelrc && \
+  (cd "$CENTIPEDE_SRC" && \
+    git checkout 2a2c78a2c161d99f5962b9710bce61feb00acc3d && \
+    ./install_dependencies_debian.sh && \
+    bazel build -c opt :all) && \
+  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede'
+
+RUN /clang/bin/clang "$CENTIPEDE_SRC/weak_sancov_stubs.cc" -c -o /lib/weak.o

--- a/fuzzers/centipede_counter/fuzzer.py
+++ b/fuzzers/centipede_counter/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for a mode of centipede fuzzer."""
+from fuzzers.centipede import fuzzer
+
+
+def build():
+    """Build benchmark."""
+    fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling run_fuzzer."""
+    # Use features derived from counting the occurrences number of a given PC.
+    mode_flags = ['--use_counter_features=1']
+    fuzzer.run_fuzzer(input_corpus,
+                      output_corpus,
+                      target_binary,
+                      extra_flags=mode_flags)

--- a/fuzzers/centipede_counter/runner.Dockerfile
+++ b/fuzzers/centipede_counter/runner.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+COPY --from=base-clang /usr/local/bin/llvm-symbolizer /usr/local/bin/

--- a/fuzzers/centipede_coverage_frontier/builder.Dockerfile
+++ b/fuzzers/centipede_coverage_frontier/builder.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+ENV CENTIPEDE_SRC=/src/centipede
+
+# Build centipede.
+RUN git clone -n \
+    https://github.com/google/centipede.git "$CENTIPEDE_SRC" && \
+  echo 'build --client_env=CC=clang --cxxopt=-std=c++17 ' \
+    '--cxxopt=-stdlib=libc++ --linkopt=-lc++' >> ~/.bazelrc && \
+  (cd "$CENTIPEDE_SRC" && \
+    git checkout 2a2c78a2c161d99f5962b9710bce61feb00acc3d && \
+    ./install_dependencies_debian.sh && \
+    bazel build -c opt :all) && \
+  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede'
+
+RUN /clang/bin/clang "$CENTIPEDE_SRC/weak_sancov_stubs.cc" -c -o /lib/weak.o

--- a/fuzzers/centipede_coverage_frontier/fuzzer.py
+++ b/fuzzers/centipede_coverage_frontier/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for a mode of centipede fuzzer."""
+from fuzzers.centipede import fuzzer
+
+
+def build():
+    """Build benchmark."""
+    fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling run_fuzzer."""
+    # Use coverage frontier when choosing the corpus element to mutate.
+    mode_flags = ['--use_coverage_frontier=1']
+    fuzzer.run_fuzzer(input_corpus,
+                      output_corpus,
+                      target_binary,
+                      extra_flags=mode_flags)

--- a/fuzzers/centipede_coverage_frontier/runner.Dockerfile
+++ b/fuzzers/centipede_coverage_frontier/runner.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+COPY --from=base-clang /usr/local/bin/llvm-symbolizer /usr/local/bin/

--- a/fuzzers/centipede_no_cmp/builder.Dockerfile
+++ b/fuzzers/centipede_no_cmp/builder.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+ENV CENTIPEDE_SRC=/src/centipede
+
+# Build centipede.
+RUN git clone -n \
+    https://github.com/google/centipede.git "$CENTIPEDE_SRC" && \
+  echo 'build --client_env=CC=clang --cxxopt=-std=c++17 ' \
+    '--cxxopt=-stdlib=libc++ --linkopt=-lc++' >> ~/.bazelrc && \
+  (cd "$CENTIPEDE_SRC" && \
+    git checkout 2a2c78a2c161d99f5962b9710bce61feb00acc3d && \
+    ./install_dependencies_debian.sh && \
+    bazel build -c opt :all) && \
+  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede'
+
+RUN /clang/bin/clang "$CENTIPEDE_SRC/weak_sancov_stubs.cc" -c -o /lib/weak.o

--- a/fuzzers/centipede_no_cmp/fuzzer.py
+++ b/fuzzers/centipede_no_cmp/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for a mode of centipede fuzzer."""
+from fuzzers.centipede import fuzzer
+
+
+def build():
+    """Build benchmark."""
+    fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling run_fuzzer."""
+    # Not use features derived from instrumentation of CMP instructions.
+    mode_flags = ['--use_cmp_features=0']
+    fuzzer.run_fuzzer(input_corpus,
+                      output_corpus,
+                      target_binary,
+                      extra_flags=mode_flags)

--- a/fuzzers/centipede_no_cmp/runner.Dockerfile
+++ b/fuzzers/centipede_no_cmp/runner.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+COPY --from=base-clang /usr/local/bin/llvm-symbolizer /usr/local/bin/

--- a/fuzzers/centipede_no_corpus_weight/builder.Dockerfile
+++ b/fuzzers/centipede_no_corpus_weight/builder.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+ENV CENTIPEDE_SRC=/src/centipede
+
+# Build centipede.
+RUN git clone -n \
+    https://github.com/google/centipede.git "$CENTIPEDE_SRC" && \
+  echo 'build --client_env=CC=clang --cxxopt=-std=c++17 ' \
+    '--cxxopt=-stdlib=libc++ --linkopt=-lc++' >> ~/.bazelrc && \
+  (cd "$CENTIPEDE_SRC" && \
+    git checkout 2a2c78a2c161d99f5962b9710bce61feb00acc3d && \
+    ./install_dependencies_debian.sh && \
+    bazel build -c opt :all) && \
+  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede'
+
+RUN /clang/bin/clang "$CENTIPEDE_SRC/weak_sancov_stubs.cc" -c -o /lib/weak.o

--- a/fuzzers/centipede_no_corpus_weight/fuzzer.py
+++ b/fuzzers/centipede_no_corpus_weight/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for a mode of centipede fuzzer."""
+from fuzzers.centipede import fuzzer
+
+
+def build():
+    """Build benchmark."""
+    fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling run_fuzzer."""
+    # Not use weighted distribution when choosing the corpus element to mutate.
+    mode_flags = ['--use_corpus_weights=0']
+    fuzzer.run_fuzzer(input_corpus,
+                      output_corpus,
+                      target_binary,
+                      extra_flags=mode_flags)

--- a/fuzzers/centipede_no_corpus_weight/runner.Dockerfile
+++ b/fuzzers/centipede_no_corpus_weight/runner.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+COPY --from=base-clang /usr/local/bin/llvm-symbolizer /usr/local/bin/

--- a/fuzzers/centipede_no_dataflow/builder.Dockerfile
+++ b/fuzzers/centipede_no_dataflow/builder.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+ENV CENTIPEDE_SRC=/src/centipede
+
+# Build centipede.
+RUN git clone -n \
+    https://github.com/google/centipede.git "$CENTIPEDE_SRC" && \
+  echo 'build --client_env=CC=clang --cxxopt=-std=c++17 ' \
+    '--cxxopt=-stdlib=libc++ --linkopt=-lc++' >> ~/.bazelrc && \
+  (cd "$CENTIPEDE_SRC" && \
+    git checkout 2a2c78a2c161d99f5962b9710bce61feb00acc3d && \
+    ./install_dependencies_debian.sh && \
+    bazel build -c opt :all) && \
+  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede'
+
+RUN /clang/bin/clang "$CENTIPEDE_SRC/weak_sancov_stubs.cc" -c -o /lib/weak.o

--- a/fuzzers/centipede_no_dataflow/fuzzer.py
+++ b/fuzzers/centipede_no_dataflow/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for a mode of centipede fuzzer."""
+from fuzzers.centipede import fuzzer
+
+
+def build():
+    """Build benchmark."""
+    fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling run_fuzzer."""
+    # Not use features derived from instrumentation of dataflows.
+    mode_flags = ['--use_dataflow_features=0']
+    fuzzer.run_fuzzer(input_corpus,
+                      output_corpus,
+                      target_binary,
+                      extra_flags=mode_flags)

--- a/fuzzers/centipede_no_dataflow/runner.Dockerfile
+++ b/fuzzers/centipede_no_dataflow/runner.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+COPY --from=base-clang /usr/local/bin/llvm-symbolizer /usr/local/bin/

--- a/fuzzers/centipede_path_10/builder.Dockerfile
+++ b/fuzzers/centipede_path_10/builder.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+ENV CENTIPEDE_SRC=/src/centipede
+
+# Build centipede.
+RUN git clone -n \
+    https://github.com/google/centipede.git "$CENTIPEDE_SRC" && \
+  echo 'build --client_env=CC=clang --cxxopt=-std=c++17 ' \
+    '--cxxopt=-stdlib=libc++ --linkopt=-lc++' >> ~/.bazelrc && \
+  (cd "$CENTIPEDE_SRC" && \
+    git checkout 2a2c78a2c161d99f5962b9710bce61feb00acc3d && \
+    ./install_dependencies_debian.sh && \
+    bazel build -c opt :all) && \
+  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede'
+
+RUN /clang/bin/clang "$CENTIPEDE_SRC/weak_sancov_stubs.cc" -c -o /lib/weak.o

--- a/fuzzers/centipede_path_10/fuzzer.py
+++ b/fuzzers/centipede_path_10/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for a mode of centipede fuzzer."""
+from fuzzers.centipede import fuzzer
+
+
+def build():
+    """Build benchmark."""
+    fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling run_fuzzer."""
+    # Use features derived from bounded execution paths.
+    mode_flags = ['--path_level=10']
+    fuzzer.run_fuzzer(input_corpus,
+                      output_corpus,
+                      target_binary,
+                      extra_flags=mode_flags)

--- a/fuzzers/centipede_path_10/runner.Dockerfile
+++ b/fuzzers/centipede_path_10/runner.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+COPY --from=base-clang /usr/local/bin/llvm-symbolizer /usr/local/bin/

--- a/fuzzers/centipede_path_5/builder.Dockerfile
+++ b/fuzzers/centipede_path_5/builder.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+ENV CENTIPEDE_SRC=/src/centipede
+
+# Build centipede.
+RUN git clone -n \
+    https://github.com/google/centipede.git "$CENTIPEDE_SRC" && \
+  echo 'build --client_env=CC=clang --cxxopt=-std=c++17 ' \
+    '--cxxopt=-stdlib=libc++ --linkopt=-lc++' >> ~/.bazelrc && \
+  (cd "$CENTIPEDE_SRC" && \
+    git checkout 2a2c78a2c161d99f5962b9710bce61feb00acc3d && \
+    ./install_dependencies_debian.sh && \
+    bazel build -c opt :all) && \
+  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede'
+
+RUN /clang/bin/clang "$CENTIPEDE_SRC/weak_sancov_stubs.cc" -c -o /lib/weak.o

--- a/fuzzers/centipede_path_5/fuzzer.py
+++ b/fuzzers/centipede_path_5/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for a mode of centipede fuzzer."""
+from fuzzers.centipede import fuzzer
+
+
+def build():
+    """Build benchmark."""
+    fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling run_fuzzer."""
+    # Use features derived from bounded execution paths.
+    mode_flags = ['--path_level=5']
+    fuzzer.run_fuzzer(input_corpus,
+                      output_corpus,
+                      target_binary,
+                      extra_flags=mode_flags)

--- a/fuzzers/centipede_path_5/runner.Dockerfile
+++ b/fuzzers/centipede_path_5/runner.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+COPY --from=base-clang /usr/local/bin/llvm-symbolizer /usr/local/bin/

--- a/fuzzers/centipede_pcpair/builder.Dockerfile
+++ b/fuzzers/centipede_pcpair/builder.Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+ENV CENTIPEDE_SRC=/src/centipede
+
+# Build centipede.
+RUN git clone -n \
+    https://github.com/google/centipede.git "$CENTIPEDE_SRC" && \
+  echo 'build --client_env=CC=clang --cxxopt=-std=c++17 ' \
+    '--cxxopt=-stdlib=libc++ --linkopt=-lc++' >> ~/.bazelrc && \
+  (cd "$CENTIPEDE_SRC" && \
+    git checkout 2a2c78a2c161d99f5962b9710bce61feb00acc3d && \
+    ./install_dependencies_debian.sh && \
+    bazel build -c opt :all) && \
+  cp "$CENTIPEDE_SRC/bazel-bin/centipede" '/out/centipede'
+
+RUN /clang/bin/clang "$CENTIPEDE_SRC/weak_sancov_stubs.cc" -c -o /lib/weak.o

--- a/fuzzers/centipede_pcpair/fuzzer.py
+++ b/fuzzers/centipede_pcpair/fuzzer.py
@@ -1,0 +1,30 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for a mode of centipede fuzzer."""
+from fuzzers.centipede import fuzzer
+
+
+def build():
+    """Build benchmark."""
+    fuzzer.build()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer. Wrapper that uses the defaults when calling run_fuzzer."""
+    # PC pairs are used as additional synthetic features.
+    mode_flags = ['--use_pcpair_features=1']
+    fuzzer.run_fuzzer(input_corpus,
+                      output_corpus,
+                      target_binary,
+                      extra_flags=mode_flags)

--- a/fuzzers/centipede_pcpair/runner.Dockerfile
+++ b/fuzzers/centipede_pcpair/runner.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+COPY --from=base-clang /usr/local/bin/llvm-symbolizer /usr/local/bin/


### PR DESCRIPTION
Add different modes of `Centipede` for coverage experiments:
* [Default](https://github.com/google/fuzzbench/blob/master/fuzzers/centipede/fuzzer.py#L71) (no extra flags)
* `--use_counter_features=1`
* `--use_corpus_weights=0`
* `--use_coverage_frontier=1`
* `--max_corpus_size=1000`
* `--max_corpus_size=10000`
* `--use_cmp_features=0`
* `--path_level=5`
* `--path_level=10`
* `--use_pcpair_features=1`
* `--use_dataflow_features=0`

Probably unnecessary to merge, as they are for temporary experiments and this is only for us to check the settings/flags.