### PR TITLE
Improve how the critical difference diagram is computed

### DIFF
--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -277,6 +277,23 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
                               key=self._relevant_column),
             experiment_level_ranking_function)
 
+    def _ranking_not_aggregated(self, benchmark_level_ranking_function,
+                                experiment_level_ranking_function):
+        df = self._experiment_snapshots_df
+        # group trials by assigning a trial group that ranges from 1 to the maximum
+        # number of trials for each combination of fuzzer and benchmark
+        df['trials_group'] = df.groupby(['fuzzer', 'benchmark']).cumcount() + 1
+        df['trials_group'] = df['trials_group'].astype(str)
+        # append the trial group to each benchmark name
+        df['benchmark'] = df[['benchmark', 'trials_group']].agg('-'.join,
+                                                                axis=1)
+        new_df = df.drop(columns=['trials_group'])
+        return data_utils.experiment_level_ranking(
+            new_df,
+            functools.partial(benchmark_level_ranking_function,
+                              key=self._relevant_column),
+            experiment_level_ranking_function)
+
     @property
     def rank_by_average_rank_and_average_rank(self):
         """Rank fuzzers using average rank per benchmark and average rank
@@ -297,6 +314,14 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
         across benchmarks."""
         return self._ranking(data_utils.benchmark_rank_by_median,
                              data_utils.experiment_rank_by_average_rank)
+
+    @property
+    def rank_by_coverage_and_normalized_score(self):
+        """Rank fuzzers using coverage per trial and normalized score 
+        across trials."""
+        return self._ranking_not_aggregated(
+            data_utils.benchmark_rank_by_median,
+            data_utils.experiment_rank_by_average_rank)
 
     @property
     def rank_by_median_and_average_normalized_score(self):
@@ -357,8 +382,8 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
 
         Represents average ranks of fuzzers across all benchmarks,
         considering medians on final coverage.
-        """
-        average_ranks = self.rank_by_median_and_average_rank
+        """        
+        average_ranks = self.rank_by_coverage_and_normalized_score
         num_of_benchmarks = self.summary_table.shape[0]
 
         plot_filename = 'experiment_critical_difference_plot.svg'

--- a/analysis/report_templates/default.html
+++ b/analysis/report_templates/default.html
@@ -97,7 +97,7 @@
                 <div class="col s5">
                     <h5 class="center-align">By avg. rank</h5>
                     {{ experiment.linkify_names(
-                         experiment.rank_by_median_and_average_rank.round(2).to_frame()
+                         experiment.rank_by_coverage_and_normalized_score.round(2).to_frame()
                        ).to_html(escape=False)
                     }}
                 </div>


### PR DESCRIPTION
This PR fixes an issue with how the criticial difference diagram is computed (see https://github.com/google/fuzzbench/issues/1417). Namely, increasing the number of trials per benchmarks (T) does not reduce the critical difference since the computation is based on the average rank across all trials. Increasing the number of trials does increase the confidence in the average rank, but this is not reflected in the critical difference diagram.

This PR proposes the following alternative: instead of computing the average rank per benchmark we group trials for a given benchmark such that each sub-benchmark only contains a single trial per fuzzer. In other words, for each benchmark we create T sub-benchmarks with exactly one trial per fuzzer; i.e., given B benchmarks with T trials each, we end up with BxT sub-benchmarks with 1 trial each. Finally, the critical difference diagram is compute on the sub-benchmarks.

As a result, any increase in the number of trials T will reduce the critical difference.

To demonstrate the effect, let us compare the two approaches for a past fuzzbench run with 20 trials (see [Main experiment](https://www.fuzzbench.com/reports/paper/Main%20Experiment/index.html)). This is the critical difference diagram with the existing approach:

![image](https://user-images.githubusercontent.com/16756648/193569585-e18113c5-608d-4ea9-8923-a05a0ee533d4.png)


This is the critical difference diagram when using the alternative approach:

![image](https://user-images.githubusercontent.com/16756648/193569627-cfdbd55d-0c8e-43fd-8441-9c65df02ee2f.png)


As we can see, the alternative approach actually reduces the critical difference significantly. For instance, there is now a significant difference between fuzzers aflplusplus and honggfuzz whereas the difference was not significant with the existing approach.

