### PR TITLE
Fix validation of runner config options

### DIFF
--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -181,6 +181,8 @@ def read_and_validate_experiment_config(config_filename: str) -> Dict:
             Requirement(False, bool, False, ''),
         'preemptible_runners':
             Requirement(False, bool, False, ''),
+        'runner_num_cpu_cores':
+            Requirement(False, int, False, ''),
     }
 
     all_params_valid = _validate_config_parameters(config, config_requirements)

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -181,6 +181,8 @@ def read_and_validate_experiment_config(config_filename: str) -> Dict:
             Requirement(False, bool, False, ''),
         'preemptible_runners':
             Requirement(False, bool, False, ''),
+        'runner_machine_type':
+            Requirement(False, str, True, ''),
         'runner_num_cpu_cores':
             Requirement(False, int, False, ''),
     }


### PR DESCRIPTION
This PR modifies the config file validation to allow to specify `runner_machine_type` and `runner_num_cpu_cores`.