### PR TITLE
Reduce concurrent builds down to 30.

### DIFF
--- a/experiment/build/builder.py
+++ b/experiment/build/builder.py
@@ -34,7 +34,7 @@ from common import utils
 from common import logs
 
 from experiment.build import build_utils
-from experiment.run_experiment import DEFAULT_CONCURRENT_BUILDS
+from experiment import run_experiment
 
 if not experiment_utils.is_local_experiment():
     import experiment.build.gcb_build as buildlib
@@ -215,13 +215,13 @@ def main():
                         '--num-concurrent-builds',
                         help='Max concurrent builds allowed.',
                         type=int,
-                        default=DEFAULT_CONCURRENT_BUILDS,
+                        default=run_experiment.DEFAULT_CONCURRENT_BUILDS,
                         required=False)
 
     logs.initialize()
     args = parser.parse_args()
     os.environ['CONCURRENT_BUILDS'] = os.getenv('CONCURRENT_BUILDS',
-                                                args.num_concurrent_builds)
+                                                str(args.num_concurrent_builds))
 
     build_all_fuzzer_benchmarks(args.fuzzers, args.benchmarks)
 

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -60,6 +60,7 @@ FILTER_SOURCE_REGEX = re.compile(r'('
 _OSS_FUZZ_CORPUS_BACKUP_URL_FORMAT = (
     'gs://{project}-backup.clusterfuzz-external.appspot.com/corpus/'
     'libFuzzer/{fuzz_target}/public.zip')
+DEFAULT_CONCURRENT_BUILDS = 30
 
 Requirement = namedtuple('Requirement',
                          ['mandatory', 'type', 'lowercase', 'startswith'])

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -30,11 +30,11 @@ import yaml
 
 from common import benchmark_utils
 from common import experiment_utils
+from common import filestore_utils
 from common import filesystem
 from common import fuzzer_utils
 from common import gcloud
 from common import gsutil
-from common import filestore_utils
 from common import logs
 from common import new_process
 from common import utils
@@ -60,7 +60,6 @@ FILTER_SOURCE_REGEX = re.compile(r'('
 _OSS_FUZZ_CORPUS_BACKUP_URL_FORMAT = (
     'gs://{project}-backup.clusterfuzz-external.appspot.com/corpus/'
     'libFuzzer/{fuzz_target}/public.zip')
-DEFAULT_CONCURRENT_BUILDS = 30
 
 Requirement = namedtuple('Requirement',
                          ['mandatory', 'type', 'lowercase', 'startswith'])

--- a/service/automatic_run_experiment.py
+++ b/service/automatic_run_experiment.py
@@ -44,7 +44,7 @@ REQUESTED_EXPERIMENTS_PATH = os.path.join(utils.ROOT_DIR, 'service',
 PAUSE_SERVICE_KEYWORD = 'PAUSE_SERVICE'
 
 EXPERIMENT_NAME_REGEX = re.compile(r'^\d{4}-\d{2}-\d{2}.*')
-SERVICE_CONCURRENT_BUILDS = 150
+CONCURRENT_BUILDS = 30
 
 
 def _get_experiment_name(experiment_config: dict) -> str:
@@ -272,7 +272,7 @@ def _run_experiment(  # pylint: disable=too-many-arguments
                                     benchmarks,
                                     fuzzers,
                                     description=description,
-                                    concurrent_builds=SERVICE_CONCURRENT_BUILDS,
+                                    concurrent_builds=CONCURRENT_BUILDS,
                                     oss_fuzz_corpus=oss_fuzz_corpus)
 
 

--- a/service/test_automatic_run_experiment.py
+++ b/service/test_automatic_run_experiment.py
@@ -36,8 +36,6 @@ EXPERIMENT_REQUESTS = [{
     'oss_fuzz_corpus': True,
 }]
 
-SERVICE_CONCURRENT_BUILDS = 150
-
 
 @mock.patch('experiment.run_experiment.start_experiment')
 @mock.patch('common.logs.warning')
@@ -104,7 +102,8 @@ def test_run_requested_experiment(mocked_get_requested_experiments,
                               expected_benchmarks,
                               expected_fuzzers,
                               description='Test experiment',
-                              concurrent_builds=SERVICE_CONCURRENT_BUILDS,
+                              concurrent_builds=(
+                                  automatic_run_experiment.CONCURRENT_BUILDS),
                               oss_fuzz_corpus=True)
     start_experiment_call_args = mocked_start_experiment.call_args_list
     assert len(start_experiment_call_args) == 1

--- a/service/test_automatic_run_experiment.py
+++ b/service/test_automatic_run_experiment.py
@@ -97,14 +97,14 @@ def test_run_requested_experiment(mocked_get_requested_experiments,
         'vorbis_decode_fuzzer',
         'woff2_convert_woff2ttf_fuzzer',
     ])
-    expected_call = mock.call(expected_experiment_name,
-                              expected_config_file,
-                              expected_benchmarks,
-                              expected_fuzzers,
-                              description='Test experiment',
-                              concurrent_builds=(
-                                  automatic_run_experiment.CONCURRENT_BUILDS),
-                              oss_fuzz_corpus=True)
+    expected_call = mock.call(
+        expected_experiment_name,
+        expected_config_file,
+        expected_benchmarks,
+        expected_fuzzers,
+        description='Test experiment',
+        concurrent_builds=(automatic_run_experiment.CONCURRENT_BUILDS),
+        oss_fuzz_corpus=True)
     start_experiment_call_args = mocked_start_experiment.call_args_list
     assert len(start_experiment_call_args) == 1
     start_experiment_call_args = start_experiment_call_args[0]


### PR DESCRIPTION
We only need more for um experiments, it's just nice to have for others. But it breaks things.

Related: https://github.com/google/fuzzbench/issues/1648