### PR TITLE
Fix new presubmit error

### DIFF
--- a/analysis/test_coverage_data_utils.py
+++ b/analysis/test_coverage_data_utils.py
@@ -20,7 +20,7 @@ import pandas.testing as pd_test
 from analysis import coverage_data_utils
 
 FUZZER = 'afl'
-BENCHMARK = 'libpng-1.2.56'
+BENCHMARK = 'libpng-1.6.38'
 EXPERIMENT_FILESTORE_PATH = 'gs://fuzzbench-data/myexperiment'
 SAMPLE_DF = pd.DataFrame([{
     'experiment_filestore': 'gs://fuzzbench-data',
@@ -38,8 +38,8 @@ SAMPLE_DF = pd.DataFrame([{
 def create_coverage_data():
     """Utility function to create test data."""
     return {
-        'afl libpng-1.2.56': [[0, 0, 1, 1], [0, 0, 2, 2], [0, 0, 3, 3]],
-        'libfuzzer libpng-1.2.56': [[0, 0, 1, 1], [0, 0, 2, 3], [0, 0, 3, 3],
+        'afl libpng-1.6.38': [[0, 0, 1, 1], [0, 0, 2, 2], [0, 0, 3, 3]],
+        'libfuzzer libpng-1.6.38': [[0, 0, 1, 1], [0, 0, 2, 3], [0, 0, 3, 3],
                                     [0, 0, 4, 4]]
     }
 
@@ -48,7 +48,7 @@ def test_get_unique_branch_dict():
     """Tests get_unique_branch_dict() function."""
     coverage_dict = create_coverage_data()
     benchmark_coverage_dict = coverage_data_utils.get_benchmark_cov_dict(
-        coverage_dict, 'libpng-1.2.56')
+        coverage_dict, 'libpng-1.6.38')
     unique_branch_dict = coverage_data_utils.get_unique_branch_dict(
         benchmark_coverage_dict)
     expected_dict = {
@@ -63,7 +63,7 @@ def test_get_unique_branch_cov_df():
     """Tests get_unique_branch_cov_df() function."""
     coverage_dict = create_coverage_data()
     benchmark_coverage_dict = coverage_data_utils.get_benchmark_cov_dict(
-        coverage_dict, 'libpng-1.2.56')
+        coverage_dict, 'libpng-1.6.38')
     unique_branch_dict = coverage_data_utils.get_unique_branch_dict(
         benchmark_coverage_dict)
     fuzzer_names = ['afl', 'libfuzzer']
@@ -84,7 +84,7 @@ def test_get_unique_branch_cov_df():
 def test_get_benchmark_cov_dict():
     """Tests that get_benchmark_cov_dict() returns correct dictionary."""
     coverage_dict = create_coverage_data()
-    benchmark = 'libpng-1.2.56'
+    benchmark = 'libpng-1.6.38'
     benchmark_cov_dict = coverage_data_utils.get_benchmark_cov_dict(
         coverage_dict, benchmark)
     expected_cov_dict = {
@@ -99,7 +99,7 @@ def test_get_pairwise_unique_coverage_table():
     correct dataframe."""
     coverage_dict = create_coverage_data()
     benchmark_coverage_dict = coverage_data_utils.get_benchmark_cov_dict(
-        coverage_dict, 'libpng-1.2.56')
+        coverage_dict, 'libpng-1.6.38')
     fuzzers = ['libfuzzer', 'afl']
     table = coverage_data_utils.get_pairwise_unique_coverage_table(
         benchmark_coverage_dict, fuzzers)
@@ -116,19 +116,19 @@ def test_get_fuzzer_benchmark_covered_branches_filestore_path():
             get_fuzzer_benchmark_covered_branches_filestore_path(
                 FUZZER, BENCHMARK, EXPERIMENT_FILESTORE_PATH) == (
                     'gs://fuzzbench-data/myexperiment/'
-                    'coverage/data/libpng-1.2.56/afl/'
+                    'coverage/data/libpng-1.6.38/afl/'
                     'covered_branches.json'))
 
 
 def test_fuzzer_and_benchmark_to_key():
     """Tests that fuzzer_and_benchmark_to_key returns the correct result."""
     assert (coverage_data_utils.fuzzer_and_benchmark_to_key(
-        FUZZER, BENCHMARK) == 'afl libpng-1.2.56')
+        FUZZER, BENCHMARK) == 'afl libpng-1.6.38')
 
 
 def test_key_to_fuzzer_and_benchmark():
     """Tests that key_to_fuzzer_and_benchmark returns the correct result."""
-    assert (coverage_data_utils.key_to_fuzzer_and_benchmark('afl libpng-1.2.56')
+    assert (coverage_data_utils.key_to_fuzzer_and_benchmark('afl libpng-1.6.38')
             == (FUZZER, BENCHMARK))
 
 
@@ -193,6 +193,6 @@ def test_coverage_report_filestore_path():
     """Tests that get_coverage_report_filestore_path returns the correct
     result."""
     expected_cov_report_url = ('gs://fuzzbench-data/exp1/coverage/reports/'
-                               'libpng-1.2.56/afl/index.html')
+                               'libpng-1.6.38/afl/index.html')
     assert coverage_data_utils.get_coverage_report_filestore_path(
         FUZZER, BENCHMARK, SAMPLE_DF) == expected_cov_report_url

--- a/analysis/test_data_utils.py
+++ b/analysis/test_data_utils.py
@@ -46,13 +46,13 @@ def create_experiment_data(experiment='test_experiment',
                            experiment_filestore='gs://fuzzbench-data'):
     """Utility function to create test experiment data."""
     return pd.concat([
-        create_trial_data(0, 'libpng-1.2.56', 'afl', 10, 100, experiment,
+        create_trial_data(0, 'libpng-1.6.38', 'afl', 10, 100, experiment,
                           experiment_filestore),
-        create_trial_data(1, 'libpng-1.2.56', 'afl', 10, 200, experiment,
+        create_trial_data(1, 'libpng-1.6.38', 'afl', 10, 200, experiment,
                           experiment_filestore),
-        create_trial_data(2, 'libpng-1.2.56', 'libfuzzer', 10, 200, experiment,
+        create_trial_data(2, 'libpng-1.6.38', 'libfuzzer', 10, 200, experiment,
                           experiment_filestore),
-        create_trial_data(3, 'libpng-1.2.56', 'libfuzzer', 10, 300, experiment,
+        create_trial_data(3, 'libpng-1.6.38', 'libfuzzer', 10, 300, experiment,
                           experiment_filestore),
         create_trial_data(4, 'libxml', 'afl', 6 if incomplete else 10, 1000,
                           experiment, experiment_filestore),
@@ -94,7 +94,7 @@ def test_clobber_experiments_data():
     df.reset_index(inplace=True)
 
     to_drop = df[(df.experiment == 'experiment-2') &
-                 (df.benchmark == 'libpng-1.2.56') & (df.fuzzer == 'afl')].index
+                 (df.benchmark == 'libpng-1.6.38') & (df.fuzzer == 'afl')].index
     df.drop(to_drop, inplace=True)
 
     experiments = list(df['experiment'].drop_duplicates().values)
@@ -102,10 +102,10 @@ def test_clobber_experiments_data():
 
     columns = ['experiment', 'benchmark', 'fuzzer']
     expected_result = pd.DataFrame([
-        ['experiment-2', 'libpng-1.2.56', 'libfuzzer'],
+        ['experiment-2', 'libpng-1.6.38', 'libfuzzer'],
         ['experiment-2', 'libxml', 'afl'],
         ['experiment-2', 'libxml', 'libfuzzer'],
-        ['experiment-1', 'libpng-1.2.56', 'afl'],
+        ['experiment-1', 'libpng-1.6.38', 'afl'],
     ],
                                    columns=columns)
     expected_result.sort_index(inplace=True)
@@ -123,7 +123,7 @@ def test_filter_fuzzers():
 
 def test_filter_benchmarks():
     experiment_df = create_experiment_data()
-    benchmarks_to_keep = ['libpng-1.2.56']
+    benchmarks_to_keep = ['libpng-1.6.38']
     filtered_df = data_utils.filter_benchmarks(experiment_df,
                                                benchmarks_to_keep)
 
@@ -245,7 +245,7 @@ def test_experiment_summary():
     summary = data_utils.experiment_summary(snapshots_df)
 
     expected_summary = pd.DataFrame({
-        'benchmark': ['libpng-1.2.56', 'libpng-1.2.56', 'libxml', 'libxml'],
+        'benchmark': ['libpng-1.6.38', 'libpng-1.6.38', 'libxml', 'libxml'],
         'fuzzer': ['libfuzzer', 'afl', 'afl', 'libfuzzer'],
         'time': [9, 9, 9, 9],
         'count': [2, 2, 2, 2],
@@ -306,8 +306,8 @@ def test_experiment_pivot_table():
 
     # yapf: disable
     expected_data = pd.DataFrame([
-        {'benchmark': 'libpng-1.2.56', 'fuzzer': 'afl', 'median':  150},
-        {'benchmark': 'libpng-1.2.56', 'fuzzer': 'libfuzzer', 'median':  250},
+        {'benchmark': 'libpng-1.6.38', 'fuzzer': 'afl', 'median':  150},
+        {'benchmark': 'libpng-1.6.38', 'fuzzer': 'libfuzzer', 'median':  250},
         {'benchmark': 'libxml', 'fuzzer': 'afl', 'median': 1100},
         {'benchmark': 'libxml', 'fuzzer': 'libfuzzer', 'median':  700},
     ])

--- a/fuzzers/aflplusplus_optimal/fuzzer.py
+++ b/fuzzers/aflplusplus_optimal/fuzzer.py
@@ -94,7 +94,7 @@ def fuzz(input_corpus, output_corpus, target_binary):  # pylint: disable=too-man
         os.environ['AFL_KEEP_TIMEOUTS'] = '1'
     elif benchmark_name == 'harfbuzz-1.3.2':
         os.environ['AFL_KEEP_TIMEOUTS'] = '1'
-    elif benchmark_name == 'libpng-1.2.56':
+    elif benchmark_name == 'libpng-1.6.38':
         os.environ['AFL_TESTCACHE_SIZE'] = '2'
         os.environ['AFL_KEEP_TIMEOUTS'] = '1'
         run_options = ['-l', '2AT']

--- a/fuzzers/aflsmart/fuzzer.py
+++ b/fuzzers/aflsmart/fuzzer.py
@@ -42,7 +42,7 @@ def fuzz(input_corpus, output_corpus, target_binary):
     composite_mode = False
     input_model = ''
     benchmark_name = os.environ['BENCHMARK']
-    if benchmark_name == 'libpng-1.2.56':
+    if benchmark_name == 'libpng-1.6.38':
         input_model = 'png.xml'
     if benchmark_name == 'libpcap_fuzz_both':
         input_model = 'pcap.xml'


### PR DESCRIPTION
Update `libpng` version name in `analysis/test_data_utils.py` and others:
1. We updated libpng's version and dir name in `benchmarks/`, so we need to [update the benchmark name in the tests](https://github.com/google/fuzzbench/pull/1562/files#diff-d005e46b99437fd253139e309447006fb2a9fd17b7a06ad8a2ef7864c5ae290a). This did not cause errors in #1526 because I only [enforced name matching](https://github.com/google/fuzzbench/pull/1562/files#diff-d2f14ec051a28cb8be0e33f570b5e031fcbd0884ebd5af1d3fb24764eb6aaeb2R106) in a later PR #1562.
2. Update its name in other tests. Although they do not fail, it's better to keep them all consistent.