### PR TITLE
[runner] Don't exclude any files when archiving corpus.

### DIFF
--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -45,21 +45,6 @@ RETRY_DELAY = 3
 
 FUZZ_TARGET_DIR = os.getenv('OUT', '/out')
 
-# This is an optimization to sync corpora only when it is needed. These files
-# are temporary files generated during fuzzer runtime and are not related to
-# the actual corpora.
-EXCLUDE_PATHS = set([
-    # AFL excludes.
-    '.cur_input',
-    '.state',
-    'fuzz_bitmap',
-    'fuzzer_stats',
-    'plot_data',
-
-    # QSYM excludes.
-    'bitmap',
-])
-
 CORPUS_ELEMENT_BYTES_LIMIT = 1 * 1024 * 1024
 SEED_CORPUS_ARCHIVE_SUFFIX = '_seed_corpus.zip'
 
@@ -451,28 +436,14 @@ def get_fuzzer_module(fuzzer):
 
 
 def get_corpus_elements(corpus_dir):
-    """Returns a list of absolute paths to corpus elements in |corpus_dir|.
-    Excludes certain elements."""
+    """Returns a list of absolute paths to corpus elements in |corpus_dir|."""
     corpus_dir = os.path.abspath(corpus_dir)
     corpus_elements = []
     for root, _, files in os.walk(corpus_dir):
         for filename in files:
             file_path = os.path.join(root, filename)
-            if _is_path_excluded(file_path):
-                continue
             corpus_elements.append(file_path)
     return corpus_elements
-
-
-def _is_path_excluded(path):
-    """Is any part of |path| in |EXCLUDE_PATHS|."""
-    path_parts = path.split(os.sep)
-    for part in path_parts:
-        if not part:
-            continue
-        if part in EXCLUDE_PATHS:
-            return True
-    return False
 
 
 def experiment_main():


### PR DESCRIPTION
It's not being used the way it was intended which was for unchanged-cycles.
Fixes: https://github.com/google/fuzzbench/issues/1719