### PR TITLE
Separate line makers from filled markers

### DIFF
--- a/analysis/plotting.py
+++ b/analysis/plotting.py
@@ -88,10 +88,13 @@ class Plotter:
     # We need a manually specified marker list due to:
     # https://github.com/mwaskom/seaborn/issues/1513
     # We specify 20 markers for the 20 colors above.
-    _MARKER_PALETTE = [
+    # We cannot mix filled and line markers.
+    _FILLED_MARKER_PALETTE = [
         'o', 'v', '^', '<', '>', '8', 's', 'p', '*', 'h', 'H', 'D', 'd', 'P',
-        'X', ',', '+', 'x', '|', '_'
+        'X', ',', '.'
     ]
+    # Keep following line markers in case needed.
+    _LINE_MARKER_PALETTE = ['+', 'x', '|', '_']
 
     def __init__(self, fuzzers, quick=False, logscale=False):
         """Instantiates plotter with list of |fuzzers|. If |quick| is True,
@@ -102,7 +105,8 @@ class Plotter:
             for idx, fuzzer in enumerate(sorted(fuzzers))
         }
         self._fuzzer_markers = {
-            fuzzer: self._MARKER_PALETTE[idx % len(self._MARKER_PALETTE)]
+            fuzzer:
+            self._FILLED_MARKER_PALETTE[idx % len(self._FILLED_MARKER_PALETTE)]
             for idx, fuzzer in enumerate(sorted(fuzzers))
         }
 

--- a/analysis/plotting.py
+++ b/analysis/plotting.py
@@ -88,13 +88,10 @@ class Plotter:
     # We need a manually specified marker list due to:
     # https://github.com/mwaskom/seaborn/issues/1513
     # We specify 20 markers for the 20 colors above.
-    # We cannot mix filled and line markers.
-    _FILLED_MARKER_PALETTE = [
+    _MARKER_PALETTE = [
         'o', 'v', '^', '<', '>', '8', 's', 'p', '*', 'h', 'H', 'D', 'd', 'P',
         'X', ',', '.'
     ]
-    # Keep following line markers in case needed.
-    _LINE_MARKER_PALETTE = ['+', 'x', '|', '_']
 
     def __init__(self, fuzzers, quick=False, logscale=False):
         """Instantiates plotter with list of |fuzzers|. If |quick| is True,
@@ -105,8 +102,7 @@ class Plotter:
             for idx, fuzzer in enumerate(sorted(fuzzers))
         }
         self._fuzzer_markers = {
-            fuzzer:
-            self._FILLED_MARKER_PALETTE[idx % len(self._FILLED_MARKER_PALETTE)]
+            fuzzer: self._MARKER_PALETTE[idx % len(self._MARKER_PALETTE)]
             for idx, fuzzer in enumerate(sorted(fuzzers))
         }
 


### PR DESCRIPTION
Fix [`seaborn` marker errors](https://pantheon.corp.google.com/logs/query;cursorTimestamp=2022-12-03T20:41:57.898659379Z;query=centipede%0Aseverity%3D%2528WARNING%20OR%20ERROR%20OR%20CRITICAL%20OR%20ALERT%20OR%20EMERGENCY%2529%0Atimestamp%3D%222022-12-03T20:41:57.898659379Z%22%0AinsertId%3D%2213ej031f25ni5n%22?project=fuzzbench).

This only happens when we have >= 17 fuzzers, because the first 16 markers are filled markers and the rest are line markers.
Mixing them will incur the following error:
```json
{
  "insertId": "13ej031f25ni5n",
  "jsonPayload": {
    "traceback": "Traceback (most recent call last):
  File "/work/src/experiment/reporter.py", line 76, in output_report
    generate_report.generate_report(
  File "/work/src/analysis/generate_report.py", line 261, in generate_report
    detailed_report = rendering.render_report(experiment_ctx, template,
  File "/work/src/analysis/rendering.py", line 46, in render_report
    return template.render(experiment=experiment_results,
  File "/usr/local/lib/python3.8/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.8/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/local/lib/python3.8/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "/work/src/analysis/report_templates/default.html", line 257, in top-level template code
    src="{{ benchmark.coverage_growth_plot }}">
  File "/usr/local/lib/python3.8/site-packages/jinja2/environment.py", line 471, in getattr
    return getattr(obj, attribute)
  File "/work/src/analysis/benchmark_results.py", line 329, in coverage_growth_plot
    return self._coverage_growth_plot('coverage_growth.svg')
  File "/work/src/analysis/benchmark_results.py", line 318, in _coverage_growth_plot
    self._plotter.write_coverage_growth_plot(
  File "/work/src/analysis/plotting.py", line 213, in write_coverage_growth_plot
    self._write_plot_to_image(self.coverage_growth_plot,
  File "/work/src/analysis/plotting.py", line 128, in _write_plot_to_image
    plot_function(data, axes=axes, **kwargs)
  File "/work/src/analysis/plotting.py", line 159, in coverage_growth_plot
    axes = sns.lineplot(
  File "/usr/local/lib/python3.8/site-packages/seaborn/_decorators.py", line 46, in inner_f
    return f(**kwargs)
  File "/usr/local/lib/python3.8/site-packages/seaborn/relational.py", line 693, in lineplot
    p.map_style(markers=markers, dashes=dashes, order=style_order)
  File "/usr/local/lib/python3.8/site-packages/seaborn/_core.py", line 53, in map
    setattr(plotter, method_name, cls(plotter, *args, **kwargs))
  File "/usr/local/lib/python3.8/site-packages/seaborn/_core.py", line 534, in __init__
    raise ValueError(err)
ValueError: Filled and line art markers cannot be mixed",
    "message": "Error generating HTML report.",
    "component": "dispatcher",
    "instance_name": "d-2022-12-04-centipede-flag",
    "experiment": "2022-12-04-centipede-flag"
  },
  "resource": {
    "type": "global",
    "labels": {
      "project_id": "fuzzbench"
    }
  },
  "timestamp": "2022-12-03T20:41:57.898659379Z",
  "severity": "ERROR",
  "logName": "projects/fuzzbench/logs/reporter",
  "receiveTimestamp": "2022-12-03T20:41:57.898659379Z"
}
```