### PR TITLE
Make it easier to route logs from fuzzbench code to a public bucket

### DIFF
--- a/analysis/coverage_data_utils.py
+++ b/analysis/coverage_data_utils.py
@@ -26,7 +26,7 @@ from analysis import data_utils
 from common import filestore_utils
 from common import logs
 
-logger = logs.Logger('coverage_data_utils')
+logger = logs.Logger()
 
 
 def fuzzer_and_benchmark_to_key(fuzzer: str, benchmark: str) -> str:

--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -19,7 +19,7 @@ from common import benchmark_utils
 from common import environment
 from common import logs
 
-logger = logs.Logger('data_utils')
+logger = logs.Logger()
 
 
 class EmptyDataError(ValueError):

--- a/analysis/generate_report.py
+++ b/analysis/generate_report.py
@@ -28,7 +28,7 @@ from analysis import rendering
 from common import filesystem
 from common import logs
 
-logger = logs.Logger('generate_report')
+logger = logs.Logger()
 
 DATA_FILENAME = 'data.csv.gz'
 

--- a/common/benchmark_config.py
+++ b/common/benchmark_config.py
@@ -19,7 +19,7 @@ from common import utils
 from common import yaml_utils
 from common import logs
 
-logger = logs.Logger('benchmark_config')
+logger = logs.Logger()
 
 BENCHMARKS_DIR = os.path.join(utils.ROOT_DIR, 'benchmarks')
 

--- a/common/logs.py
+++ b/common/logs.py
@@ -107,15 +107,17 @@ class Logger:
     """Wrapper around logging.Logger that allows it to be used like we use the
     root logger for stackdriver."""
 
-    def __init__(self, name, default_extras=None, log_level=logging.INFO):
+    _LOGGER_NAME = 'fuzzbench'
+
+    def __init__(self, default_extras=None, log_level=logging.INFO):
         if not utils.is_local():
             _initialize_cloud_clients()
-            self.logger = _log_client.logger(name)
+            self.logger = _log_client.logger(self._LOGGER_NAME)
         else:
-            self.logger = logging.getLogger(name)
+            self.logger = logging.getLogger(self._LOGGER_NAME)
 
-        logging.getLogger(name).setLevel(log_level)
-        logging.getLogger(name).addFilter(LengthFilter())
+        logging.getLogger(self._LOGGER_NAME).setLevel(log_level)
+        logging.getLogger(self._LOGGER_NAME).addFilter(LengthFilter())
         self.default_extras = default_extras if default_extras else {}
 
     def error(self, *args, **kwargs):

--- a/experiment/build/builder.py
+++ b/experiment/build/builder.py
@@ -47,7 +47,7 @@ BUILD_FAIL_WAIT = 5 * 60
 
 BENCHMARKS_DIR = os.path.join(utils.ROOT_DIR, 'benchmarks')
 
-logger = logs.Logger('builder')  # pylint: disable=invalid-name
+logger = logs.Logger()  # pylint: disable=invalid-name
 
 
 def get_fuzzer_benchmark_pairs(fuzzers, benchmarks):

--- a/experiment/build/gcb_build.py
+++ b/experiment/build/gcb_build.py
@@ -31,7 +31,7 @@ CONFIG_DIR = 'config'
 # Maximum time to wait for a GCB config to finish build.
 GCB_BUILD_TIMEOUT = 13 * 60 * 60  # 4 hours.
 
-logger = logs.Logger('builder')  # pylint: disable=invalid-name
+logger = logs.Logger()  # pylint: disable=invalid-name
 
 
 def _get_buildable_images(fuzzer=None, benchmark=None):

--- a/experiment/build/local_build.py
+++ b/experiment/build/local_build.py
@@ -24,7 +24,7 @@ from common import logs
 from common import new_process
 from common import utils
 
-logger = logs.Logger('builder')  # pylint: disable=invalid-name
+logger = logs.Logger()  # pylint: disable=invalid-name
 
 
 def make(targets):

--- a/experiment/measurer/coverage_utils.py
+++ b/experiment/measurer/coverage_utils.py
@@ -28,7 +28,7 @@ from database import utils as db_utils
 from database import models
 from experiment.build import build_utils
 
-logger = logs.Logger('coverage_utils')  # pylint: disable=invalid-name
+logger = logs.Logger()  # pylint: disable=invalid-name
 
 COV_DIFF_QUEUE_GET_TIMEOUT = 1
 

--- a/experiment/measurer/measure_manager.py
+++ b/experiment/measurer/measure_manager.py
@@ -48,7 +48,7 @@ from experiment.measurer import run_coverage
 from experiment.measurer import run_crashes
 from experiment import scheduler
 
