### PR TITLE
Add worker pool name to config

### DIFF
--- a/service/experiment-config.yaml
+++ b/service/experiment-config.yaml
@@ -10,6 +10,7 @@ cloud_compute_zone: us-central1-c
 experiment_filestore: gs://fuzzbench-data
 report_filestore: gs://www.fuzzbench.com/reports
 cloud_sql_instance_connection_name: "fuzzbench:us-central1:postgres-experiment-db=tcp:5432"
+worker_pool_name: "projects/fuzzbench/locations/us-central1/workerPools/buildpool"
 preemptible_runners: true
 
 # This experiment should generate a report that is combined with other public


### PR DESCRIPTION
A follow-up of #1535: Add `worker_pool_name` to config file.