### PR TITLE
Expect mock test to run with 150 concurrent builds

### DIFF
--- a/service/test_automatic_run_experiment.py
+++ b/service/test_automatic_run_experiment.py
@@ -36,6 +36,8 @@ EXPERIMENT_REQUESTS = [{
     'oss_fuzz_corpus': True,
 }]
 
+SERVICE_CONCURRENT_BUILDS = 150
+
 
 @mock.patch('experiment.run_experiment.start_experiment')
 @mock.patch('common.logs.warning')
@@ -125,6 +127,7 @@ def test_run_requested_experiment(mocked_get_requested_experiments,
                               expected_benchmarks,
                               expected_fuzzers,
                               description='Test experiment',
+                              concurrent_builds=SERVICE_CONCURRENT_BUILDS,
                               oss_fuzz_corpus=True)
     start_experiment_call_args = mocked_start_experiment.call_args_list
     assert len(start_experiment_call_args) == 1


### PR DESCRIPTION
Our earlier commit [fix issue with service](https://github.com/google/fuzzbench/commit/5ec25663710c9dc20d6623f82e01e79a7630f94c) did not edit the corresponding test, hence introducing a CI failure.
This PR fixes that failure by adding the new parameter to the expected call.