### PR TITLE
Fix failure when merging previous experiments

### DIFF
--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -15,6 +15,9 @@
 from analysis import stat_tests
 from common import benchmark_utils
 from common import environment
+from common import logs
+
+logger = logs.Logger('data_utils')
 
 
 class EmptyDataError(ValueError):
@@ -99,9 +102,22 @@ def filter_benchmarks(experiment_df, included_benchmarks):
     """Returns table with only rows where benchmark is in
     |included_benchmarks|."""
     valid_benchmarks = [
-        benchmarks for benchmarks in included_benchmarks
-        if benchmark_utils.validate(benchmarks)
+        benchmark for benchmark in included_benchmarks
+        if benchmark_utils.validate(benchmark)
     ]
+    logger.info('Included benchmarks: %s', included_benchmarks)
+    logger.warning('Invalid included benchmarks: %s',
+                   set(included_benchmarks) - set(valid_benchmarks))
+    experiment_df = experiment_df[experiment_df['benchmark'].isin(
+        valid_benchmarks)]
+
+    valid_benchmarks = [
+        benchmark for benchmark in experiment_df['benchmark']
+        if benchmark_utils.validate(benchmark)
+    ]
+    logger.info('experiment_df benchmarks: %s', experiment_df['benchmark'])
+    logger.warning('Invalid experiment_df Includedbenchmarks: %s',
+                   set(included_benchmarks) - set(experiment_df['benchmark']))
     return experiment_df[experiment_df['benchmark'].isin(valid_benchmarks)]
 
 

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -117,7 +117,7 @@ def filter_benchmarks(experiment_df, included_benchmarks):
     ]
     logger.info('experiment_df benchmarks: %s', experiment_df['benchmark'])
     logger.warning('Invalid experiment_df Includedbenchmarks: %s',
-                   set(included_benchmarks) - set(experiment_df['benchmark']))
+                   set(experiment_df['benchmark']) - set(valid_benchmarks))
     return experiment_df[experiment_df['benchmark'].isin(valid_benchmarks)]
 
 

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -107,7 +107,7 @@ def filter_benchmarks(experiment_df, included_benchmarks):
     ]
     logger.warning('Filtered out invalid benchmarks: %s.',
                    set(included_benchmarks) - set(valid_benchmarks))
-    logger.debug('Benchmarks passed: %s.', valid_benchmarks)
+    logger.debug('Valid benchmarks: %s.', valid_benchmarks)
     return experiment_df[experiment_df['benchmark'].isin(valid_benchmarks)]
 
 

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -98,16 +98,16 @@ def filter_fuzzers(experiment_df, included_fuzzers):
     return experiment_df[experiment_df['fuzzer'].isin(included_fuzzers)]
 
 
-def filter_benchmarks(experiment_df, included_benchmarks, experiment_type=None):
+def filter_benchmarks(experiment_df, included_benchmarks):
     """Returns table with only rows where benchmark is in
     |included_benchmarks|."""
     valid_benchmarks = [
         benchmark for benchmark in included_benchmarks
-        if benchmark_utils.validate(benchmark, experiment_type)
+        if benchmark_utils.validate(benchmark)
     ]
