### PR TITLE
Fix build breakage in harfbuzz.

### DIFF
--- a/benchmarks/harfbuzz_hb-shape-fuzzer/Dockerfile
+++ b/benchmarks/harfbuzz_hb-shape-fuzzer/Dockerfile
@@ -17,9 +17,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
 
 RUN apt-get update && \
-    apt-get install -y \
-        python3-pip ragel pkg-config && \
-    pip3 install meson==0.56.0 ninja
+    apt-get install -y ragel pkg-config
 
 RUN git clone https://github.com/harfbuzz/harfbuzz.git
 

--- a/benchmarks/harfbuzz_hb-shape-fuzzer/build.sh
+++ b/benchmarks/harfbuzz_hb-shape-fuzzer/build.sh
@@ -15,7 +15,7 @@
 
 
 # Do this here because the original python3.8 gets clobbered.
-pip3 install meson==0.56.0 ninja>=1.7 --upgrade
+pip3 install ninja==1.7.2 meson==0.56.0 --upgrade
 
 # Disable:
 # 1. UBSan vptr since target built with -fno-rtti.

--- a/benchmarks/harfbuzz_hb-shape-fuzzer/build.sh
+++ b/benchmarks/harfbuzz_hb-shape-fuzzer/build.sh
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+# Do this here because the original python3.8 gets clobbered.
+pip3 install meson==0.56.0 ninja>=1.7 --upgrade
+
 # Disable:
 # 1. UBSan vptr since target built with -fno-rtti.
 export CFLAGS="$CFLAGS -fno-sanitize=vptr -DHB_NO_VISIBILITY"

--- a/benchmarks/harfbuzz_hb-shape-fuzzer/build.sh
+++ b/benchmarks/harfbuzz_hb-shape-fuzzer/build.sh
@@ -15,7 +15,8 @@
 
 
 # Do this here because the original python3.8 gets clobbered.
-pip3 install ninja==1.7.2 meson==0.56.0 --upgrade
+apt-get update && apt-get install python3 python3-pip -y
+python3.8 -m pip install ninja meson==0.56.0
 
 # Disable:
 # 1. UBSan vptr since target built with -fno-rtti.


### PR DESCRIPTION
Harfbuzz is broken by using python3.10 because it clobbers python3.8. So make sure not to depend on the python3.8 installation. Fixes: https://github.com/google/fuzzbench/issues/1708