### PR TITLE
Fix libfuzzer update

### DIFF
--- a/fuzzers/libfuzzer/builder.Dockerfile
+++ b/fuzzers/libfuzzer/builder.Dockerfile
@@ -15,11 +15,12 @@
 ARG parent_image
 FROM $parent_image
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_dataflow/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow/builder.Dockerfile
@@ -19,20 +19,16 @@ ADD https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/cl
 RUN mkdir /clang && \
     tar zxvf /clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz -C /clang
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82
-
-COPY weak.c /
+COPY weak.c Trace-store-and-load-commands.patch /
 RUN /clang/bin/clang /weak.c -c -o /weak.o
 
-COPY Trace-store-and-load-commands.patch /
-
-RUN cd /llvm-project/ && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     git apply /Trace-store-and-load-commands.patch && \
-    cd compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      /clang/bin/clang -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o
-

--- a/fuzzers/libfuzzer_dataflow/variant-build.sh
+++ b/fuzzers/libfuzzer_dataflow/variant-build.sh
@@ -19,6 +19,6 @@ cd /llvm-project/ && \
 git apply /src/fuzzers/libfuzzer_dataflow/Trace-store-and-load-commands.patch && \
 cd compiler-rt/lib/fuzzer && \
 (for f in *.cpp; do \
-  /clang/bin/clang -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+  /clang/bin/clang -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
 done && wait) && \
 ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_dataflow_load/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_load/builder.Dockerfile
@@ -19,6 +19,16 @@ ADD https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/cl
 RUN mkdir /clang && \
     tar zxvf /clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz -C /clang
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82
+COPY weak.c Trace-store-and-load-commands.patch /
+RUN /clang/bin/clang /weak.c -c -o /weak.o
+
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
+    git apply /Trace-store-and-load-commands.patch && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
+    done && wait) && \
+    ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_dataflow_load/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_load/builder.Dockerfile
@@ -19,16 +19,7 @@ ADD https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/cl
 RUN mkdir /clang && \
     tar zxvf /clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz -C /clang
 
-COPY weak.c Trace-store-and-load-commands.patch /
-RUN /clang/bin/clang /weak.c -c -o /weak.o
-
 RUN git clone \
     --depth 1 \
     --branch llvmorg-15.0.3 \
-    https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/compiler-rt/lib/fuzzer && \
-    git apply /Trace-store-and-load-commands.patch && \
-    (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
-    done && wait) && \
-    ar r /usr/lib/libFuzzer.a *.o
+    https://github.com/llvm/llvm-project.git /llvm-project

--- a/fuzzers/libfuzzer_dataflow_pre/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_pre/builder.Dockerfile
@@ -19,11 +19,12 @@ ADD https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/cl
 RUN mkdir /clang && \
     tar zxvf /clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz -C /clang
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      /clang/bin/clang -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_dataflow_store/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_store/builder.Dockerfile
@@ -19,6 +19,16 @@ ADD https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/cl
 RUN mkdir /clang && \
     tar zxvf /clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz -C /clang
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82
+COPY weak.c Trace-store-and-load-commands.patch /
+RUN /clang/bin/clang /weak.c -c -o /weak.o
+
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
+    git apply /Trace-store-and-load-commands.patch && \
+    (for f in *.cpp; do \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
+    done && wait) && \
+    ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_dataflow_store/builder.Dockerfile
+++ b/fuzzers/libfuzzer_dataflow_store/builder.Dockerfile
@@ -19,16 +19,7 @@ ADD https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/cl
 RUN mkdir /clang && \
     tar zxvf /clang-llvmorg-15-init-1995-g5bec1ea7-1.tgz -C /clang
 
-COPY weak.c Trace-store-and-load-commands.patch /
-RUN /clang/bin/clang /weak.c -c -o /weak.o
-
 RUN git clone \
     --depth 1 \
     --branch llvmorg-15.0.3 \
-    https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/compiler-rt/lib/fuzzer && \
-    git apply /Trace-store-and-load-commands.patch && \
-    (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
-    done && wait) && \
-    ar r /usr/lib/libFuzzer.a *.o
+    https://github.com/llvm/llvm-project.git /llvm-project

--- a/fuzzers/libfuzzer_focus_idx0/builder.Dockerfile
+++ b/fuzzers/libfuzzer_focus_idx0/builder.Dockerfile
@@ -15,12 +15,12 @@
 ARG parent_image
 FROM $parent_image
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o
-

--- a/fuzzers/libfuzzer_focus_idx1/builder.Dockerfile
+++ b/fuzzers/libfuzzer_focus_idx1/builder.Dockerfile
@@ -15,12 +15,12 @@
 ARG parent_image
 FROM $parent_image
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o
-

--- a/fuzzers/libfuzzer_focus_idx2/builder.Dockerfile
+++ b/fuzzers/libfuzzer_focus_idx2/builder.Dockerfile
@@ -15,12 +15,12 @@
 ARG parent_image
 FROM $parent_image
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o
-