-    logger.info('Included benchmarks: %s', included_benchmarks)
-    logger.warning('Invalid included benchmarks: %s',
+    logger.warning('Filtered out invalid benchmarks: %s',
                    set(included_benchmarks) - set(valid_benchmarks))
+    logger.debug('Benchmarks passed: %s', valid_benchmarks)
     return experiment_df[experiment_df['benchmark'].isin(valid_benchmarks)]
 
 

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -98,12 +98,12 @@ def filter_fuzzers(experiment_df, included_fuzzers):
     return experiment_df[experiment_df['fuzzer'].isin(included_fuzzers)]
 
 
-def filter_benchmarks(experiment_df, included_benchmarks):
+def filter_benchmarks(experiment_df, included_benchmarks, experiment_type=None):
     """Returns table with only rows where benchmark is in
     |included_benchmarks|."""
     valid_benchmarks = [
         benchmark for benchmark in included_benchmarks
-        if benchmark_utils.validate(benchmark)
+        if benchmark_utils.validate(benchmark, experiment_type)
     ]
     logger.info('Included benchmarks: %s', included_benchmarks)
     logger.warning('Invalid included benchmarks: %s',

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -108,16 +108,6 @@ def filter_benchmarks(experiment_df, included_benchmarks):
     logger.info('Included benchmarks: %s', included_benchmarks)
     logger.warning('Invalid included benchmarks: %s',
                    set(included_benchmarks) - set(valid_benchmarks))
-    experiment_df = experiment_df[experiment_df['benchmark'].isin(
-        valid_benchmarks)]
-
-    valid_benchmarks = [
-        benchmark for benchmark in experiment_df['benchmark']
-        if benchmark_utils.validate(benchmark)
-    ]
-    logger.info('experiment_df benchmarks: %s', experiment_df['benchmark'])
-    logger.warning('Invalid experiment_df Includedbenchmarks: %s',
-                   set(experiment_df['benchmark']) - set(valid_benchmarks))
     return experiment_df[experiment_df['benchmark'].isin(valid_benchmarks)]
 
 

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utility functions for data (frame) transformations."""
 from analysis import stat_tests
+from common import benchmark_utils
 from common import environment
 
 
@@ -97,7 +98,11 @@ def filter_fuzzers(experiment_df, included_fuzzers):
 def filter_benchmarks(experiment_df, included_benchmarks):
     """Returns table with only rows where benchmark is in
     |included_benchmarks|."""
-    return experiment_df[experiment_df['benchmark'].isin(included_benchmarks)]
+    valid_benchmarks = [
+        benchmarks for benchmarks in included_benchmarks
+        if benchmark_utils.validate(benchmarks)
+    ]
+    return experiment_df[experiment_df['benchmark'].isin(valid_benchmarks)]
 
 
 def label_fuzzers_by_experiment(experiment_df):

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -105,9 +105,9 @@ def filter_benchmarks(experiment_df, included_benchmarks):
         benchmark for benchmark in included_benchmarks
         if benchmark_utils.validate(benchmark)
     ]
-    logger.warning('Filtered out invalid benchmarks: %s',
+    logger.warning('Filtered out invalid benchmarks: %s.',
                    set(included_benchmarks) - set(valid_benchmarks))
-    logger.debug('Benchmarks passed: %s', valid_benchmarks)
+    logger.debug('Benchmarks passed: %s.', valid_benchmarks)
     return experiment_df[experiment_df['benchmark'].isin(valid_benchmarks)]
 
 

--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -22,6 +22,10 @@ from analysis import benchmark_results
 from analysis import coverage_data_utils
 from analysis import data_utils
 from analysis import stat_tests
+from common import benchmark_config
+from common import logs
+
+logger = logs.Logger('generate_report')
 
 
 def strip_gs_protocol(url):
@@ -132,12 +136,26 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
         until a property is evaluated.
         """
         benchmark_names = self._experiment_df.benchmark.unique()
+        logger.debug('All experiment_df benchmark names: %s.', benchmark_names)
+
+        exist_benchmark_names = []
+        for name in sorted(benchmark_names):
+            if os.path.isfile(benchmark_config.get_config_file(name)):
+                logger.debug('Benchmark %s exists.', name)
+                exist_benchmark_names.append(name)
+                continue
+            logger.error('Benchmark %s does not exist.', name)
+        logger.debug('Exist experiment_df benchmark names: %s.',
+                     benchmark_names)
+        logger.error('Non-exist experiment_df benchmark names: %s.',
+                     set(benchmark_names) - set(exist_benchmark_names))
+
         return [
             benchmark_results.BenchmarkResults(name, self._experiment_df,
                                                self._coverage_dict,
                                                self._output_directory,
                                                self._plotter)
-            for name in sorted(benchmark_names)
+            for name in sorted(exist_benchmark_names)
         ]
 
     @property
@@ -153,8 +171,7 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
             return 'bug'
         if all(b.type == 'code' for b in self.benchmarks):
             return 'code'
-        benchmark_types = ';'.join(
-            [f'{b}: {b.type}' for b in self.benchmarks])
+        benchmark_types = ';'.join([f'{b}: {b.type}' for b in self.benchmarks])
         raise ValueError(
             'Cannot mix bug benchmarks with code coverage benchmarks: '
             f'{benchmark_types}')

--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -153,10 +153,10 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
             return 'bug'
         if all(b.type == 'code' for b in self.benchmarks):
             return 'code'
-        benchmark_types = '\n'.join(
-            [f'{b}\t: {b.type}' for b in self.benchmarks])
+        benchmark_types = ';'.join(
+            [f'{b}: {b.type}' for b in self.benchmarks])
         raise ValueError(
-            'Cannot mix bug benchmarks with code coverage benchmarks.\n'
+            'Cannot mix bug benchmarks with code coverage benchmarks: '
             f'{benchmark_types}')
 
     @property

--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -153,10 +153,11 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
             return 'bug'
         if all(b.type == 'code' for b in self.benchmarks):
             return 'code'
+        benchmark_types = '\n'.join(
+            [f'{b}\t: {b.type}' for b in self.benchmarks])
         raise ValueError(
             'Cannot mix bug benchmarks with code coverage benchmarks.\n'
-            f'{"\n".join([f"{b}\t: {b.type}" for b in self.benchmarks])}'
-        )
+            f'{benchmark_types}')
 
     @property
     def _relevant_column(self):

--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -154,7 +154,9 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
         if all(b.type == 'code' for b in self.benchmarks):
             return 'code'
         raise ValueError(
-            'Cannot mix bug benchmarks with code coverage benchmarks.')
+            'Cannot mix bug benchmarks with code coverage benchmarks.\n'
+            '"\n".join([f"{b}\t: {b.type}" for b in self.benchmarks])'
+        )
 
     @property
     def _relevant_column(self):

--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -155,7 +155,7 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
             return 'code'
         raise ValueError(
             'Cannot mix bug benchmarks with code coverage benchmarks.\n'
-            '"\n".join([f"{b}\t: {b.type}" for b in self.benchmarks])'
+            f'{"\n".join([f"{b}\t: {b.type}" for b in self.benchmarks])}'
         )
 
     @property

--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -171,7 +171,8 @@ class ExperimentResults:  # pylint: disable=too-many-instance-attributes
             return 'bug'
         if all(b.type == 'code' for b in self.benchmarks):
             return 'code'
