### PR TITLE
Fix mixed markers

### DIFF
--- a/analysis/plotting.py
+++ b/analysis/plotting.py
@@ -21,6 +21,9 @@ import seaborn as sns
 
 from analysis import data_utils
 from common import experiment_utils
+from common import logs
+
+logger = logs.Logger('plotting')
 
 _DEFAULT_TICKS_COUNT = 12
 _DEFAULT_LABEL_ROTATION = 30
@@ -155,6 +158,15 @@ class Plotter:
         snapshot_time = benchmark_snapshot_df.time.unique()[0]
         fuzzer_order = data_utils.benchmark_rank_by_mean(
             benchmark_snapshot_df, key=column_of_interest).index
+
+        logger.debug('column of interest: %s', column_of_interest)
+        logger.debug('fuzzer_order: %s', fuzzer_order)
+        logger.debug('benchmark_df: %s',
+                     benchmark_df[benchmark_df.time <= snapshot_time])
+        logger.debug('ci: %s', None if bugs or self._quick else 95)
+        logger.debug('estimator: %s', np.median)
+        logger.debug('palette: %s', self._fuzzer_colors)
+        logger.info('markers: %s', self._fuzzer_markers)
 
         axes = sns.lineplot(
             y=column_of_interest,

--- a/analysis/plotting.py
+++ b/analysis/plotting.py
@@ -91,10 +91,11 @@ class Plotter:
     # We need a manually specified marker list due to:
     # https://github.com/mwaskom/seaborn/issues/1513
     # We specify 20 markers for the 20 colors above.
-    _MARKER_PALETTE = [
+    _FILLED_MARKER_PALETTE = [
         'o', 'v', '^', '<', '>', '8', 's', 'p', '*', 'h', 'H', 'D', 'd', 'P',
-        'X', ',', '+', 'x', '|', '_'
+        'X', ',', '.'
     ]
+    _LINE_MARKER_PALETTE = ['+', 'x', '|', '_']
 
     def __init__(self, fuzzers, quick=False, logscale=False):
         """Instantiates plotter with list of |fuzzers|. If |quick| is True,
@@ -105,7 +106,8 @@ class Plotter:
             for idx, fuzzer in enumerate(sorted(fuzzers))
         }
         self._fuzzer_markers = {
-            fuzzer: self._MARKER_PALETTE[idx % len(self._MARKER_PALETTE)]
+            fuzzer:
+            self._FILLED_MARKER_PALETTE[idx % len(self._FILLED_MARKER_PALETTE)]
             for idx, fuzzer in enumerate(sorted(fuzzers))
         }
 


### PR DESCRIPTION
Fix [marker error in centipede experiments](https://pantheon.corp.google.com/logs/query;cursorTimestamp=2022-12-03T20:41:57.898659379Z;query=centipede%0Aseverity%3D%2528WARNING%20OR%20ERROR%20OR%20CRITICAL%20OR%20ALERT%20OR%20EMERGENCY%2529%0Atimestamp%3D%222022-12-03T20:41:57.898659379Z%22%0AinsertId%3D%2213ej031f25ni5n%22?project=fuzzbench).
This is only observed in recent centipede experiments:
```json
{
  "insertId": "13ej031f25ni5n",
  "jsonPayload": {
    "traceback": "Traceback (most recent call last):
  File "/work/src/experiment/reporter.py", line 76, in output_report
    generate_report.generate_report(
  File "/work/src/analysis/generate_report.py", line 261, in generate_report
    detailed_report = rendering.render_report(experiment_ctx, template,
  File "/work/src/analysis/rendering.py", line 46, in render_report
    return template.render(experiment=experiment_results,
  File "/usr/local/lib/python3.8/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.8/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/local/lib/python3.8/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "/work/src/analysis/report_templates/default.html", line 257, in top-level template code
    src="{{ benchmark.coverage_growth_plot }}">
  File "/usr/local/lib/python3.8/site-packages/jinja2/environment.py", line 471, in getattr
    return getattr(obj, attribute)
  File "/work/src/analysis/benchmark_results.py", line 329, in coverage_growth_plot
    return self._coverage_growth_plot('coverage_growth.svg')
  File "/work/src/analysis/benchmark_results.py", line 318, in _coverage_growth_plot
    self._plotter.write_coverage_growth_plot(
  File "/work/src/analysis/plotting.py", line 213, in write_coverage_growth_plot
    self._write_plot_to_image(self.coverage_growth_plot,
  File "/work/src/analysis/plotting.py", line 128, in _write_plot_to_image
    plot_function(data, axes=axes, **kwargs)
  File "/work/src/analysis/plotting.py", line 159, in coverage_growth_plot
    axes = sns.lineplot(
  File "/usr/local/lib/python3.8/site-packages/seaborn/_decorators.py", line 46, in inner_f
    return f(**kwargs)
  File "/usr/local/lib/python3.8/site-packages/seaborn/relational.py", line 693, in lineplot
    p.map_style(markers=markers, dashes=dashes, order=style_order)
  File "/usr/local/lib/python3.8/site-packages/seaborn/_core.py", line 53, in map
    setattr(plotter, method_name, cls(plotter, *args, **kwargs))
  File "/usr/local/lib/python3.8/site-packages/seaborn/_core.py", line 534, in __init__
    raise ValueError(err)
ValueError: Filled and line art markers cannot be mixed",
    "message": "Error generating HTML report.",
    "component": "dispatcher",
    "instance_name": "d-2022-12-04-centipede-flag",
    "experiment": "2022-12-04-centipede-flag"
  },
  "resource": {
    "type": "global",
    "labels": {
      "project_id": "fuzzbench"
    }
  },
  "timestamp": "2022-12-03T20:41:57.898659379Z",
  "severity": "ERROR",
  "logName": "projects/fuzzbench/logs/reporter",
  "receiveTimestamp": "2022-12-03T20:41:57.898659379Z"
}
```