### PR TITLE
Ignore `config/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ignore the configuration directory created by locally-launched experiments.
+config/
+
 # Byte-compiled / optimized / DLL files.
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Launching experiments locally will automatically create a configuration directory `config/` containing the configure file used by the experiment.
The `git` repo does not need to keep track of this file, so this PR removes with `.gitignore`.