### PR TITLE
Fix bug-based benchmark labelling

### DIFF
--- a/benchmarks/libarchive_libarchive_fuzzer/benchmark.yaml
+++ b/benchmarks/libarchive_libarchive_fuzzer/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: libarchive_fuzzer
 project: libarchive
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/libgit2_objects_fuzzer/benchmark.yaml
+++ b/benchmarks/libgit2_objects_fuzzer/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: objects_fuzzer
 project: libgit2
+type: bug
 unsupported_fuzzers:
   - libafl
   - aflcc

--- a/benchmarks/libhevc_hevc_dec_fuzzer/benchmark.yaml
+++ b/benchmarks/libhevc_hevc_dec_fuzzer/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: hevc_dec_fuzzer
 project: libhevc
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/libhtp_fuzz_htp/benchmark.yaml
+++ b/benchmarks/libhtp_fuzz_htp/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: fuzz_htp
 project: libhtp
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/libxml2_libxml2_xml_reader_for_file_fuzzer/benchmark.yaml
+++ b/benchmarks/libxml2_libxml2_xml_reader_for_file_fuzzer/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: libxml2_xml_reader_for_file_fuzzer
 project: libxml2
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/matio_matio_fuzzer/benchmark.yaml
+++ b/benchmarks/matio_matio_fuzzer/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: matio_fuzzer
 project: matio
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/mruby-2018-05-23/benchmark.yaml
+++ b/benchmarks/mruby-2018-05-23/benchmark.yaml
@@ -1,4 +1,5 @@
 fuzz_target: mruby_fuzzer
 project: mruby
+type: bug
 unsupported_fuzzers:
   - libafl

--- a/benchmarks/muparser_set_eval_fuzzer/benchmark.yaml
+++ b/benchmarks/muparser_set_eval_fuzzer/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: set_eval_fuzzer
 project: muparser
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/njs_njs_process_script_fuzzer/benchmark.yaml
+++ b/benchmarks/njs_njs_process_script_fuzzer/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: njs_process_script_fuzzer
 project: njs
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/php_php-fuzz-execute/benchmark.yaml
+++ b/benchmarks/php_php-fuzz-execute/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: php-fuzz-execute
 project: php
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/php_php-fuzz-parser/benchmark.yaml
+++ b/benchmarks/php_php-fuzz-parser/benchmark.yaml
@@ -16,6 +16,7 @@ commit: 3516a9c8f096a71f493b90fb6b2be3ee3b0f0293
 commit_date: 2020-06-30 16:43:40+00:00
 fuzz_target: php-fuzz-parser
 project: php
+type: bug
 unsupported_fuzzers:
   - aflcc
   - klee

--- a/benchmarks/poppler_pdf_fuzzer/benchmark.yaml
+++ b/benchmarks/poppler_pdf_fuzzer/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: pdf_fuzzer
 project: poppler
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/proj4_standard_fuzzer/benchmark.yaml
+++ b/benchmarks/proj4_standard_fuzzer/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: standard_fuzzer
 project: proj4
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/quickjs_eval-2020-01-05/benchmark.yaml
+++ b/benchmarks/quickjs_eval-2020-01-05/benchmark.yaml
@@ -1,3 +1,4 @@
 fuzz_target: fuzz_eval
 project: quickjs
+type: bug
 unsupported_fuzzers:

--- a/benchmarks/systemd_fuzz-varlink/benchmark.yaml
+++ b/benchmarks/systemd_fuzz-varlink/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: fuzz-varlink
 project: systemd
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/usrsctp_fuzzer_connect/benchmark.yaml
+++ b/benchmarks/usrsctp_fuzzer_connect/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: fuzzer_connect
 project: usrsctp
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/wireshark_fuzzshark_ip/benchmark.yaml
+++ b/benchmarks/wireshark_fuzzshark_ip/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: fuzzshark_ip
 project: wireshark
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu

--- a/benchmarks/zstd_stream_decompress/benchmark.yaml
+++ b/benchmarks/zstd_stream_decompress/benchmark.yaml
@@ -1,5 +1,6 @@
 fuzz_target: stream_decompress
 project: zstd
+type: bug
 unsupported_fuzzers:
   - aflcc
   - afl_qemu


### PR DESCRIPTION
During upgrade some benchmarks were erroneously converted from
bug to coverage. Make these bug-based again so that they aren't run during bug-based experiments.