### PR TITLE
Remove future & decprecation warnings

### DIFF
--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -108,8 +108,9 @@ def filter_benchmarks(experiment_df, included_benchmarks):
         benchmark for benchmark in included_benchmarks
         if benchmark_utils.validate(benchmark)
     ]
-    logger.warning('Filtered out invalid benchmarks: %s.',
-                   set(included_benchmarks) - set(valid_benchmarks))
+    invalid_benchmarks = set(included_benchmarks) - set(valid_benchmarks)
+    if invalid_benchmarks:
+        logger.info('Filtered out invalid benchmarks: %s.', invalid_benchmarks)
     logger.debug('Valid benchmarks: %s.', valid_benchmarks)
     return experiment_df[experiment_df['benchmark'].isin(valid_benchmarks)]
 

--- a/analysis/plotting.py
+++ b/analysis/plotting.py
@@ -16,6 +16,7 @@
 import numpy as np
 import Orange
 import seaborn as sns
+import warnings
 
 from matplotlib import colors
 from matplotlib import pyplot as plt
@@ -23,6 +24,8 @@ from analysis import data_utils
 
 _DEFAULT_TICKS_COUNT = 12
 _DEFAULT_LABEL_ROTATION = 30
+warnings.simplefilter(action='ignore', category=FutureWarning)
+warnings.simplefilter(action='ignore', category=DeprecationWarning)
 
 
 def _formatted_hour_min(seconds):


### PR DESCRIPTION
1. Suppress a future warning on `seaborn.lineplot`'s `ci`.
2. Suppress a deprecation warning on `Orange`.
3. Adjust a warning on invalid benchmarks.