### PR TITLE
Fix building libjpeg-turbo benchmark

### DIFF
--- a/benchmarks/libjpeg-turbo_libjpeg_turbo_fuzzer/Dockerfile
+++ b/benchmarks/libjpeg-turbo_libjpeg_turbo_fuzzer/Dockerfile
@@ -19,11 +19,7 @@ FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d
 RUN apt-get update && \
     apt-get install -y make yasm cmake
 
-RUN git clone https://github.com/libjpeg-turbo/fuzz && \
-    cat fuzz/branches.txt | while read branch; do \
-      git clone https://github.com/libjpeg-turbo/libjpeg-turbo \
-          -b $branch libjpeg-turbo.$branch; \
-    done
+RUN git clone https://github.com/libjpeg-turbo/libjpeg-turbo libjpeg-turbo
 
 RUN git clone https://github.com/libjpeg-turbo/seed-corpora && \
     git -C seed-corpora checkout 7c9ea5ffaac76ef618657978c9fdfa845d310b93
@@ -42,3 +38,4 @@ RUN cd seed-corpora && \
 RUN rm -rf seed-corpora
 
 COPY build.sh $SRC/
+COPY libjpeg_turbo_fuzzer.cc $SRC/decompress.cc

--- a/benchmarks/libjpeg-turbo_libjpeg_turbo_fuzzer/build.sh
+++ b/benchmarks/libjpeg-turbo_libjpeg_turbo_fuzzer/build.sh
@@ -16,12 +16,10 @@
 set -e
 set -u
 
-cat fuzz/branches.txt | while read branch; do
-    pushd libjpeg-turbo.$branch
-    if [ "$branch" = "main" ]; then
-        sh fuzz/build.sh
-    else
-        sh fuzz/build.sh _$branch
-    fi
-    popd
-done
+cd libjpeg-turbo
+
+# Substitute original fuzz target
+rm fuzz/decompress.cc
+cp ../decompress.cc fuzz/decompress.cc
+
+sh fuzz/build.sh


### PR DESCRIPTION
Hi! During my local experiments I found that libjpeg-turbo benchmark building is incorrect:

1. It ignores commit-hash specified in benchmark.yaml and always build from the latest commit in repo.
2. It downloads and builds 3 branches of libjpeg-turbo while using only fuzztarget from main-branch. Moreover, it uses fuzztarget from libjpeg repo instead of one provided in fuzzbench.

The fact that libjpeg is built with unintended version is due to `docker/benchmark-builder/checkout_commit.py` logic: it visits every directory of $SRC (which contains aflplusplus, hongfuzz etc) and tries to checkout on commit from yaml. It stops on succeed, but in case of libjpeg-turbo there are 3 versions of libjpeg repo in $SRC. I think it would be more reliable if `checkout_commit.py` will explicitly perform checkout only for `project` dir (obtained from yaml). But this solution required all benchmarks cloned from git with this defined name.

This PR proposes changes that enforce building of provided `libjpeg_turbo_fuzz.cc` target instead of using default target from remote libjpeg-turbo repo. However, I don't know how appropriate is that. Maybe it should be always build the default target.