### PR TITLE
Do not report unused args as errors

### DIFF
--- a/benchmarks/systemd_fuzz-varlink/benchmark.yaml
+++ b/benchmarks/systemd_fuzz-varlink/benchmark.yaml
@@ -1,7 +1,6 @@
 fuzz_target: fuzz-varlink
 project: systemd
 unsupported_fuzzers:
-  - centipede
   - aflcc
   - afl_qemu
   - aflplusplus_qemu

--- a/fuzzers/centipede/fuzzer.py
+++ b/fuzzers/centipede/fuzzer.py
@@ -24,7 +24,7 @@ def build():
     san_cflags = ['-fsanitize-coverage=trace-loads']
 
     link_cflags = [
-        '-Wno-error=unused-command-line-argument'
+        '-Wno-error=unused-command-line-argument',
         '-ldl',
         '-lrt',
         '-lpthread',

--- a/fuzzers/centipede/fuzzer.py
+++ b/fuzzers/centipede/fuzzer.py
@@ -24,6 +24,7 @@ def build():
     san_cflags = ['-fsanitize-coverage=trace-loads']
 
     link_cflags = [
+        '-Wno-error=unused-command-line-argument'
         '-ldl',
         '-lrt',
         '-lpthread',


### PR DESCRIPTION
Some projects use `-Werror` to turn all warnings into errors.
This affects `Centipede` as we do not separate build and linking flags as it expects, which leads to `unused-command-line-argument` warnings.
This PR disables turning that specific warning into errors and keeps the rest the same.

See [the same PR from OSS-Fuzz](https://github.com/google/oss-fuzz/pull/9030) for more info and [the error in this PR](https://github.com/google/oss-fuzz/pull/8990) for its use case.