### PR TITLE
Fix centipede linker flags

### DIFF
--- a/fuzzers/centipede/fuzzer.py
+++ b/fuzzers/centipede/fuzzer.py
@@ -24,11 +24,8 @@ def build():
     san_cflags = ['-fsanitize-coverage=trace-loads']
 
     link_cflags = [
-        '-Wno-error=unused-command-line-argument',
-        '-ldl',
-        '-lrt',
-        '-lpthread',
-        '/lib/weak.o',
+        '-Wno-unused-command-line-argument',
+        '-Wl,-ldl,-lrt,-lpthread,/lib/weak.o'
     ]
 
     # TODO(Dongge): Build targets with sanitizers.
@@ -41,6 +38,7 @@ def build():
     cflags = san_cflags + centipede_cflags + link_cflags
     utils.append_flags('CFLAGS', cflags)
     utils.append_flags('CXXFLAGS', cflags)
+    utils.append_flags('LDFLAGS', ['/lib/weak.o'])
 
     os.environ['CC'] = '/clang/bin/clang'
     os.environ['CXX'] = '/clang/bin/clang++'


### PR DESCRIPTION
Mirrors [the fixes from OSS-Fuzz](https://github.com/google/oss-fuzz/pull/9427):
1. Use [`-Wl` on the linker flags](https://github.com/google/oss-fuzz/pull/9427#issuecomment-1385205488).
2. Use [`LDFLAGS`](https://github.com/google/oss-fuzz/pull/9427#issuecomment-1385375441).