-logger = logs.Logger('measurer')
+logger = logs.Logger()
 
 SnapshotMeasureRequest = collections.namedtuple(
     'SnapshotMeasureRequest', ['fuzzer', 'benchmark', 'trial_id', 'cycle'])
@@ -660,13 +660,13 @@ def measure_snapshot_coverage(  # pylint: disable=too-many-locals
         region_coverage: bool) -> models.Snapshot:
     """Measure coverage of the snapshot for |cycle| for |trial_num| of |fuzzer|
     and |benchmark|."""
-    snapshot_logger = logs.Logger('measurer',
-                                  default_extras={
-                                      'fuzzer': fuzzer,
-                                      'benchmark': benchmark,
-                                      'trial_id': str(trial_num),
-                                      'cycle': str(cycle),
-                                  })
+    snapshot_logger = logs.Logger(
+        default_extras={
+            'fuzzer': fuzzer,
+            'benchmark': benchmark,
+            'trial_id': str(trial_num),
+            'cycle': str(cycle),
+        })
     snapshot_measurer = SnapshotMeasurer(fuzzer, benchmark, trial_num,
                                          snapshot_logger, region_coverage)
 

--- a/experiment/measurer/run_coverage.py
+++ b/experiment/measurer/run_coverage.py
@@ -23,7 +23,7 @@ from common import logs
 from common import new_process
 from common import sanitizer
 
-logger = logs.Logger('run_coverage')
+logger = logs.Logger()
 
 # Time buffer for libfuzzer merge to gracefully exit.
 EXIT_BUFFER = 15

--- a/experiment/measurer/run_crashes.py
+++ b/experiment/measurer/run_crashes.py
@@ -24,7 +24,7 @@ from common import new_process
 from common import sanitizer
 from experiment.measurer import run_coverage
 
-logger = logs.Logger('run_crashes')
+logger = logs.Logger()
 
 Crash = collections.namedtuple('Crash', [
     'crash_testcase', 'crash_type', 'crash_address', 'crash_state',

--- a/experiment/reporter.py
+++ b/experiment/reporter.py
@@ -29,7 +29,7 @@ from analysis import data_utils
 
 CORE_FUZZERS_YAML = os.path.join(utils.ROOT_DIR, 'service', 'core-fuzzers.yaml')
 
-logger = logs.Logger('reporter')  # pylint: disable=invalid-name
+logger = logs.Logger()  # pylint: disable=invalid-name
 
 
 def get_reports_dir():

--- a/experiment/schedule_measure_workers.py
+++ b/experiment/schedule_measure_workers.py
@@ -25,7 +25,7 @@ from common import logs
 from common import queue_utils
 from common import yaml_utils
 
-logger = logs.Logger('schedule_measure_workers')  # pylint: disable=invalid-name
+logger = logs.Logger()  # pylint: disable=invalid-name
 
 # This is the default quota on GCE.
 # TODO(metzman): Use the GCE API to determine this quota.

--- a/experiment/scheduler.py
+++ b/experiment/scheduler.py
@@ -41,7 +41,7 @@ GRACE_TIME_SECONDS = 5 * 60
 
 FAIL_WAIT_SECONDS = 10 * 60
 
-logger = logs.Logger('scheduler')  # pylint: disable=invalid-name
+logger = logs.Logger()  # pylint: disable=invalid-name
 
 RESOURCES_DIR = os.path.join(utils.ROOT_DIR, 'experiment', 'resources')
 

--- a/experiment/stop_experiment.py
+++ b/experiment/stop_experiment.py
@@ -22,7 +22,7 @@ from common import gce
 from common import gcloud
 from common import yaml_utils
 
-logger = logs.Logger('stop_experiment')  # pylint: disable=invalid-name
+logger = logs.Logger()  # pylint: disable=invalid-name
 
 
 def stop_experiment(experiment_name, experiment_config_filename):

--- a/service/automatic_run_experiment.py
+++ b/service/automatic_run_experiment.py
@@ -31,7 +31,7 @@ from database import models
 from database import utils as db_utils
 from experiment import run_experiment
 
-logger = logs.Logger('automatic_run_experiment')  # pylint: disable=invalid-name
+logger = logs.Logger()  # pylint: disable=invalid-name
 
 EXPERIMENT_CONFIG_FILE = os.path.join(utils.ROOT_DIR, 'service',
                                       'experiment-config.yaml')


### PR DESCRIPTION
By getting rid of this we can match
logName=projects/fuzzbench/logs/fuzzbench

Related: https://github.com/google/fuzzbench/issues/1636