--- a/fuzzers/libfuzzer_focus_idx3/builder.Dockerfile
+++ b/fuzzers/libfuzzer_focus_idx3/builder.Dockerfile
@@ -15,12 +15,12 @@
 ARG parent_image
 FROM $parent_image
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o
-

--- a/fuzzers/libfuzzer_focus_idx4/builder.Dockerfile
+++ b/fuzzers/libfuzzer_focus_idx4/builder.Dockerfile
@@ -15,12 +15,12 @@
 ARG parent_image
 FROM $parent_image
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o
-

--- a/fuzzers/libfuzzer_focus_idx5/builder.Dockerfile
+++ b/fuzzers/libfuzzer_focus_idx5/builder.Dockerfile
@@ -15,12 +15,12 @@
 ARG parent_image
 FROM $parent_image
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o
-

--- a/fuzzers/libfuzzer_focus_idx6/builder.Dockerfile
+++ b/fuzzers/libfuzzer_focus_idx6/builder.Dockerfile
@@ -15,12 +15,12 @@
 ARG parent_image
 FROM $parent_image
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o
-

--- a/fuzzers/libfuzzer_focus_idx7/builder.Dockerfile
+++ b/fuzzers/libfuzzer_focus_idx7/builder.Dockerfile
@@ -15,12 +15,12 @@
 ARG parent_image
 FROM $parent_image
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o
-

--- a/fuzzers/libfuzzer_focus_idx8/builder.Dockerfile
+++ b/fuzzers/libfuzzer_focus_idx8/builder.Dockerfile
@@ -15,12 +15,12 @@
 ARG parent_image
 FROM $parent_image
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o
-

--- a/fuzzers/libfuzzer_fork_parallel/builder.Dockerfile
+++ b/fuzzers/libfuzzer_fork_parallel/builder.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,11 +15,12 @@
 ARG parent_image
 FROM $parent_image
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_um_parallel/builder.Dockerfile
+++ b/fuzzers/libfuzzer_um_parallel/builder.Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && apt-get install -y python3
 RUN pip3 install --upgrade --force pip
 RUN pip install universalmutator
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_um_prioritize/builder.Dockerfile
+++ b/fuzzers/libfuzzer_um_prioritize/builder.Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && apt-get install -y python3
 RUN pip3 install --upgrade --force pip
 RUN pip install universalmutator
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_um_prioritize_75/builder.Dockerfile
+++ b/fuzzers/libfuzzer_um_prioritize_75/builder.Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && apt-get install -y python3
 RUN pip3 install --upgrade --force pip
 RUN pip install universalmutator
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_um_random/builder.Dockerfile
+++ b/fuzzers/libfuzzer_um_random/builder.Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && apt-get install -y python3
 RUN pip3 install --upgrade --force pip
 RUN pip install universalmutator
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o

--- a/fuzzers/libfuzzer_um_random_75/builder.Dockerfile
+++ b/fuzzers/libfuzzer_um_random_75/builder.Dockerfile
@@ -19,11 +19,12 @@ RUN apt-get update && apt-get install -y python3
 RUN pip3 install --upgrade --force pip
 RUN pip install universalmutator
 
-RUN git clone https://github.com/llvm/llvm-project.git /llvm-project && \
-    cd /llvm-project/ && \
-    git checkout aaecabe68b6add7874d481e67cd430cb6f06cb82 && \
-    cd compiler-rt/lib/fuzzer && \
+RUN git clone \
+    --depth 1 \
+    --branch llvmorg-15.0.3 \
+    https://github.com/llvm/llvm-project.git /llvm-project && \
+    cd /llvm-project/compiler-rt/lib/fuzzer && \
     (for f in *.cpp; do \
-      clang++ -stdlib=libc++ -fPIC -O2 -std=c++11 $f -c & \
+      clang++ -stdlib=libc++ -fPIC -O2 -std=c++14 $f -c & \
     done && wait) && \
     ar r /usr/lib/libFuzzer.a *.o

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -20,6 +20,13 @@
 # Please add new experiment requests towards the top of this file.
 #
 
+- experiment: 2022-10-31-update-libfuzzer-2
+  description: "Compare and consider replacing Entropic with Centipede"
+  fuzzers:
+    - libfuzzer
+    - entropic
+    - centipede
+
 - experiment: 2022-10-19-um-full
   description: "Add parallel experiments and libfuzzer ones too"
   fuzzers:


### PR DESCRIPTION
Not sure why the previous `libFuzzer` update PR passed CI tests (maybe due to missing CIs?), but it has a build error.
Its [`0s` literal](https://github.com/llvm/llvm-project/blob/4a2c05b05ed07f1f620e94f6524a8b4b2760a0b1/compiler-rt/lib/fuzzer/FuzzerLoop.cpp#L855) requires [`C++14`](https://en.cppreference.com/w/cpp/chrono/operator%22%22s), but we built it with `-std=c++11`.

This PR fixes that error, and anchors `libFuzzer` on tag `llvmorg-15.0.3`, which is the latest release.
