### PR TITLE
Request re-run WingFuzz experiment

### DIFF
--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -20,6 +20,22 @@
 # Please add new experiment requests towards the top of this file.
 #
 
+- experiment: 2022-10-08-wingfuzz
+  description: "Wingfuzz coverage experiment (compare against core fuzzers)"
+  fuzzers:
+    - afl
+    - aflfast
+    - aflplusplus
+    - aflsmart
+    - entropic
+    - eclipser
+    - fairfuzz
+    - honggfuzz
+    - lafintel
+    - libfuzzer
+    - mopt
+    - wingfuzz
+
 - experiment: 2022-10-07-um-full
   description: "UM fuzzer experiment"
   fuzzers:


### PR DESCRIPTION
It seems that the previous run (2022-09-29-wingfuzz) was not successful. I can't find the report on FuzzBench's [website](https://www.fuzzbench.com/reports/experimental/index.html).

The only log that I can find is the following snippet:

```
Output: Creating temporary tarball archive of 964 file(s) totalling 10.5 MiB before compression.
Uploading tarball of [/work/src] to [gs://fuzzbench_cloudbuild/source/1664481781.196186-ee1e5a05847a47eb8ecc0db53363a30a.tgz]
Created [https://cloudbuild.googleapis.com/v1/projects/fuzzbench/locations/global/builds/b0a75d8a-bb9b-48cd-ad31-13ea8d339b30].
Logs are available at [https://console.cloud.google.com/cloud-build/builds/b0a75d8a-bb9b-48cd-ad31-13ea8d339b30?project=1097086166031].
ERROR: (gcloud.builds.submit) build b0a75d8a-bb9b-48cd-ad31-13ea8d339b30 completed with status "EXPIRED"
```

I guess the orchestration of multiple workers is error-prone. Therefore, I'm requesting another experiment. Maybe it will work this time, hopefully ;-)