### PR TITLE
Change format of corpus snapshots to save cost

### DIFF
--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -25,7 +25,7 @@ import sys
 import tempfile
 import tarfile
 import time
-from typing import List, Set
+from typing import List
 import queue
 import psutil
 

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -404,11 +404,9 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
     def run_cov_new_units(self):
         """Run the coverage binary on new units."""
         coverage_binary = coverage_utils.get_coverage_binary(self.benchmark)
-        run_coverage.do_coverage_run(coverage_binary,
-                                     self.corpus_dir,
+        run_coverage.do_coverage_run(coverage_binary, self.corpus_dir,
                                      self.profraw_file_pattern,
                                      self.crashes_dir)
-
 
     def generate_summary(self, cycle: int, summary_only=False):
         """Transforms the .profdata file into json form."""

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -328,8 +328,7 @@ def get_unmeasured_snapshots(experiment: str,
     return unmeasured_first_snapshots + unmeasured_latest_snapshots
 
 
-def extract_corpus(corpus_archive: str, sha_blacklist: Set[str],
-                   output_directory: str):
+def extract_corpus(corpus_archive: str, output_directory: str):
     """Extract a corpus from |corpus_archive| to |output_directory|."""
     pathlib.Path(output_directory).mkdir(exist_ok=True)
     with tarfile.open(corpus_archive, 'r:gz') as tar:
@@ -345,11 +344,10 @@ def extract_corpus(corpus_archive: str, sha_blacklist: Set[str],
                 logger.info('Failed to get handle to %s.', member)
                 continue
 
+            # TODO(metzman): Consider removing the hashing. We don't really need
+            # it anymore.
             member_contents = member_file_handle.read()
             filename = utils.string_hash(member_contents)
-            if filename in sha_blacklist:
-                continue
-
             file_path = os.path.join(output_directory, filename)
 
             if os.path.exists(file_path):
@@ -363,8 +361,6 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
     """Class used for storing details needed to measure coverage of a particular
     trial."""
 
-    UNIT_BLACKLIST = collections.defaultdict(set)
-
     # pylint: disable=too-many-arguments
     def __init__(self, fuzzer: str, benchmark: str, trial_num: int,
                  trial_logger: logs.Logger, region_coverage: bool):
@@ -376,15 +372,6 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
         self.coverage_dir = os.path.join(self.measurement_dir, 'coverage')
         self.trial_dir = os.path.join(self.work_dir, 'experiment-folders',
                                       self.benchmark_fuzzer_trial_dir)
-
-        # Stores the files that have already been measured for a trial.
-        self.measured_files_path = os.path.join(self.report_dir,
-                                                'measured-files.txt')
-
-        # Used by the runner to signal that there won't be a corpus archive for
-        # a cycle because the corpus hasn't changed since the last cycle.
-        self.unchanged_cycles_path = os.path.join(self.trial_dir, 'results',
-                                                  'unchanged-cycles')
 
         # Store the profraw file containing coverage data for each cycle.
         self.profraw_file_pattern = os.path.join(self.coverage_dir,
@@ -417,13 +404,11 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
     def run_cov_new_units(self):
         """Run the coverage binary on new units."""
         coverage_binary = coverage_utils.get_coverage_binary(self.benchmark)
-        crashing_units = run_coverage.do_coverage_run(coverage_binary,
-                                                      self.corpus_dir,
-                                                      self.profraw_file_pattern,
-                                                      self.crashes_dir)
+        run_coverage.do_coverage_run(coverage_binary,
+                                     self.corpus_dir,
+                                     self.profraw_file_pattern,
+                                     self.crashes_dir)
 
-        self.UNIT_BLACKLIST[self.benchmark] = (
-            self.UNIT_BLACKLIST[self.benchmark].union(set(crashing_units)))
 
     def generate_summary(self, cycle: int, summary_only=False):
         """Transforms the .profdata file into json form."""
@@ -493,54 +478,13 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
             return
         self.generate_summary(cycle)
 
-    def is_cycle_unchanged(self, cycle: int) -> bool:
-        """Returns True if |cycle| is unchanged according to the
-        unchanged-cycles file. This file is written to by the trial's runner."""
-
-        def copy_unchanged_cycles_file():
-            unchanged_cycles_filestore_path = exp_path.filestore(
-                self.unchanged_cycles_path)
-            result = filestore_utils.cp(unchanged_cycles_filestore_path,
-                                        self.unchanged_cycles_path,
-                                        expect_zero=False)
-            return result.retcode == 0
-
-        if not os.path.exists(self.unchanged_cycles_path):
-            if not copy_unchanged_cycles_file():
-                return False
-
-        def get_unchanged_cycles():
-            return [
-                int(cycle) for cycle in filesystem.read(
-                    self.unchanged_cycles_path).splitlines()
-            ]
-
-        unchanged_cycles = get_unchanged_cycles()
-        if cycle in unchanged_cycles:
-            return True
-
-        if cycle < max(unchanged_cycles):
-            # If the last/max unchanged cycle is greater than |cycle| then we
-            # don't need to copy the file again.
-            return False
-
-        if not copy_unchanged_cycles_file():
-            return False
-
-        unchanged_cycles = get_unchanged_cycles()
-        return cycle in unchanged_cycles
-
     def extract_corpus(self, corpus_archive_path) -> bool:
         """Extract the corpus archive for this cycle if it exists."""
         if not os.path.exists(corpus_archive_path):
             self.logger.warning('Corpus not found: %s.', corpus_archive_path)
             return False
 
-        already_measured_units = self.get_measured_files()
-        crash_blacklist = self.UNIT_BLACKLIST[self.benchmark]
-        unit_blacklist = already_measured_units.union(crash_blacklist)
-
-        extract_corpus(corpus_archive_path, unit_blacklist, self.corpus_dir)
+        extract_corpus(corpus_archive_path, self.corpus_dir)
         return True
 
     def save_crash_files(self, cycle):
@@ -585,21 +529,6 @@ class SnapshotMeasurer(coverage_utils.TrialCoverage):  # pylint: disable=too-man
                              crash_state=crash.crash_state,
                              crash_stacktrace=crash.crash_stacktrace))
         return crashes
-
-    def update_measured_files(self):
-        """Updates the measured-files.txt file for this trial with
-        files measured in this snapshot."""
-        current_files = set(os.listdir(self.corpus_dir))
-        already_measured = self.get_measured_files()
-        filesystem.write(self.measured_files_path,
-                         '\n'.join(current_files.union(already_measured)))
-
-    def get_measured_files(self):
-        """Returns a the set of files that have been measured for this
-        snapshot's trials."""
-        if not os.path.exists(self.measured_files_path):
-            return set()
-        return set(filesystem.read(self.measured_files_path).splitlines())
 
     def get_fuzzer_stats(self, cycle):
         """Get the fuzzer stats for |cycle|."""
@@ -673,16 +602,6 @@ def measure_snapshot_coverage(  # pylint: disable=too-many-locals
     measuring_start_time = time.time()
     snapshot_logger.info('Measuring cycle: %d.', cycle)
     this_time = experiment_utils.get_cycle_time(cycle)
-    if snapshot_measurer.is_cycle_unchanged(cycle):
-        snapshot_logger.info('Cycle: %d is unchanged.', cycle)
-        branches_covered = snapshot_measurer.get_current_coverage()
-        fuzzer_stats_data = snapshot_measurer.get_fuzzer_stats(cycle)
-        return models.Snapshot(time=this_time,
-                               trial_id=trial_num,
-                               edges_covered=branches_covered,
-                               fuzzer_stats=fuzzer_stats_data,
-                               crashes=[])
-
     corpus_archive_dst = os.path.join(
         snapshot_measurer.trial_dir, 'corpus',
         experiment_utils.get_corpus_archive_name(cycle))
@@ -720,9 +639,6 @@ def measure_snapshot_coverage(  # pylint: disable=too-many-locals
                                edges_covered=branches_covered,
                                fuzzer_stats=fuzzer_stats_data,
                                crashes=crashes)
-
-    # Record the new corpus files.
-    snapshot_measurer.update_measured_files()
 
     measuring_time = round(time.time() - measuring_start_time, 2)
     snapshot_logger.info('Measured cycle: %d in %f seconds.', cycle,

--- a/experiment/measurer/run_coverage.py
+++ b/experiment/measurer/run_coverage.py
@@ -40,7 +40,7 @@ MAX_TOTAL_TIME = experiment_utils.get_snapshot_seconds()
 
 def do_coverage_run(  # pylint: disable=too-many-locals
         coverage_binary: str, new_units_dir: List[str],
-        profraw_file_pattern: str):
+        profraw_file_pattern: str, crashes_dir: str):
     """Does a coverage run of |coverage_binary| on |new_units_dir|. Writes
     the result to |profraw_file_pattern|."""
     with tempfile.TemporaryDirectory() as merge_dir:

--- a/experiment/measurer/run_coverage.py
+++ b/experiment/measurer/run_coverage.py
@@ -38,20 +38,9 @@ UNIT_TIMEOUT = 10
 MAX_TOTAL_TIME = experiment_utils.get_snapshot_seconds()
 
 
-def find_crashing_units(artifacts_dir: str) -> List[str]:
-    """Returns the crashing unit in coverage_binary_output."""
-    return [
-        # This assumes the artifacts are named {crash,oom,timeout,*}-$SHA1_HASH
-        # and that input units are also named with their hash.
-        filename.split('-')[1]
-        for filename in os.listdir(artifacts_dir)
-        if os.path.isfile(os.path.join(artifacts_dir, filename))
-    ]
-
-
 def do_coverage_run(  # pylint: disable=too-many-locals
         coverage_binary: str, new_units_dir: List[str],
-        profraw_file_pattern: str, crashes_dir: str) -> List[str]:
+        profraw_file_pattern: str):
     """Does a coverage run of |coverage_binary| on |new_units_dir|. Writes
     the result to |profraw_file_pattern|."""
     with tempfile.TemporaryDirectory() as merge_dir:
@@ -79,4 +68,3 @@ def do_coverage_run(  # pylint: disable=too-many-locals
                          'coverage_binary': coverage_binary,
                          'output': result.output[-new_process.LOG_LIMIT_FIELD:],
                      })
-    return find_crashing_units(crashes_dir)

--- a/experiment/measurer/test_measure_manager.py
+++ b/experiment/measurer/test_measure_manager.py
@@ -222,72 +222,6 @@ def test_is_cycle_unchanged_doesnt_exist(experiment):
         assert not snapshot_measurer.is_cycle_unchanged(this_cycle)
 
 
-@mock.patch('common.filestore_utils.cp')
-@mock.patch('common.filesystem.read')
-def test_is_cycle_unchanged_first_copy(mocked_read, mocked_cp, experiment):
-    """Test that is_cycle_unchanged can properly determine if a cycle is
-    unchanged or not when it needs to copy the file for the first time."""
-    snapshot_measurer = measure_manager.SnapshotMeasurer(
-        FUZZER, BENCHMARK, TRIAL_NUM, SNAPSHOT_LOGGER, REGION_COVERAGE)
-    this_cycle = 100
-    unchanged_cycles_file_contents = (
-        '\n'.join([str(num) for num in range(10)] + [str(this_cycle)]))
-    mocked_read.return_value = unchanged_cycles_file_contents
-    mocked_cp.return_value = new_process.ProcessResult(0, '', False)
-
-    assert snapshot_measurer.is_cycle_unchanged(this_cycle)
-    assert not snapshot_measurer.is_cycle_unchanged(this_cycle + 1)
-
-
-def test_is_cycle_unchanged_update(fs, experiment):
-    """Test that is_cycle_unchanged can properly determine that a
-    cycle has changed when it has the file but needs to update it."""
-    snapshot_measurer = measure_manager.SnapshotMeasurer(
-        FUZZER, BENCHMARK, TRIAL_NUM, SNAPSHOT_LOGGER, REGION_COVERAGE)
-
-    this_cycle = 100
-    initial_unchanged_cycles_file_contents = (
-        '\n'.join([str(num) for num in range(10)] + [str(this_cycle)]))
-    fs.create_file(snapshot_measurer.unchanged_cycles_path,
-                   contents=initial_unchanged_cycles_file_contents)
-
-    next_cycle = this_cycle + 1
-    unchanged_cycles_file_contents = (initial_unchanged_cycles_file_contents +
-                                      '\n' + str(next_cycle))
-    assert snapshot_measurer.is_cycle_unchanged(this_cycle)
-    with mock.patch('common.filestore_utils.cp') as mocked_cp:
-        with mock.patch('common.filesystem.read') as mocked_read:
-            mocked_cp.return_value = new_process.ProcessResult(0, '', False)
-            mocked_read.return_value = unchanged_cycles_file_contents
-            assert snapshot_measurer.is_cycle_unchanged(next_cycle)
-
-
-@mock.patch('common.filestore_utils.cp')
-def test_is_cycle_unchanged_skip_cp(mocked_cp, fs, experiment):
-    """Check that is_cycle_unchanged doesn't call filestore_utils.cp
-    unnecessarily."""
-    snapshot_measurer = measure_manager.SnapshotMeasurer(
-        FUZZER, BENCHMARK, TRIAL_NUM, SNAPSHOT_LOGGER, REGION_COVERAGE)
-    this_cycle = 100
-    initial_unchanged_cycles_file_contents = (
-        '\n'.join([str(num) for num in range(10)] + [str(this_cycle + 1)]))
-    fs.create_file(snapshot_measurer.unchanged_cycles_path,
-                   contents=initial_unchanged_cycles_file_contents)
-    assert not snapshot_measurer.is_cycle_unchanged(this_cycle)
-    mocked_cp.assert_not_called()
-
-
-@mock.patch('common.filestore_utils.cp')
-def test_is_cycle_unchanged_no_file(mocked_cp, fs, experiment):
-    """Test that is_cycle_unchanged returns False when there is no
-    unchanged-cycles file."""
-    # Make sure we log if there is no unchanged-cycles file.
-    snapshot_measurer = measure_manager.SnapshotMeasurer(
-        FUZZER, BENCHMARK, TRIAL_NUM, SNAPSHOT_LOGGER, REGION_COVERAGE)
-    mocked_cp.return_value = new_process.ProcessResult(1, '', False)
-    assert not snapshot_measurer.is_cycle_unchanged(0)
-
-
 @mock.patch('common.new_process.execute')
 @mock.patch('common.benchmark_utils.get_fuzz_target',
             return_value='fuzz-target')
@@ -302,12 +236,6 @@ def test_run_cov_new_units(_, mocked_execute, fs, environ):
     snapshot_measurer = measure_manager.SnapshotMeasurer(
         FUZZER, BENCHMARK, TRIAL_NUM, SNAPSHOT_LOGGER, REGION_COVERAGE)
     snapshot_measurer.initialize_measurement_dirs()
-    shared_units = ['shared1', 'shared2']
-    fs.create_file(snapshot_measurer.measured_files_path,
-                   contents='\n'.join(shared_units))
-    for unit in shared_units:
-        fs.create_file(os.path.join(snapshot_measurer.corpus_dir, unit))
-
     new_units = ['new1', 'new2']
     for unit in new_units:
         fs.create_file(os.path.join(snapshot_measurer.corpus_dir, unit))
@@ -428,7 +356,7 @@ class TestIntegrationMeasurement:
 def test_extract_corpus(archive_name, tmp_path):
     """"Tests that extract_corpus unpacks a corpus as we expect."""
     archive_path = get_test_data_path(archive_name)
-    measure_manager.extract_corpus(archive_path, set(), tmp_path)
+    measure_manager.extract_corpus(archive_path, tmp_path)
     expected_corpus_files = {
         '5ea57dfc9631f35beecb5016c4f1366eb6faa810',
         '2f1507c3229c5a1f8b619a542a8e03ccdbb3c29c',

--- a/experiment/measurer/test_measure_manager.py
+++ b/experiment/measurer/test_measure_manager.py
@@ -212,16 +212,6 @@ def test_measure_all_trials_no_more(mocked_directories_have_same_files,
         queue.Queue(), False)
 
 
-def test_is_cycle_unchanged_doesnt_exist(experiment):
-    """Test that is_cycle_unchanged can properly determine if a cycle is
-    unchanged or not when it needs to copy the file for the first time."""
-    snapshot_measurer = measure_manager.SnapshotMeasurer(
-        FUZZER, BENCHMARK, TRIAL_NUM, SNAPSHOT_LOGGER, REGION_COVERAGE)
-    this_cycle = 1
-    with test_utils.mock_popen_ctx_mgr(returncode=1):
-        assert not snapshot_measurer.is_cycle_unchanged(this_cycle)
-
-
 @mock.patch('common.new_process.execute')
 @mock.patch('common.benchmark_utils.get_fuzz_target',
             return_value='fuzz-target')
@@ -294,10 +284,8 @@ class TestIntegrationMeasurement:
     # portable binary.
     @pytest.mark.skipif(not os.getenv('FUZZBENCH_TEST_INTEGRATION'),
                         reason='Not running integration tests.')
-    @mock.patch('experiment.measurer.measure_manager.SnapshotMeasurer'
-                '.is_cycle_unchanged')
     def test_measure_snapshot_coverage(  # pylint: disable=too-many-locals
-            self, mocked_is_cycle_unchanged, db, experiment, tmp_path):
+            self, db, experiment, tmp_path):
         """Integration test for measure_snapshot_coverage."""
         # WORK is set by experiment to a directory that only makes sense in a
         # fakefs. A directory containing necessary llvm tools is also added to
@@ -305,7 +293,6 @@ class TestIntegrationMeasurement:
         llvm_tools_path = get_test_data_path('llvm_tools')
         os.environ['PATH'] += os.pathsep + llvm_tools_path
         os.environ['WORK'] = str(tmp_path)
-        mocked_is_cycle_unchanged.return_value = False
         # Set up the coverage binary.
         benchmark = 'freetype2-2017'
         coverage_binary_src = get_test_data_path(

--- a/experiment/measurer/test_run_coverage.py
+++ b/experiment/measurer/test_run_coverage.py
@@ -66,9 +66,8 @@ class TestIntegrationRunCoverage:
         coverage_dir = _make_coverage_dir(tmp_path)
         profraw_file = os.path.join(coverage_dir, 'test_crash.profraw')
         crashes_dir = _make_crashes_dir(tmp_path)
-        run_coverage.do_coverage_run(self.COVERAGE_BINARY_PATH,
-                                     units, profraw_file,
-                                     crashes_dir)
+        run_coverage.do_coverage_run(self.COVERAGE_BINARY_PATH, units,
+                                     profraw_file, crashes_dir)
 
         # Ensure the crashing units are returned.
         assert os.listdir(crashes_dir) == [
@@ -83,9 +82,8 @@ class TestIntegrationRunCoverage:
         coverage_dir = _make_coverage_dir(tmp_path)
         profraw_file = os.path.join(coverage_dir, 'test_no_crash.profraw')
         crashes_dir = _make_crashes_dir(tmp_path)
-        run_coverage.do_coverage_run(self.COVERAGE_BINARY_PATH,
-                                     units, profraw_file,
-                                     crashes_dir)
+        run_coverage.do_coverage_run(self.COVERAGE_BINARY_PATH, units,
+                                     profraw_file, crashes_dir)
 
         # Assert no crashing units.
         assert not os.listdir(crashes_dir)
@@ -100,9 +98,8 @@ class TestIntegrationRunCoverage:
         coverage_dir = _make_coverage_dir(tmp_path)
         profraw_file = os.path.join(coverage_dir, 'test_max_time.profraw')
         crashes_dir = _make_crashes_dir(tmp_path)
-        run_coverage.do_coverage_run(self.COVERAGE_BINARY_PATH,
-                                     units, profraw_file,
-                                     crashes_dir)
+        run_coverage.do_coverage_run(self.COVERAGE_BINARY_PATH, units,
+                                     profraw_file, crashes_dir)
 
         assert mocked_log_error.call_count
         # Assert no crashing units

--- a/experiment/measurer/test_run_coverage.py
+++ b/experiment/measurer/test_run_coverage.py
@@ -71,7 +71,7 @@ class TestIntegrationRunCoverage:
 
         # Ensure the crashing units are returned.
         assert os.listdir(crashes_dir) == [
-            '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
+            'crash-86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
         ]
         _assert_profraw_files(coverage_dir)
 

--- a/experiment/measurer/test_run_coverage.py
+++ b/experiment/measurer/test_run_coverage.py
@@ -66,12 +66,14 @@ class TestIntegrationRunCoverage:
         coverage_dir = _make_coverage_dir(tmp_path)
         profraw_file = os.path.join(coverage_dir, 'test_crash.profraw')
         crashes_dir = _make_crashes_dir(tmp_path)
-        crashing_units = run_coverage.do_coverage_run(self.COVERAGE_BINARY_PATH,
-                                                      units, profraw_file,
-                                                      crashes_dir)
+        run_coverage.do_coverage_run(self.COVERAGE_BINARY_PATH,
+                                     units, profraw_file,
+                                     crashes_dir)
 
         # Ensure the crashing units are returned.
-        assert crashing_units == ['86f7e437faa5a7fce15d1ddcb9eaeaea377667b8']
+        assert os.listdir(crashes_dir) == [
+            '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
+        ]
         _assert_profraw_files(coverage_dir)
 
     def test_integration_do_coverage_run_no_crash(self, tmp_path):
@@ -81,12 +83,12 @@ class TestIntegrationRunCoverage:
         coverage_dir = _make_coverage_dir(tmp_path)
         profraw_file = os.path.join(coverage_dir, 'test_no_crash.profraw')
         crashes_dir = _make_crashes_dir(tmp_path)
-        crashing_units = run_coverage.do_coverage_run(self.COVERAGE_BINARY_PATH,
-                                                      units, profraw_file,
-                                                      crashes_dir)
+        run_coverage.do_coverage_run(self.COVERAGE_BINARY_PATH,
+                                     units, profraw_file,
+                                     crashes_dir)
 
-        # Ensure no crashing unit is returned.
-        assert not crashing_units
+        # Assert no crashing units.
+        assert not os.listdir(crashes_dir)
         _assert_profraw_files(coverage_dir)
 
     @mock.patch('common.logs.error')
@@ -98,10 +100,10 @@ class TestIntegrationRunCoverage:
         coverage_dir = _make_coverage_dir(tmp_path)
         profraw_file = os.path.join(coverage_dir, 'test_max_time.profraw')
         crashes_dir = _make_crashes_dir(tmp_path)
-        crashing_units = run_coverage.do_coverage_run(self.COVERAGE_BINARY_PATH,
-                                                      units, profraw_file,
-                                                      crashes_dir)
+        run_coverage.do_coverage_run(self.COVERAGE_BINARY_PATH,
+                                     units, profraw_file,
+                                     crashes_dir)
 
         assert mocked_log_error.call_count
-        # Ensure no crashing unit is returned.
-        assert not crashing_units
+        # Assert no crashing units
+        assert not os.listdir(crashes_dir)

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -434,7 +434,7 @@ class TrialRunner:  # pylint: disable=too-many-instance-attributes
         # directory and can be written to by the fuzzer at any time.
         results_copy = filesystem.make_dir_copy(self.results_dir)
         filestore_utils.rsync(
-            results_copy, posixpath.join(self.gcs_sync_dir, RESULTS_DIR_NAME))
+            results_copy, posixpath.join(self.gcs_sync_dir, RESULTS_DIRNAME))
 
 
 def get_fuzzer_module(fuzzer):

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -433,8 +433,8 @@ class TrialRunner:  # pylint: disable=too-many-instance-attributes
         # in size because the log file containing the fuzzer's output is in this
         # directory and can be written to by the fuzzer at any time.
         results_copy = filesystem.make_dir_copy(self.results_dir)
-        filestore_utils.rsync(results_copy, posixpath.join(self.gcs_sync_dir, RESULTS_DIR_NAME))
-
+        filestore_utils.rsync(
+            results_copy, posixpath.join(self.gcs_sync_dir, RESULTS_DIR_NAME))
 
 
 def get_fuzzer_module(fuzzer):

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Runs fuzzer for trial."""
 
-from collections import namedtuple
 import importlib
 import json
 import os
@@ -64,9 +63,10 @@ EXCLUDE_PATHS = set([
 CORPUS_ELEMENT_BYTES_LIMIT = 1 * 1024 * 1024
 SEED_CORPUS_ARCHIVE_SUFFIX = '_seed_corpus.zip'
 
-File = namedtuple('File', ['path', 'modified_time', 'change_time'])
-
 fuzzer_errored_out = False  # pylint:disable=invalid-name
+
+RESULTS_DIRNAME = 'results'
+CORPUS_DIRNAME = 'corpus'
 
 
 def _clean_seed_corpus(seed_corpus_dir):
@@ -250,14 +250,12 @@ class TrialRunner:  # pylint: disable=too-many-instance-attributes
             self.gcs_sync_dir = None
 
         self.cycle = 0
-        self.corpus_dir = 'corpus'
-        self.corpus_archives_dir = 'corpus-archives'
-        self.results_dir = 'results'
-        self.unchanged_cycles_path = os.path.join(self.results_dir,
-                                                  'unchanged-cycles')
+        self.corpus_dir = os.path.abspath(CORPUS_DIRNAME)
+        self.corpus_archives_dir = os.path.abspath('corpus-archives')
+        self.results_dir = os.path.abspath(RESULTS_DIRNAME)
         self.log_file = os.path.join(self.results_dir, 'fuzzer-log.txt')
         self.last_sync_time = None
-        self.corpus_dir_contents = set()
+        self.last_archive_time = -float('inf')
 
     def initialize_directories(self):
         """Initialize directories needed for the trial."""
@@ -304,7 +302,7 @@ class TrialRunner:  # pylint: disable=too-many-instance-attributes
             self.do_sync()
 
         logs.info('Doing final sync.')
-        self.do_sync(final_sync=True)
+        self.do_sync()
         fuzz_thread.join()
 
     def sleep_until_next_sync(self):
@@ -328,55 +326,11 @@ class TrialRunner:  # pylint: disable=too-many-instance-attributes
         # roughly get_snapshot_seconds() after each other.
         self.last_sync_time = time.time()
 
-    def _set_corpus_dir_contents(self):
-        """Set |self.corpus_dir_contents| to the current contents of
-        |self.corpus_dir|. Don't include files or directories excluded by
-        |EXCLUDE_PATHS|."""
-        self.corpus_dir_contents = set()
-        corpus_dir = os.path.abspath(self.corpus_dir)
-        for root, _, files in os.walk(corpus_dir):
-            # Check if root is excluded.
-            relpath = os.path.relpath(root, corpus_dir)
-            if _is_path_excluded(relpath):
-                continue
-
-            for filename in files:
-                # Check if filename is excluded first.
-                if _is_path_excluded(filename):
-                    continue
-
-                file_path = os.path.join(root, filename)
-                try:
-                    stat_info = os.stat(file_path)
-                    last_modified_time = stat_info.st_mtime
-                    # Warning: ctime means creation time on Win and
-                    # may not work as expected.
-                    last_changed_time = stat_info.st_ctime
-                    file_tuple = File(file_path, last_modified_time,
-                                      last_changed_time)
-                    self.corpus_dir_contents.add(file_tuple)
-                except Exception:  # pylint: disable=broad-except
-                    pass
-
-    def is_corpus_dir_same(self):
-        """Sets |self.corpus_dir_contents| to the current contents and returns
-        True if it is the same as the previous contents."""
-        logs.debug('Checking if corpus dir is the same.')
-        prev_contents = self.corpus_dir_contents.copy()
-        self._set_corpus_dir_contents()
-        return prev_contents == self.corpus_dir_contents
-
-    def do_sync(self, final_sync=False):
+    def do_sync(self):
         """Save corpus archives and results to GCS."""
         try:
-            if not final_sync and self.is_corpus_dir_same():
-                logs.debug('Cycle: %d unchanged.', self.cycle)
-                filesystem.append(self.unchanged_cycles_path, str(self.cycle))
-            else:
-                logs.debug('Cycle: %d changed.', self.cycle)
-                self.archive_and_save_corpus()
-
-            self.record_stats()
+            self.archive_and_save_corpus()
+            # TODO(metzman): Enable stats.
             self.save_results()
             logs.debug('Finished sync.')
         except Exception:  # pylint: disable=broad-except
@@ -421,9 +375,30 @@ class TrialRunner:  # pylint: disable=too-many-instance-attributes
             self.corpus_archives_dir,
             experiment_utils.get_corpus_archive_name(self.cycle))
 
-        directories = [self.corpus_dir]
+        corpus_dir_name = os.path.basename(self.corpus_dir)
+        with tarfile.open(archive, 'w:gz') as tar:
+            new_archive_time = self.last_archive_time
+            for file_path in get_corpus_elements(self.corpus_dir):
+                stat_info = os.stat(file_path)
+                last_modified_time = stat_info.st_mtime
+                if last_modified_time <= self.last_archive_time:
+                    continue  # We've saved this file already.
+                new_archive_time = max(new_archive_time, last_modified_time)
 
-        archive_directories(directories, archive)
+                arcname = os.path.join(
+                    corpus_dir_name, os.path.relpath(file_path,
+                                                     corpus_dir_name))
+                try:
+                    tar.add(file_path, arcname=arcname)
+                except (FileNotFoundError, OSError):
+                    # We will get these errors if files or directories are being
+                    # deleted from |directory| as we archive it. Don't bother
+                    # rescanning the directory, new files will be archived in
+                    # the next sync.
+                    pass
+                except Exception:  # pylint: disable=broad-except
+                    logs.error('Unexpected exception occurred when archiving.')
+        self.last_archive_time = new_archive_time
         return archive
 
     def save_corpus_archive(self, archive):
@@ -432,7 +407,7 @@ class TrialRunner:  # pylint: disable=too-many-instance-attributes
             return
 
         basename = os.path.basename(archive)
-        gcs_path = posixpath.join(self.gcs_sync_dir, self.corpus_dir, basename)
+        gcs_path = posixpath.join(self.gcs_sync_dir, CORPUS_DIRNAME, basename)
 
         # Don't use parallel to avoid stability issues.
         filestore_utils.cp(archive, gcs_path)
@@ -458,8 +433,8 @@ class TrialRunner:  # pylint: disable=too-many-instance-attributes
         # in size because the log file containing the fuzzer's output is in this
         # directory and can be written to by the fuzzer at any time.
         results_copy = filesystem.make_dir_copy(self.results_dir)
-        filestore_utils.rsync(
-            results_copy, posixpath.join(self.gcs_sync_dir, self.results_dir))
+        filestore_utils.rsync(results_copy, posixpath.join(self.gcs_sync_dir, RESULTS_DIR_NAME))
+
 
 
 def get_fuzzer_module(fuzzer):
@@ -469,14 +444,6 @@ def get_fuzzer_module(fuzzer):
     fuzzer_module_name = f'fuzzers.{fuzzer}.fuzzer'
     fuzzer_module = importlib.import_module(fuzzer_module_name)
     return fuzzer_module
-
-
-def archive_directories(directories, archive_path):
-    """Create a tar.gz file named |archive_path| containing the contents of each
-    directory in |directories|."""
-    with tarfile.open(archive_path, 'w:gz') as tar:
-        for directory in directories:
-            tar_directory(directory, tar)
 
 
 def tar_directory(directory, tar):
@@ -500,6 +467,20 @@ def tar_directory(directory, tar):
                 pass
             except Exception:  # pylint: disable=broad-except
                 logs.error('Unexpected exception occurred when archiving.')
+
+
+def get_corpus_elements(corpus_dir):
+    """Returns a list of absolute paths to corpus elements in |corpus_dir|.
+    Excludes certain elements."""
+    corpus_dir = os.path.abspath(corpus_dir)
+    corpus_elements = []
+    for root, _, files in os.walk(corpus_dir):
+        for filename in files:
+            file_path = os.path.join(root, filename)
+            if _is_path_excluded(file_path):
+                continue
+            corpus_elements.append(file_path)
+    return corpus_elements
 
 
 def _is_path_excluded(path):

--- a/experiment/test_runner.py
+++ b/experiment/test_runner.py
@@ -250,7 +250,7 @@ def test_do_sync_changed(mocked_execute, fs, trial_runner, fuzzer_module):
     trial_runner.do_sync()
     assert mocked_execute.call_args_list == [
         mock.call([
-            'gsutil', 'cp', 'corpus-archives/corpus-archive-1337.tar.gz',
+            'gsutil', 'cp', '/corpus-archives/corpus-archive-1337.tar.gz',
             ('gs://bucket/experiment-name/experiment-folders/'
              'benchmark-1-fuzzer_a/trial-1/corpus/'
              'corpus-archive-1337.tar.gz')
@@ -263,10 +263,6 @@ def test_do_sync_changed(mocked_execute, fs, trial_runner, fuzzer_module):
         ],
                   expect_zero=True)
     ]
-    unchanged_cycles_path = os.path.join(trial_runner.results_dir,
-                                         'unchanged-cycles')
-    assert not os.path.exists(unchanged_cycles_path)
-
     # Archives should get deleted after syncing.
     archives = os.listdir(trial_runner.corpus_archives_dir)
     assert len(archives) == 0

--- a/experiment/test_runner.py
+++ b/experiment/test_runner.py
@@ -257,7 +257,7 @@ def test_do_sync_changed(mocked_execute, fs, trial_runner, fuzzer_module):
         ],
                   expect_zero=True),
         mock.call([
-            'gsutil', 'rsync', '-d', '-r', 'results-copy',
+            'gsutil', 'rsync', '-d', '-r', '/results-copy',
             ('gs://bucket/experiment-name/experiment-folders/'
              'benchmark-1-fuzzer_a/trial-1/results')
         ],

--- a/experiment/test_runner.py
+++ b/experiment/test_runner.py
@@ -217,39 +217,37 @@ def test_archive_corpus_name_correct(_, trial_runner):
 
 
 @mock.patch('common.logs.debug')
-@mock.patch('experiment.runner.TrialRunner.is_corpus_dir_same')
-def test_do_sync_unchanged(mocked_is_corpus_dir_same, mocked_debug,
+def test_do_sync_unchanged(mocked_debug,
                            trial_runner, fuzzer_module):
     """Test that do_sync records if there was no corpus change since last
     cycle."""
     trial_runner.cycle = 1337
-    mocked_is_corpus_dir_same.return_value = True
     with test_utils.mock_popen_ctx_mgr() as mocked_popen:
         trial_runner.do_sync()
-        assert mocked_popen.commands == [[
-            'gsutil', 'rsync', '-d', '-r', 'results-copy',
-            ('gs://bucket/experiment-name/experiment-folders/'
-             'benchmark-1-fuzzer_a/trial-1/results')
-        ]]
-    mocked_debug.assert_any_call('Cycle: %d unchanged.', trial_runner.cycle)
-    unchanged_cycles_path = os.path.join(trial_runner.results_dir,
-                                         'unchanged-cycles')
-    with open(unchanged_cycles_path, encoding='utf-8') as file_handle:
-        assert str(trial_runner.cycle) == file_handle.read().strip()
-    assert not os.listdir(trial_runner.corpus_archives_dir)
+        assert mocked_popen.commands == [
+            [
+                'gsutil', 'cp', '/corpus-archives/corpus-archive-1337.tar.gz',
+                ('gs://bucket/experiment-name/experiment-folders/'
+                 'benchmark-1-fuzzer_a/trial-1/corpus/'
+                 'corpus-archive-1337.tar.gz')
+            ],
+            [
+                'gsutil', 'rsync', '-d', '-r', '/results-copy',
+                ('gs://bucket/experiment-name/experiment-folders/'
+                 'benchmark-1-fuzzer_a/trial-1/results')
+            ]
+        ]
+    assert not os.listdir(trial_runner.corpus_archives_dir) # !!! make it work
 
 
-@mock.patch('experiment.runner.TrialRunner.is_corpus_dir_same')
 @mock.patch('common.new_process.execute')
-def test_do_sync_changed(mocked_execute, mocked_is_corpus_dir_same, fs,
-                         trial_runner, fuzzer_module):
+def test_do_sync_changed(mocked_execute, fs, trial_runner, fuzzer_module):
     """Test that do_sync archives and saves a corpus if it changed from the
     previous one."""
     mocked_execute.return_value = new_process.ProcessResult(0, '', False)
     corpus_file_name = 'corpus-file'
     fs.create_file(os.path.join(trial_runner.corpus_dir, corpus_file_name))
     trial_runner.cycle = 1337
-    mocked_is_corpus_dir_same.return_value = False
     trial_runner.do_sync()
     assert mocked_execute.call_args_list == [
         mock.call([
@@ -273,48 +271,6 @@ def test_do_sync_changed(mocked_execute, mocked_is_corpus_dir_same, fs,
     # Archives should get deleted after syncing.
     archives = os.listdir(trial_runner.corpus_archives_dir)
     assert len(archives) == 0
-
-
-def test_is_corpus_dir_same_unchanged(trial_runner, fs):
-    """Test is_corpus_dir_same behaves as expected when the corpus is
-    unchanged."""
-    file_path = os.path.join(trial_runner.corpus_dir, '1')
-    fs.create_file(file_path)
-    stat_info = os.stat(file_path)
-    last_modified_time = stat_info.st_mtime
-    last_changed_time = stat_info.st_ctime
-    trial_runner.corpus_dir_contents.add(
-        runner.File(os.path.abspath(file_path), last_modified_time,
-                    last_changed_time))
-    assert trial_runner.is_corpus_dir_same()
-
-
-EXCLUDED_PATTERN = '.cur_input'
-EXCLUDED_DIR_FILE = os.path.join(EXCLUDED_PATTERN, 'hello')
-
-
-@pytest.mark.parametrize(('new_path', 'expected_result'),
-                         [(EXCLUDED_DIR_FILE, True), (EXCLUDED_PATTERN, True),
-                          ('other', False)])
-def test_is_corpus_dir_same_changed(new_path, expected_result, trial_runner,
-                                    fs):
-    """Test is_corpus_dir_same behaves as expected when there actually is a
-    change in the corpus (though some of these changes are excluded from being
-    considered."""
-    file_path = os.path.join(trial_runner.corpus_dir, new_path)
-    fs.create_file(file_path)
-    assert bool(trial_runner.is_corpus_dir_same()) == expected_result
-
-
-def test_is_corpus_dir_same_modified(trial_runner, fs):
-    """Test is_corpus_dir_same behaves as expected when all of the files in the
-    corpus have the same names but one was modified."""
-    file_path = os.path.join(trial_runner.corpus_dir, 'f')
-    fs.create_file(file_path)
-    trial_runner._set_corpus_dir_contents()  # pylint: disable=protected-access
-    with open(file_path, 'w', encoding='utf-8') as file_handle:
-        file_handle.write('hi')
-    assert not trial_runner.is_corpus_dir_same()
 
 
 class TestIntegrationRunner:

--- a/experiment/test_runner.py
+++ b/experiment/test_runner.py
@@ -217,8 +217,7 @@ def test_archive_corpus_name_correct(_, trial_runner):
 
 
 @mock.patch('common.logs.debug')
-def test_do_sync_unchanged(mocked_debug,
-                           trial_runner, fuzzer_module):
+def test_do_sync_unchanged(mocked_debug, trial_runner, fuzzer_module):
     """Test that do_sync records if there was no corpus change since last
     cycle."""
     trial_runner.cycle = 1337
@@ -237,7 +236,7 @@ def test_do_sync_unchanged(mocked_debug,
                  'benchmark-1-fuzzer_a/trial-1/results')
             ]
         ]
-    assert not os.listdir(trial_runner.corpus_archives_dir) # !!! make it work
+    assert not os.listdir(trial_runner.corpus_archives_dir)  # !!! make it work
 
 
 @mock.patch('common.new_process.execute')

--- a/service/gcbrun_experiment.py
+++ b/service/gcbrun_experiment.py
@@ -86,5 +86,6 @@ def main():
     return 1
 
 
+
 if __name__ == '__main__':
     sys.exit(main())

--- a/service/gcbrun_experiment.py
+++ b/service/gcbrun_experiment.py
@@ -86,6 +86,5 @@ def main():
     return 1
 
 
-
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
Don't store every file on each snapshot, just newly modified ones.
Also, get rid of unchanged-cycles, it's no longer as useful and adds complexity.