-        benchmark_types = ';'.join([f'{b}: {b.type}' for b in self.benchmarks])
+        benchmark_types = ';'.join(
+            [f'{b.name}: {b.type}' for b in self.benchmarks])
         raise ValueError(
             'Cannot mix bug benchmarks with code coverage benchmarks: '
             f'{benchmark_types}')

--- a/analysis/experiment_results.py
+++ b/analysis/experiment_results.py
@@ -23,9 +23,6 @@ from analysis import coverage_data_utils
 from analysis import data_utils
 from analysis import stat_tests
 from common import experiment_utils
-from common import logs
-
-logger = logs.Logger('generate_report')
 
 
 def strip_gs_protocol(url):

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -149,10 +149,22 @@ def modify_experiment_data_if_requested(  # pylint: disable=too-many-arguments
     """Helper function that returns a copy of |experiment_df| that is modified
     based on the other parameters. These parameters come from values specified
     by the user on the command line (or callers to generate_report)."""
+    logger.debug('Before filtering benchmarks (benchmarks): %s', benchmarks)
+    logger.debug('Before filtering benchmarks (experiment_df benchmarks): %s',
+                 experiment_df['benchmarks'])
+    logger.debug('Before filtering benchmarks (experiment_df): %s',
+                 experiment_df)
     if benchmarks:
         # Filter benchmarks if requested.
         experiment_df = data_utils.filter_benchmarks(experiment_df, benchmarks)
 
+    logger.debug('After filtering benchmarks (benchmarks): %s', benchmarks)
+    logger.debug('After filtering benchmarks (experiment_df benchmarks): %s',
+                 experiment_df['benchmarks'])
+    logger.debug('After filtering benchmarks (experiment_df): %s',
+                 experiment_df)
+
+    logger.debug('Filter fuzzers %s', fuzzers)
     if fuzzers is not None:
         # Filter fuzzers if requested.
         experiment_df = data_utils.filter_fuzzers(experiment_df, fuzzers)
@@ -191,29 +203,37 @@ def generate_report(experiment_names,
                     merge_with_clobber_nonprivate=False,
                     coverage_report=False):
     """Generate report helper."""
+    logger.debug('Generate report with benchmarks 1: %s', benchmarks)
     if merge_with_clobber_nonprivate:
         experiment_names = (
             queries.add_nonprivate_experiments_for_merge_with_clobber(
                 experiment_names))
         merge_with_clobber = True
 
+    logger.debug('Generate report with benchmarks 2: %s', benchmarks)
     main_experiment_name = experiment_names[0]
     report_name = report_name or main_experiment_name
 
+    logger.debug('Generate report with benchmarks 3: %s', benchmarks)
     filesystem.create_directory(report_directory)
 
+    logger.debug('Generate report with benchmarks 4: %s', benchmarks)
     data_path = os.path.join(report_directory, DATA_FILENAME)
     experiment_df, experiment_description = get_experiment_data(
         experiment_names, main_experiment_name, from_cached_data, data_path)
 
+    logger.debug('Generate report with benchmarks 5: %s', benchmarks)
     # TODO(metzman): Ensure that each experiment is in the df. Otherwise there
     # is a good chance user misspelled something.
     data_utils.validate_data(experiment_df)
 
+    logger.debug('Modify experiment data with benchmarks: %s', benchmarks)
+    logger.debug('Modify experiment data with experiment_df: %s', experiment_df)
     experiment_df = modify_experiment_data_if_requested(
         experiment_df, experiment_names, benchmarks, fuzzers,
         label_by_experiment, end_time, merge_with_clobber)
 
+    logger.debug('Modified experiment data with benchmarks: %s', experiment_df)
     # Add |bugs_covered| column prior to export.
     experiment_df = data_utils.add_bugs_covered_column(experiment_df)
 

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -149,7 +149,7 @@ def filter_experiments(all_experiment_names):
     a list of old experiments of the same type as the main experiment."""
     main_experiment_name, prev_experiment_names = all_experiment_names[
         0], all_experiment_names[1:]
-    logger.debug('Verifying benchmark type of the main experiment ...')
+    logger.debug('Verifying benchmark type of the main experiment...')
     experiment_benchmark_df = queries.get_experiment_benchmarks(
         [main_experiment_name])
     main_experiment_type = experiment_utils.get_experiment_type(
@@ -158,7 +158,7 @@ def filter_experiments(all_experiment_names):
 
     same_type_experiments = [main_experiment_name]
     for experiment_name in prev_experiment_names:
-        logger.debug('Verifying the benchmark type of %s ...', experiment_name)
+        logger.debug('Verifying the benchmark type of %s...', experiment_name)
         try:
             experiment_benchmark_df = queries.get_experiment_benchmarks(
                 [experiment_name])
@@ -186,13 +186,13 @@ def modify_experiment_data_if_requested(  # pylint: disable=too-many-arguments
     by the user on the command line (or callers to generate_report)."""
     if benchmarks:
         # Filter benchmarks if requested.
-        logger.debug('Filter included benchmarks: %s', benchmarks)
+        logger.debug('Filter included benchmarks: %s.', benchmarks)
         experiment_df = data_utils.filter_benchmarks(experiment_df, benchmarks)
 
     if not experiment_df['benchmark'].empty:
         # Filter benchmarks in experiment DataFrame.
         unique_benchmarks = experiment_df['benchmark'].unique().tolist()
-        logger.debug('Filter experiment_df benchmarks: %s', unique_benchmarks)
+        logger.debug('Filter experiment_df benchmarks: %s.', unique_benchmarks)
         experiment_df = data_utils.filter_benchmarks(experiment_df,
                                                      unique_benchmarks)
 

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -149,16 +149,14 @@ def modify_experiment_data_if_requested(  # pylint: disable=too-many-arguments
     """Helper function that returns a copy of |experiment_df| that is modified
     based on the other parameters. These parameters come from values specified
     by the user on the command line (or callers to generate_report)."""
-    logger.debug('Before filtering benchmarks (benchmarks): %s', benchmarks)
-    logger.debug('Before filtering benchmarks (experiment_df benchmarks): %s',
-                 list(experiment_df['benchmark']))
-    if benchmarks or list(experiment_df['benchmark']):
+    if benchmarks:
         # Filter benchmarks if requested.
         experiment_df = data_utils.filter_benchmarks(experiment_df, benchmarks)
 
-    logger.debug('After filtering benchmarks (benchmarks): %s', benchmarks)
-    logger.debug('After filtering benchmarks (experiment_df benchmarks): %s',
-                 list(experiment_df['benchmark']))
+    if not experiment_df['benchmark'].empty:
+        # Filter benchmarks in experiment dataframe.
+        experiment_df = data_utils.filter_benchmarks(experiment_df,
+                                                     experiment_df['benchmark'])
 
     logger.debug('Filter fuzzers %s', fuzzers)
     if fuzzers is not None:

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -151,7 +151,7 @@ def modify_experiment_data_if_requested(  # pylint: disable=too-many-arguments
     by the user on the command line (or callers to generate_report)."""
     logger.debug('Before filtering benchmarks (benchmarks): %s', benchmarks)
     logger.debug('Before filtering benchmarks (experiment_df benchmarks): %s',
-                 experiment_df['benchmarks'])
+                 experiment_df['benchmark'])
     logger.debug('Before filtering benchmarks (experiment_df): %s',
                  experiment_df)
     if benchmarks:
@@ -160,7 +160,7 @@ def modify_experiment_data_if_requested(  # pylint: disable=too-many-arguments
 
     logger.debug('After filtering benchmarks (benchmarks): %s', benchmarks)
     logger.debug('After filtering benchmarks (experiment_df benchmarks): %s',
-                 experiment_df['benchmarks'])
+                 experiment_df['benchmark'])
     logger.debug('After filtering benchmarks (experiment_df): %s',
                  experiment_df)
 

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -149,14 +149,18 @@ def modify_experiment_data_if_requested(  # pylint: disable=too-many-arguments
     """Helper function that returns a copy of |experiment_df| that is modified
     based on the other parameters. These parameters come from values specified
     by the user on the command line (or callers to generate_report)."""
+    logger.info('Filter the following benchmarks from "benchmarks": %s',
+                benchmarks)
     if benchmarks:
         # Filter benchmarks if requested.
         experiment_df = data_utils.filter_benchmarks(experiment_df, benchmarks)
 
+    logger.info('Filter the following benchmarks from "experiment_df": %s',
+                experiment_df['benchmark'].unique())
     if not experiment_df['benchmark'].empty:
         # Filter benchmarks in experiment dataframe.
-        experiment_df = data_utils.filter_benchmarks(experiment_df,
-                                                     experiment_df['benchmark'])
+        experiment_df = data_utils.filter_benchmarks(
+            experiment_df, experiment_df['benchmark'].unique())
 
     logger.debug('Filter fuzzers %s', fuzzers)
     if fuzzers is not None:
@@ -222,7 +226,8 @@ def generate_report(experiment_names,
     data_utils.validate_data(experiment_df)
 
     logger.debug('Modify experiment data with benchmarks: %s', benchmarks)
-    logger.debug('Modify experiment data with experiment_df: %s', experiment_df)
+    logger.debug('Modify experiment data with experiment_df: %s',
+                 experiment_df['benchmark'])
     experiment_df = modify_experiment_data_if_requested(
         experiment_df, experiment_names, benchmarks, fuzzers,
         label_by_experiment, end_time, merge_with_clobber)

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -151,18 +151,14 @@ def modify_experiment_data_if_requested(  # pylint: disable=too-many-arguments
     by the user on the command line (or callers to generate_report)."""
     logger.debug('Before filtering benchmarks (benchmarks): %s', benchmarks)
     logger.debug('Before filtering benchmarks (experiment_df benchmarks): %s',
-                 experiment_df['benchmark'])
-    logger.debug('Before filtering benchmarks (experiment_df): %s',
-                 experiment_df)
-    if benchmarks:
+                 list(experiment_df['benchmark']))
+    if benchmarks or list(experiment_df['benchmark']):
         # Filter benchmarks if requested.
         experiment_df = data_utils.filter_benchmarks(experiment_df, benchmarks)
 
     logger.debug('After filtering benchmarks (benchmarks): %s', benchmarks)
     logger.debug('After filtering benchmarks (experiment_df benchmarks): %s',
-                 experiment_df['benchmark'])
-    logger.debug('After filtering benchmarks (experiment_df): %s',
-                 experiment_df)
+                 list(experiment_df['benchmark']))
 
     logger.debug('Filter fuzzers %s', fuzzers)
     if fuzzers is not None:

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -147,23 +147,23 @@ def get_experiment_data(experiment_names, main_experiment_name,
 def filter_experiments(all_experiment_names):
     """Helper function that reads data from disk or from the database. Returns
     a list of old experiments of the same type as the main experiment."""
-    main_experiment_name, prev_experiment_names = all_experiment_names[
-        0], all_experiment_names[1:]
     logger.debug('Verifying benchmark type of the main experiment...')
-    experiment_benchmark_df = queries.get_experiment_benchmarks(
+    main_experiment_name = all_experiment_names[0]
+    experiment_benchmarks = queries.get_experiment_benchmarks(
         [main_experiment_name])
     main_experiment_type = experiment_utils.get_experiment_type(
-        experiment_benchmark_df['benchmark'].unique().tolist())
+        experiment_benchmarks)
     logger.info('Main experiment benchmark type is %s.', main_experiment_type)
 
     same_type_experiments = [main_experiment_name]
+    prev_experiment_names = all_experiment_names[1:]
     for experiment_name in prev_experiment_names:
         logger.debug('Verifying the benchmark type of %s...', experiment_name)
         try:
-            experiment_benchmark_df = queries.get_experiment_benchmarks(
+            experiment_benchmarks = queries.get_experiment_benchmarks(
                 [experiment_name])
             experiment_type = experiment_utils.get_experiment_type(
-                experiment_benchmark_df['benchmark'].unique().tolist())
+                experiment_benchmarks)
         except ValueError as mixing_benchmark_error:
             # Ignore old experiments with mixing benchmarks.
             logger.warning(mixing_benchmark_error)

--- a/analysis/queries.py
+++ b/analysis/queries.py
@@ -21,21 +21,7 @@ from database.models import Experiment, Trial, Snapshot, Crash
 from database import utils as db_utils
 
 
-def get_experiment_benchmarks(experiment_names):
-    """Get benchmarks of |experiment_names| from the database."""
-    with db_utils.session_scope() as session:
-        snapshots_query = session.query(Trial.benchmark, Trial.experiment)\
-            .distinct(Trial.benchmark)\
-            .select_from(Experiment)\
-            .join(Trial)\
-            .filter(Experiment.name.in_(experiment_names))\
-            .filter(Trial.preempted.is_(False))
-
-    return pd.read_sql_query(snapshots_query.statement,
-                             db_utils.engine)['benchmark'].tolist()
-
-
-def get_experiment_data(experiment_names):
+def get_experiment_data(experiment_names, main_experiment_benchmarks=None):
     """Get measurements (such as coverage) on experiments from the database."""
     with db_utils.session_scope() as session:
         snapshots_query = session.query(
@@ -52,6 +38,9 @@ def get_experiment_data(experiment_names):
                        Snapshot.trial_id == Crash.trial_id), isouter=True)\
             .filter(Experiment.name.in_(experiment_names))\
             .filter(Trial.preempted.is_(False))
+        if main_experiment_benchmarks:
+            snapshots_query = snapshots_query.filter(
+                Trial.benchmark.in_(main_experiment_benchmarks))
 
     return pd.read_sql_query(snapshots_query.statement, db_utils.engine)
 

--- a/analysis/queries.py
+++ b/analysis/queries.py
@@ -21,6 +21,18 @@ from database.models import Experiment, Trial, Snapshot, Crash
 from database import utils as db_utils
 
 
+def get_experiment_benchmarks(experiment_names):
+    """Get benchmarks of |experiment_names| from the database."""
+    with db_utils.session_scope() as session:
+        snapshots_query = session.query(Trial.benchmark)\
+            .select_from(Experiment)\
+            .join(Trial)\
+            .filter(Experiment.name.in_(experiment_names))\
+            .filter(Trial.preempted.is_(False))
+
+    return pd.read_sql_query(snapshots_query.statement, db_utils.engine)
+
+
 def get_experiment_data(experiment_names):
     """Get measurements (such as coverage) on experiments from the database."""
     with db_utils.session_scope() as session:

--- a/analysis/queries.py
+++ b/analysis/queries.py
@@ -24,13 +24,15 @@ from database import utils as db_utils
 def get_experiment_benchmarks(experiment_names):
     """Get benchmarks of |experiment_names| from the database."""
     with db_utils.session_scope() as session:
-        snapshots_query = session.query(Trial.benchmark)\
+        snapshots_query = session.query(Trial.benchmark, Trial.experiment)\
+            .distinct(Trial.benchmark)\
             .select_from(Experiment)\
             .join(Trial)\
             .filter(Experiment.name.in_(experiment_names))\
             .filter(Trial.preempted.is_(False))
 
-    return pd.read_sql_query(snapshots_query.statement, db_utils.engine)
+    return pd.read_sql_query(snapshots_query.statement,
+                             db_utils.engine)['benchmark'].tolist()
 
 
 def get_experiment_data(experiment_names):

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -46,13 +46,13 @@ def create_experiment_data(experiment='test_experiment',
                            experiment_filestore='gs://fuzzbench-data'):
     """Utility function to create test experiment data."""
     return pd.concat([
-        create_trial_data(0, 'libpng', 'afl', 10, 100, experiment,
+        create_trial_data(0, 'libpng-1.2.56', 'afl', 10, 100, experiment,
                           experiment_filestore),
-        create_trial_data(1, 'libpng', 'afl', 10, 200, experiment,
+        create_trial_data(1, 'libpng-1.2.56', 'afl', 10, 200, experiment,
                           experiment_filestore),
-        create_trial_data(2, 'libpng', 'libfuzzer', 10, 200, experiment,
+        create_trial_data(2, 'libpng-1.2.56', 'libfuzzer', 10, 200, experiment,
                           experiment_filestore),
-        create_trial_data(3, 'libpng', 'libfuzzer', 10, 300, experiment,
+        create_trial_data(3, 'libpng-1.2.56', 'libfuzzer', 10, 300, experiment,
                           experiment_filestore),
         create_trial_data(4, 'libxml', 'afl', 6 if incomplete else 10, 1000,
                           experiment, experiment_filestore),
@@ -94,7 +94,7 @@ def test_clobber_experiments_data():
     df.reset_index(inplace=True)
 
     to_drop = df[(df.experiment == 'experiment-2') &
-                 (df.benchmark == 'libpng') & (df.fuzzer == 'afl')].index
+                 (df.benchmark == 'libpng-1.2.56') & (df.fuzzer == 'afl')].index
     df.drop(to_drop, inplace=True)
 
     experiments = list(df['experiment'].drop_duplicates().values)
@@ -102,10 +102,10 @@ def test_clobber_experiments_data():
 
     columns = ['experiment', 'benchmark', 'fuzzer']
     expected_result = pd.DataFrame([
-        ['experiment-2', 'libpng', 'libfuzzer'],
+        ['experiment-2', 'libpng-1.2.56', 'libfuzzer'],
         ['experiment-2', 'libxml', 'afl'],
         ['experiment-2', 'libxml', 'libfuzzer'],
-        ['experiment-1', 'libpng', 'afl'],
+        ['experiment-1', 'libpng-1.2.56', 'afl'],
     ],
                                    columns=columns)
     expected_result.sort_index(inplace=True)
@@ -123,7 +123,7 @@ def test_filter_fuzzers():
 
 def test_filter_benchmarks():
     experiment_df = create_experiment_data()
-    benchmarks_to_keep = ['libpng']
+    benchmarks_to_keep = ['libpng-1.2.56']
     filtered_df = data_utils.filter_benchmarks(experiment_df,
                                                benchmarks_to_keep)
 
@@ -245,7 +245,7 @@ def test_experiment_summary():
     summary = data_utils.experiment_summary(snapshots_df)
 
     expected_summary = pd.DataFrame({
-        'benchmark': ['libpng', 'libpng', 'libxml', 'libxml'],
+        'benchmark': ['libpng-1.2.56', 'libpng-1.2.56', 'libxml', 'libxml'],
         'fuzzer': ['libfuzzer', 'afl', 'afl', 'libfuzzer'],
         'time': [9, 9, 9, 9],
         'count': [2, 2, 2, 2],
@@ -306,8 +306,8 @@ def test_experiment_pivot_table():
 
     # yapf: disable
     expected_data = pd.DataFrame([
-        {'benchmark': 'libpng', 'fuzzer': 'afl', 'median':  150},
-        {'benchmark': 'libpng', 'fuzzer': 'libfuzzer', 'median':  250},
+        {'benchmark': 'libpng-1.2.56', 'fuzzer': 'afl', 'median':  150},
+        {'benchmark': 'libpng-1.2.56', 'fuzzer': 'libfuzzer', 'median':  250},
         {'benchmark': 'libxml', 'fuzzer': 'afl', 'median': 1100},
         {'benchmark': 'libxml', 'fuzzer': 'libfuzzer', 'median':  700},
     ])

--- a/common/benchmark_config.py
+++ b/common/benchmark_config.py
@@ -32,8 +32,8 @@ def get_config_file(benchmark):
 @functools.lru_cache(maxsize=None)
 def get_config(benchmark):
     """Returns a dictionary containing the config for a benchmark."""
-    benchmark_config = get_config_file(benchmark)
-    if os.path.isfile(benchmark_config):
-        return yaml_utils.read(benchmark_config)
-    logger.warning('Benchmark config does not exist: %s.', benchmark_config)
+    config_file = get_config_file(benchmark)
+    if os.path.isfile(config_file):
+        return yaml_utils.read(config_file)
+    logger.warning('Benchmark config does not exist: %s.', config_file)
     return {}

--- a/common/benchmark_config.py
+++ b/common/benchmark_config.py
@@ -17,6 +17,9 @@ import os
 
 from common import utils
 from common import yaml_utils
+from common import logs
+
+logger = logs.Logger('benchmark_config')
 
 BENCHMARKS_DIR = os.path.join(utils.ROOT_DIR, 'benchmarks')
 
@@ -29,4 +32,8 @@ def get_config_file(benchmark):
 @functools.lru_cache(maxsize=None)
 def get_config(benchmark):
     """Returns a dictionary containing the config for a benchmark."""
-    return yaml_utils.read(get_config_file(benchmark))
+    benchmark_config = get_config_file(benchmark)
+    if os.path.isfile(benchmark_config):
+        return yaml_utils.read(benchmark_config)
+    logger.error('Benchmark config does not exist: %s', benchmark_config)
+    return {}

--- a/common/benchmark_config.py
+++ b/common/benchmark_config.py
@@ -35,5 +35,5 @@ def get_config(benchmark):
     benchmark_config = get_config_file(benchmark)
     if os.path.isfile(benchmark_config):
         return yaml_utils.read(benchmark_config)
-    logger.error('Benchmark config does not exist: %s', benchmark_config)
+    logger.warning('Benchmark config does not exist: %s', benchmark_config)
     return {}

--- a/common/benchmark_config.py
+++ b/common/benchmark_config.py
@@ -35,5 +35,5 @@ def get_config(benchmark):
     benchmark_config = get_config_file(benchmark)
     if os.path.isfile(benchmark_config):
         return yaml_utils.read(benchmark_config)
-    logger.warning('Benchmark config does not exist: %s', benchmark_config)
+    logger.warning('Benchmark config does not exist: %s.', benchmark_config)
     return {}

--- a/common/benchmark_utils.py
+++ b/common/benchmark_utils.py
@@ -87,9 +87,14 @@ def validate_name(benchmark):
     return True
 
 
-def validate_type(benchmark):
+def validate_type(benchmark, experiment_type=None):
     """Returns True if |benchmark| has a valid type."""
     benchmark_type = get_type(benchmark)
+    if experiment_type and benchmark_type != experiment_type:
+        logs.warning(
+            '%s has an invalid benchmark type %s, must be the same as %s',
+            benchmark, benchmark_type, experiment_type)
+        return False
     if benchmark_type not in BENCHMARK_TYPE_STRS:
         logs.error('%s has an invalid benchmark type %s, must be one of %s',
                    benchmark, benchmark_type, BENCHMARK_TYPE_STRS)
@@ -97,7 +102,7 @@ def validate_type(benchmark):
     return True
 
 
-def validate(benchmark):
+def validate(benchmark, experiment_type=None):
     """Returns True if |benchmark| is a valid fuzzbench benchmark."""
     if not validate_name(benchmark):
         return False
@@ -119,7 +124,7 @@ def validate(benchmark):
         return False
 
     # Validate type.
-    return validate_type(benchmark)
+    return validate_type(benchmark, experiment_type)
 
 
 def get_all_benchmarks():

--- a/common/benchmark_utils.py
+++ b/common/benchmark_utils.py
@@ -87,14 +87,9 @@ def validate_name(benchmark):
     return True
 
 
-def validate_type(benchmark, experiment_type=None):
+def validate_type(benchmark):
     """Returns True if |benchmark| has a valid type."""
     benchmark_type = get_type(benchmark)
-    if experiment_type and benchmark_type != experiment_type:
-        logs.warning(
-            '%s has an invalid benchmark type %s, must be the same as %s',
-            benchmark, benchmark_type, experiment_type)
-        return False
     if benchmark_type not in BENCHMARK_TYPE_STRS:
         logs.error('%s has an invalid benchmark type %s, must be one of %s',
                    benchmark, benchmark_type, BENCHMARK_TYPE_STRS)
@@ -102,7 +97,7 @@ def validate_type(benchmark, experiment_type=None):
     return True
 
 
-def validate(benchmark, experiment_type=None):
+def validate(benchmark):
     """Returns True if |benchmark| is a valid fuzzbench benchmark."""
     if not validate_name(benchmark):
         return False
@@ -124,7 +119,7 @@ def validate(benchmark, experiment_type=None):
         return False
 
     # Validate type.
-    return validate_type(benchmark, experiment_type)
+    return validate_type(benchmark)
 
 
 def get_all_benchmarks():

--- a/common/experiment_utils.py
+++ b/common/experiment_utils.py
@@ -71,7 +71,7 @@ def get_experiment_type(benchmarks):
     benchmark_types = ';'.join(
         [f'{b}: {get_benchmark_type(b)}' for b in benchmarks])
     raise ValueError('Cannot mix bug benchmarks with code coverage benchmarks: '
-                     f'{benchmark_types}')
+                     f'{benchmark_types}.')
 
 
 def get_cloud_project():

--- a/common/experiment_utils.py
+++ b/common/experiment_utils.py
@@ -16,6 +16,7 @@
 import os
 import posixpath
 
+from common.benchmark_utils import BenchmarkType, get_type as get_benchmark_type
 from common import environment
 from common import experiment_path as exp_path
 
@@ -53,6 +54,24 @@ def get_experiment_name():
 def get_experiment_folders_dir():
     """Returns experiment folders directory."""
     return exp_path.path('experiment-folders')
+
+
+def get_experiment_type(benchmarks):
+    """Returns the experiment type based on the type of |benchmarks|, i.e.,
+    'code' or 'bug'.
+    Raises ValueError if the benchmark types are mixed.
+    """
+    for benchmark_type in BenchmarkType:
+        type_value = benchmark_type.value
+        if all(
+                get_benchmark_type(benchmark) == type_value
+                for benchmark in benchmarks):
+            return type_value
+
+    benchmark_types = ';'.join(
+        [f'{b}: {get_benchmark_type(b)}' for b in benchmarks])
+    raise ValueError('Cannot mix bug benchmarks with code coverage benchmarks: '
+                     f'{benchmark_types}')
 
 
 def get_cloud_project():

--- a/common/experiment_utils.py
+++ b/common/experiment_utils.py
@@ -16,7 +16,7 @@
 import os
 import posixpath
 
-from common.benchmark_utils import BenchmarkType, get_type as get_benchmark_type
+from common import benchmark_utils
 from common import environment
 from common import experiment_path as exp_path
 
@@ -61,15 +61,15 @@ def get_experiment_type(benchmarks):
     'code' or 'bug'.
     Raises ValueError if the benchmark types are mixed.
     """
-    for benchmark_type in BenchmarkType:
+    for benchmark_type in benchmark_utils.BenchmarkType:
         type_value = benchmark_type.value
         if all(
-                get_benchmark_type(benchmark) == type_value
+                benchmark_utils.get_type(benchmark) == type_value
                 for benchmark in benchmarks):
             return type_value
 
     benchmark_types = ';'.join(
-        [f'{b}: {get_benchmark_type(b)}' for b in benchmarks])
+        [f'{b}: {benchmark_utils.get_type(b)}' for b in benchmarks])
     raise ValueError('Cannot mix bug benchmarks with code coverage benchmarks: '
                      f'{benchmark_types}.')
 

--- a/experiment/reporter.py
+++ b/experiment/reporter.py
@@ -67,7 +67,7 @@ def output_report(experiment_config: dict,
     logger.info('In progress: %s.', in_progress)
     merge_with_nonprivate = (not in_progress and experiment_config.get(
         'merge_with_nonprivate', False))
-    logger.info('Merging with nonprivate: %s.', merge_with_nonprivate)
+    logger.info('Is merging with nonprivate:: %s.', merge_with_nonprivate)
 
     try:
         logger.debug('Generating report.')

--- a/experiment/reporter.py
+++ b/experiment/reporter.py
@@ -69,6 +69,7 @@ def output_report(experiment_config: dict,
         'merge_with_nonprivate', False))
     logger.info('Is merging with nonprivate:: %s.', merge_with_nonprivate)
 
+    experiment_benchmarks = set(experiment_config['benchmarks'])
     try:
         logger.debug('Generating report.')
         filesystem.recreate_directory(reports_dir)
@@ -79,7 +80,8 @@ def output_report(experiment_config: dict,
             fuzzers=fuzzers,
             in_progress=in_progress,
             merge_with_clobber_nonprivate=merge_with_nonprivate,
-            coverage_report=coverage_report)
+            coverage_report=coverage_report,
+            experiment_benchmarks=experiment_benchmarks)
         filestore_utils.rsync(
             str(reports_dir),
             web_filestore_path,

--- a/experiment/reporter.py
+++ b/experiment/reporter.py
@@ -67,7 +67,7 @@ def output_report(experiment_config: dict,
     logger.info('In progress: %s.', in_progress)
     merge_with_nonprivate = (not in_progress and experiment_config.get(
         'merge_with_nonprivate', False))
-    logger.info('Is merging with nonprivate:: %s.', merge_with_nonprivate)
+    logger.info('Is merging with nonprivate: %s.', merge_with_nonprivate)
 
     experiment_benchmarks = set(experiment_config['benchmarks'])
     try:

--- a/experiment/reporter.py
+++ b/experiment/reporter.py
@@ -64,8 +64,10 @@ def output_report(experiment_config: dict,
     # Don't merge with nonprivate experiments until the very end as doing it
     # while the experiment is in progress will produce unusable realtime
     # results.
+    logger.info('In progress: %s.', in_progress)
     merge_with_nonprivate = (not in_progress and experiment_config.get(
         'merge_with_nonprivate', False))
+    logger.info('Merging with nonprivate: %s.', merge_with_nonprivate)
 
     try:
         logger.debug('Generating report.')

--- a/experiment/test_reporter.py
+++ b/experiment/test_reporter.py
@@ -62,6 +62,7 @@ def test_output_report_filestore(experiment_fuzzers, expected_merged_fuzzers,
     filestore."""
     experiment_config = _setup_experiment_files(fs)
     experiment_config['fuzzers'] = experiment_fuzzers
+    experiment_benchmarks = set(experiment_config['benchmarks'])
 
     with test_utils.mock_popen_ctx_mgr() as mocked_popen:
         with mock.patch('analysis.generate_report.generate_report'
@@ -80,4 +81,5 @@ def test_output_report_filestore(experiment_fuzzers, expected_merged_fuzzers,
                 fuzzers=expected_merged_fuzzers,
                 in_progress=False,
                 merge_with_clobber_nonprivate=False,
-                coverage_report=False)
+                coverage_report=False,
+                experiment_benchmarks=experiment_benchmarks)


### PR DESCRIPTION
1. Exclude benchmarks if they no longer exist (or do not have a `benchmark.yaml`).
2. Exclude experiments if their types are different from the main experiment.