### PR TITLE
Add publication page to nav sidebar in github.io

### DIFF
--- a/docs/publications.md
+++ b/docs/publications.md
@@ -1,3 +1,13 @@
+---
+layout: default
+title: Publications
+has_children: false
+nav_order: 9
+permalink: /publications/
+---
+
+# Publications
+
 [FuzzBench](https://dl.acm.org/doi/pdf/10.1145/3468264.3473932)
 [[BibTeX](https://ieeexplore.ieee.org/abstract/document/9787836)]
 has been widely used by many research works to evaluate fuzzers and will


### PR DESCRIPTION
1. Show the [publication page](https://google.github.io/fuzzbench/publications.html) on the navigation sidebar.
2. Define its layout, links, etc.