### PR TITLE
afl++ version comparison

### DIFF
--- a/fuzzers/aflplusplus_313/builder.Dockerfile
+++ b/fuzzers/aflplusplus_313/builder.Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        python3-dev \
+        python3-setuptools \
+        automake \
+        cmake \
+        git \
+        flex \
+        bison \
+        libglib2.0-dev \
+        libpixman-1-dev \
+        cargo \
+        libgtk-3-dev \
+        # for QEMU mode
+        ninja-build \
+        gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-plugin-dev \
+        libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
+
+# Download afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus /afl && \
+    cd /afl && \
+    git checkout cda62bab0837f1cbec2a1245de32b04a09e61af5 || \
+    true
+
+RUN apt install -y lsb-release wget software-properties-common gnupg
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13
+
+ENV LLVM_CONFIG llvm-config-13
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && \
+    unset CFLAGS CXXFLAGS && \
+    export CC=clang AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /

--- a/fuzzers/aflplusplus_313/description.md
+++ b/fuzzers/aflplusplus_313/description.md
@@ -1,0 +1,14 @@
+# aflplusplus
+
+AFL++ fuzzer instance that has the following config active for all benchmarks:
+  - PCGUARD instrumentation 
+  - cmplog feature
+  - dict2file feature
+  - "fast" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_313/fuzzer.py
+++ b/fuzzers/aflplusplus_313/fuzzer.py
@@ -38,17 +38,17 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     build_modes = list(args)
     if 'BUILD_MODES' in os.environ:
-        build_modes = #os.environ['BUILD_MODES'].split(',')
+        build_modes = os.environ['BUILD_MODES'].split(',')
 
     # Placeholder comment.
-    build_directory = #os.environ['OUT']
+    build_directory = os.environ['OUT']
 
     # If nothing was set this is the default:
     if not build_modes:
         build_modes = ['tracepc', 'cmplog', 'dict2file']
 
     # For bug type benchmarks we have to instrument via native clang pcguard :(
-    build_flags = #os.environ['CFLAGS']
+    build_flags = os.environ['CFLAGS']
 
     if build_flags.find(
             'array-bounds'
@@ -58,115 +58,115 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     # Instrumentation coverage modes:
     if 'lto' in build_modes:
-        #os.environ['CC'] = '/afl/afl-clang-lto'
-        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        os.environ['CC'] = '/afl/afl-clang-lto'
+        os.environ['CXX'] = '/afl/afl-clang-lto++'
         edge_file = build_directory + '/aflpp_edges.txt'
-        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
         if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-13'
-            #os.environ['AR'] = 'llvm-ar-13'
-            #os.environ['AS'] = 'llvm-as-13'
+            os.environ['RANLIB'] = 'llvm-ranlib-13'
+            os.environ['AR'] = 'llvm-ar-13'
+            os.environ['AS'] = 'llvm-as-13'
         elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-12'
-            #os.environ['AR'] = 'llvm-ar-12'
-            #os.environ['AS'] = 'llvm-as-12'
+            os.environ['RANLIB'] = 'llvm-ranlib-12'
+            os.environ['AR'] = 'llvm-ar-12'
+            os.environ['AS'] = 'llvm-as-12'
         else:
-            #os.environ['RANLIB'] = 'llvm-ranlib'
-            #os.environ['AR'] = 'llvm-ar'
-            #os.environ['AS'] = 'llvm-as'
+            os.environ['RANLIB'] = 'llvm-ranlib'
+            os.environ['AR'] = 'llvm-ar'
+            os.environ['AS'] = 'llvm-as'
     elif 'qemu' in build_modes:
-        #os.environ['CC'] = 'clang'
-        #os.environ['CXX'] = 'clang++'
+        os.environ['CC'] = 'clang'
+        os.environ['CXX'] = 'clang++'
     elif 'gcc' in build_modes:
-        #os.environ['CC'] = 'afl-gcc-fast'
-        #os.environ['CXX'] = 'afl-g++-fast'
+        os.environ['CC'] = 'afl-gcc-fast'
+        os.environ['CXX'] = 'afl-g++-fast'
         if build_flags.find('array-bounds') != -1:
-            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
-            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
         else:
-            #os.environ['CFLAGS'] = ''
-            #os.environ['CXXFLAGS'] = ''
-            #os.environ['CPPFLAGS'] = ''
+            os.environ['CFLAGS'] = ''
+            os.environ['CXXFLAGS'] = ''
+            os.environ['CPPFLAGS'] = ''
     else:
-        #os.environ['CC'] = '/afl/afl-clang-fast'
-        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+        os.environ['CC'] = '/afl/afl-clang-fast'
+        os.environ['CXX'] = '/afl/afl-clang-fast++'
 
     print('AFL++ build: ')
     print(build_modes)
 
     if 'qemu' in build_modes or 'symcc' in build_modes:
-        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
         cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
-        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+        os.environ['CXXFLAGS'] = ' '.join(cxxflags)
 
     if 'tracepc' in build_modes or 'pcguard' in build_modes:
-        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+        os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
     elif 'classic' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
     elif 'native' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
 
     # Instrumentation coverage options:
     # Do not use a fixed map location (LTO only)
     if 'dynamic' in build_modes:
-        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+        os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
     # Use a fixed map location (LTO only)
     if 'fixed' in build_modes:
-        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+        os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
     # Generate an extra dictionary.
     if 'dict2file' in build_modes or 'native' in build_modes:
-        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
         #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
     # Enable context sentitivity for LLVM mode (non LTO only)
     if 'ctx' in build_modes:
-        #os.environ['AFL_LLVM_CTX'] = '1'
+        os.environ['AFL_LLVM_CTX'] = '1'
     # Enable N-gram coverage for LLVM mode (non LTO only)
     if 'ngram2' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
     elif 'ngram3' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
     elif 'ngram4' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
     elif 'ngram5' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
     elif 'ngram6' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
     elif 'ngram7' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
     elif 'ngram8' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
     elif 'ngram16' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
     if 'ctx1' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '1'
+        os.environ['AFL_LLVM_CTX_K'] = '1'
     elif 'ctx2' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '2'
+        os.environ['AFL_LLVM_CTX_K'] = '2'
     elif 'ctx3' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '3'
+        os.environ['AFL_LLVM_CTX_K'] = '3'
     elif 'ctx4' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '4'
+        os.environ['AFL_LLVM_CTX_K'] = '4'
 
     # Only one of the following OR cmplog
     # enable laf-intel compare splitting
     if 'laf' in build_modes:
-        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
         if 'autodict' not in build_modes:
-            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+            os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
 
     if 'eclipser' in build_modes:
-        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+        os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
     else:
-        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+        os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
 
     # Some benchmarks like lcms. (see:
     # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
     # fail to compile if the compiler outputs things to stderr in unexpected
     # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
     # from writing AFL specific messages to stderr.
-    #os.environ['AFL_QUIET'] = '1'
-    #os.environ['AFL_MAP_SIZE'] = '2621440'
+    os.environ['AFL_QUIET'] = '1'
+    os.environ['AFL_MAP_SIZE'] = '2621440'
 
     src = os.getenv('SRC')
     work = os.getenv('WORK')
@@ -253,8 +253,8 @@ def fuzz(input_corpus,
 
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     # decomment this to enable libdislocator.
-    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
-    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+    # os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
     flags = list(flags)
 
@@ -265,15 +265,16 @@ def fuzz(input_corpus,
     if os.path.exists(cmplog_target_binary) and no_cmplog is False:
         flags += ['-c', cmplog_target_binary]
 
-    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
-    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
-    #os.environ['AFL_FAST_CAL'] = '1'
+    #os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    os.environ['AFL_FAST_CAL'] = '1'
+    os.environ['AFL_NO_WARN_INSTABILITY'] = '1'
 
     if not skip:
-        #os.environ['AFL_DISABLE_TRIM'] = '1'
-        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        os.environ['AFL_DISABLE_TRIM'] = '1'
+        os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
         if 'ADDITIONAL_ARGS' in os.environ:
-            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+            flags += os.environ['ADDITIONAL_ARGS'].split(' ')
 
     afl_fuzzer.run_afl_fuzz(input_corpus,
                             output_corpus,

--- a/fuzzers/aflplusplus_313/fuzzer.py
+++ b/fuzzers/aflplusplus_313/fuzzer.py
@@ -1,0 +1,281 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration code for AFLplusplus fuzzer."""
+
+import os
+import shutil
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+from fuzzers import utils
+
+
+def get_cmplog_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'cmplog')
+
+
+def get_uninstrumented_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
+
+
+def build(*args):  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    # BUILD_MODES is not already supported by fuzzbench, meanwhile we provide
+    # a default configuration.
+
+    build_modes = list(args)
+    if 'BUILD_MODES' in os.environ:
+        build_modes = #os.environ['BUILD_MODES'].split(',')
+
+    # Placeholder comment.
+    build_directory = #os.environ['OUT']
+
+    # If nothing was set this is the default:
+    if not build_modes:
+        build_modes = ['tracepc', 'cmplog', 'dict2file']
+
+    # For bug type benchmarks we have to instrument via native clang pcguard :(
+    build_flags = #os.environ['CFLAGS']
+
+    if build_flags.find(
+            'array-bounds'
+    ) != -1 and 'qemu' not in build_modes and 'classic' not in build_modes:
+        if 'gcc' not in build_modes:
+            build_modes[0] = 'native'
+
+    # Instrumentation coverage modes:
+    if 'lto' in build_modes:
+        #os.environ['CC'] = '/afl/afl-clang-lto'
+        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        edge_file = build_directory + '/aflpp_edges.txt'
+        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-13'
+            #os.environ['AR'] = 'llvm-ar-13'
+            #os.environ['AS'] = 'llvm-as-13'
+        elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-12'
+            #os.environ['AR'] = 'llvm-ar-12'
+            #os.environ['AS'] = 'llvm-as-12'
+        else:
+            #os.environ['RANLIB'] = 'llvm-ranlib'
+            #os.environ['AR'] = 'llvm-ar'
+            #os.environ['AS'] = 'llvm-as'
+    elif 'qemu' in build_modes:
+        #os.environ['CC'] = 'clang'
+        #os.environ['CXX'] = 'clang++'
+    elif 'gcc' in build_modes:
+        #os.environ['CC'] = 'afl-gcc-fast'
+        #os.environ['CXX'] = 'afl-g++-fast'
+        if build_flags.find('array-bounds') != -1:
+            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+        else:
+            #os.environ['CFLAGS'] = ''
+            #os.environ['CXXFLAGS'] = ''
+            #os.environ['CPPFLAGS'] = ''
+    else:
+        #os.environ['CC'] = '/afl/afl-clang-fast'
+        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+
+    print('AFL++ build: ')
+    print(build_modes)
+
+    if 'qemu' in build_modes or 'symcc' in build_modes:
+        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
+        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+
+    if 'tracepc' in build_modes or 'pcguard' in build_modes:
+        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+    elif 'classic' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+    elif 'native' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+
+    # Instrumentation coverage options:
+    # Do not use a fixed map location (LTO only)
+    if 'dynamic' in build_modes:
+        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+    # Use a fixed map location (LTO only)
+    if 'fixed' in build_modes:
+        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+    # Generate an extra dictionary.
+    if 'dict2file' in build_modes or 'native' in build_modes:
+        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
+    # Enable context sentitivity for LLVM mode (non LTO only)
+    if 'ctx' in build_modes:
+        #os.environ['AFL_LLVM_CTX'] = '1'
+    # Enable N-gram coverage for LLVM mode (non LTO only)
+    if 'ngram2' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+    elif 'ngram3' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+    elif 'ngram4' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+    elif 'ngram5' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+    elif 'ngram6' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+    elif 'ngram7' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+    elif 'ngram8' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+    elif 'ngram16' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+    if 'ctx1' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '1'
+    elif 'ctx2' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '2'
+    elif 'ctx3' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '3'
+    elif 'ctx4' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '4'
+
+    # Only one of the following OR cmplog
+    # enable laf-intel compare splitting
+    if 'laf' in build_modes:
+        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        if 'autodict' not in build_modes:
+            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+
+    if 'eclipser' in build_modes:
+        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+    else:
+        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+
+    # Some benchmarks like lcms. (see:
+    # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
+    # fail to compile if the compiler outputs things to stderr in unexpected
+    # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
+    # from writing AFL specific messages to stderr.
+    #os.environ['AFL_QUIET'] = '1'
+    #os.environ['AFL_MAP_SIZE'] = '2621440'
+
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+
+    with utils.restore_directory(src), utils.restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        utils.build_benchmark()
+
+    if 'cmplog' in build_modes and 'qemu' not in build_modes:
+
+        # CmpLog requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['AFL_LLVM_CMPLOG'] = '1'
+
+        # For CmpLog build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new CmpLog build directory.
+        cmplog_build_directory = get_cmplog_build_directory(build_directory)
+        os.mkdir(cmplog_build_directory)
+        new_env['OUT'] = cmplog_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(cmplog_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for CmpLog fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    if 'symcc' in build_modes:
+
+        symcc_build_directory = get_uninstrumented_build_directory(
+            build_directory)
+        os.mkdir(symcc_build_directory)
+
+        # symcc requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['CC'] = '/symcc/build/symcc'
+        new_env['CXX'] = '/symcc/build/sym++'
+        new_env['SYMCC_OUTPUT_DIR'] = '/tmp'
+        new_env['CXXFLAGS'] = new_env['CXXFLAGS'].replace('-stlib=libc++', '')
+        new_env['FUZZER_LIB'] = '/libfuzzer-harness.o'
+        new_env['OUT'] = symcc_build_directory
+        new_env['SYMCC_LIBCXX_PATH'] = '/libcxx_native_build'
+        new_env['SYMCC_NO_SYMBOLIC_INPUT'] = '1'
+        new_env['SYMCC_SILENT'] = '1'
+
+        # For symcc build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new symcc build directory.
+        new_env['OUT'] = symcc_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(symcc_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for symcc fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    shutil.copy('/afl/afl-fuzz', build_directory)
+    if os.path.exists('/afl/afl-qemu-trace'):
+        shutil.copy('/afl/afl-qemu-trace', build_directory)
+    if os.path.exists('/aflpp_qemu_driver_hook.so'):
+        shutil.copy('/aflpp_qemu_driver_hook.so', build_directory)
+    if os.path.exists('/get_frida_entry.sh'):
+        shutil.copy('/afl/afl-frida-trace.so', build_directory)
+        shutil.copy('/get_frida_entry.sh', build_directory)
+
+
+# pylint: disable=too-many-arguments
+def fuzz(input_corpus,
+         output_corpus,
+         target_binary,
+         flags=tuple(),
+         skip=False,
+         no_cmplog=False):  # pylint: disable=too-many-arguments
+    """Run fuzzer."""
+    # Calculate CmpLog binary path from the instrumented target binary.
+    target_binary_directory = os.path.dirname(target_binary)
+    cmplog_target_binary_directory = (
+        get_cmplog_build_directory(target_binary_directory))
+    target_binary_name = os.path.basename(target_binary)
+    cmplog_target_binary = os.path.join(cmplog_target_binary_directory,
+                                        target_binary_name)
+
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+    # decomment this to enable libdislocator.
+    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+
+    flags = list(flags)
+
+    if os.path.exists('./afl++.dict'):
+        flags += ['-x', './afl++.dict']
+
+    # Move the following to skip for upcoming _double tests:
+    if os.path.exists(cmplog_target_binary) and no_cmplog is False:
+        flags += ['-c', cmplog_target_binary]
+
+    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    #os.environ['AFL_FAST_CAL'] = '1'
+
+    if not skip:
+        #os.environ['AFL_DISABLE_TRIM'] = '1'
+        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        if 'ADDITIONAL_ARGS' in os.environ:
+            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+
+    afl_fuzzer.run_afl_fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            additional_flags=flags)

--- a/fuzzers/aflplusplus_313/runner.Dockerfile
+++ b/fuzzers/aflplusplus_313/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/fuzzers/aflplusplus_314/builder.Dockerfile
+++ b/fuzzers/aflplusplus_314/builder.Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        python3-dev \
+        python3-setuptools \
+        automake \
+        cmake \
+        git \
+        flex \
+        bison \
+        libglib2.0-dev \
+        libpixman-1-dev \
+        cargo \
+        libgtk-3-dev \
+        # for QEMU mode
+        ninja-build \
+        gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-plugin-dev \
+        libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
+
+# Download afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus /afl && \
+    cd /afl && \
+    git checkout 1e23a8d67832eb296fa9abef0745b61ac74ae889 || \
+    true
+
+RUN apt install -y lsb-release wget software-properties-common gnupg
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13
+
+ENV LLVM_CONFIG llvm-config-13
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && \
+    unset CFLAGS CXXFLAGS && \
+    export CC=clang AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /

--- a/fuzzers/aflplusplus_314/description.md
+++ b/fuzzers/aflplusplus_314/description.md
@@ -1,0 +1,14 @@
+# aflplusplus
+
+AFL++ fuzzer instance that has the following config active for all benchmarks:
+  - PCGUARD instrumentation 
+  - cmplog feature
+  - dict2file feature
+  - "fast" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_314/fuzzer.py
+++ b/fuzzers/aflplusplus_314/fuzzer.py
@@ -38,17 +38,17 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     build_modes = list(args)
     if 'BUILD_MODES' in os.environ:
-        build_modes = #os.environ['BUILD_MODES'].split(',')
+        build_modes = os.environ['BUILD_MODES'].split(',')
 
     # Placeholder comment.
-    build_directory = #os.environ['OUT']
+    build_directory = os.environ['OUT']
 
     # If nothing was set this is the default:
     if not build_modes:
         build_modes = ['tracepc', 'cmplog', 'dict2file']
 
     # For bug type benchmarks we have to instrument via native clang pcguard :(
-    build_flags = #os.environ['CFLAGS']
+    build_flags = os.environ['CFLAGS']
 
     if build_flags.find(
             'array-bounds'
@@ -58,115 +58,115 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     # Instrumentation coverage modes:
     if 'lto' in build_modes:
-        #os.environ['CC'] = '/afl/afl-clang-lto'
-        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        os.environ['CC'] = '/afl/afl-clang-lto'
+        os.environ['CXX'] = '/afl/afl-clang-lto++'
         edge_file = build_directory + '/aflpp_edges.txt'
-        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
         if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-13'
-            #os.environ['AR'] = 'llvm-ar-13'
-            #os.environ['AS'] = 'llvm-as-13'
+            os.environ['RANLIB'] = 'llvm-ranlib-13'
+            os.environ['AR'] = 'llvm-ar-13'
+            os.environ['AS'] = 'llvm-as-13'
         elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-12'
-            #os.environ['AR'] = 'llvm-ar-12'
-            #os.environ['AS'] = 'llvm-as-12'
+            os.environ['RANLIB'] = 'llvm-ranlib-12'
+            os.environ['AR'] = 'llvm-ar-12'
+            os.environ['AS'] = 'llvm-as-12'
         else:
-            #os.environ['RANLIB'] = 'llvm-ranlib'
-            #os.environ['AR'] = 'llvm-ar'
-            #os.environ['AS'] = 'llvm-as'
+            os.environ['RANLIB'] = 'llvm-ranlib'
+            os.environ['AR'] = 'llvm-ar'
+            os.environ['AS'] = 'llvm-as'
     elif 'qemu' in build_modes:
-        #os.environ['CC'] = 'clang'
-        #os.environ['CXX'] = 'clang++'
+        os.environ['CC'] = 'clang'
+        os.environ['CXX'] = 'clang++'
     elif 'gcc' in build_modes:
-        #os.environ['CC'] = 'afl-gcc-fast'
-        #os.environ['CXX'] = 'afl-g++-fast'
+        os.environ['CC'] = 'afl-gcc-fast'
+        os.environ['CXX'] = 'afl-g++-fast'
         if build_flags.find('array-bounds') != -1:
-            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
-            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
         else:
-            #os.environ['CFLAGS'] = ''
-            #os.environ['CXXFLAGS'] = ''
-            #os.environ['CPPFLAGS'] = ''
+            os.environ['CFLAGS'] = ''
+            os.environ['CXXFLAGS'] = ''
+            os.environ['CPPFLAGS'] = ''
     else:
-        #os.environ['CC'] = '/afl/afl-clang-fast'
-        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+        os.environ['CC'] = '/afl/afl-clang-fast'
+        os.environ['CXX'] = '/afl/afl-clang-fast++'
 
     print('AFL++ build: ')
     print(build_modes)
 
     if 'qemu' in build_modes or 'symcc' in build_modes:
-        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
         cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
-        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+        os.environ['CXXFLAGS'] = ' '.join(cxxflags)
 
     if 'tracepc' in build_modes or 'pcguard' in build_modes:
-        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+        os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
     elif 'classic' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
     elif 'native' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
 
     # Instrumentation coverage options:
     # Do not use a fixed map location (LTO only)
     if 'dynamic' in build_modes:
-        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+        os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
     # Use a fixed map location (LTO only)
     if 'fixed' in build_modes:
-        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+        os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
     # Generate an extra dictionary.
     if 'dict2file' in build_modes or 'native' in build_modes:
-        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
         #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
     # Enable context sentitivity for LLVM mode (non LTO only)
     if 'ctx' in build_modes:
-        #os.environ['AFL_LLVM_CTX'] = '1'
+        os.environ['AFL_LLVM_CTX'] = '1'
     # Enable N-gram coverage for LLVM mode (non LTO only)
     if 'ngram2' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
     elif 'ngram3' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
     elif 'ngram4' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
     elif 'ngram5' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
     elif 'ngram6' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
     elif 'ngram7' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
     elif 'ngram8' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
     elif 'ngram16' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
     if 'ctx1' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '1'
+        os.environ['AFL_LLVM_CTX_K'] = '1'
     elif 'ctx2' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '2'
+        os.environ['AFL_LLVM_CTX_K'] = '2'
     elif 'ctx3' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '3'
+        os.environ['AFL_LLVM_CTX_K'] = '3'
     elif 'ctx4' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '4'
+        os.environ['AFL_LLVM_CTX_K'] = '4'
 
     # Only one of the following OR cmplog
     # enable laf-intel compare splitting
     if 'laf' in build_modes:
-        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
         if 'autodict' not in build_modes:
-            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+            os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
 
     if 'eclipser' in build_modes:
-        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+        os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
     else:
-        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+        os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
 
     # Some benchmarks like lcms. (see:
     # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
     # fail to compile if the compiler outputs things to stderr in unexpected
     # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
     # from writing AFL specific messages to stderr.
-    #os.environ['AFL_QUIET'] = '1'
-    #os.environ['AFL_MAP_SIZE'] = '2621440'
+    os.environ['AFL_QUIET'] = '1'
+    os.environ['AFL_MAP_SIZE'] = '2621440'
 
     src = os.getenv('SRC')
     work = os.getenv('WORK')
@@ -253,8 +253,8 @@ def fuzz(input_corpus,
 
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     # decomment this to enable libdislocator.
-    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
-    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+    # os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
     flags = list(flags)
 
@@ -265,15 +265,16 @@ def fuzz(input_corpus,
     if os.path.exists(cmplog_target_binary) and no_cmplog is False:
         flags += ['-c', cmplog_target_binary]
 
-    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
-    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
-    #os.environ['AFL_FAST_CAL'] = '1'
+    #os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    os.environ['AFL_FAST_CAL'] = '1'
+    os.environ['AFL_NO_WARN_INSTABILITY'] = '1'
 
     if not skip:
-        #os.environ['AFL_DISABLE_TRIM'] = '1'
-        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        os.environ['AFL_DISABLE_TRIM'] = '1'
+        os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
         if 'ADDITIONAL_ARGS' in os.environ:
-            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+            flags += os.environ['ADDITIONAL_ARGS'].split(' ')
 
     afl_fuzzer.run_afl_fuzz(input_corpus,
                             output_corpus,

--- a/fuzzers/aflplusplus_314/fuzzer.py
+++ b/fuzzers/aflplusplus_314/fuzzer.py
@@ -1,0 +1,281 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration code for AFLplusplus fuzzer."""
+
+import os
+import shutil
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+from fuzzers import utils
+
+
+def get_cmplog_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'cmplog')
+
+
+def get_uninstrumented_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
+
+
+def build(*args):  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    # BUILD_MODES is not already supported by fuzzbench, meanwhile we provide
+    # a default configuration.
+
+    build_modes = list(args)
+    if 'BUILD_MODES' in os.environ:
+        build_modes = #os.environ['BUILD_MODES'].split(',')
+
+    # Placeholder comment.
+    build_directory = #os.environ['OUT']
+
+    # If nothing was set this is the default:
+    if not build_modes:
+        build_modes = ['tracepc', 'cmplog', 'dict2file']
+
+    # For bug type benchmarks we have to instrument via native clang pcguard :(
+    build_flags = #os.environ['CFLAGS']
+
+    if build_flags.find(
+            'array-bounds'
+    ) != -1 and 'qemu' not in build_modes and 'classic' not in build_modes:
+        if 'gcc' not in build_modes:
+            build_modes[0] = 'native'
+
+    # Instrumentation coverage modes:
+    if 'lto' in build_modes:
+        #os.environ['CC'] = '/afl/afl-clang-lto'
+        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        edge_file = build_directory + '/aflpp_edges.txt'
+        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-13'
+            #os.environ['AR'] = 'llvm-ar-13'
+            #os.environ['AS'] = 'llvm-as-13'
+        elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-12'
+            #os.environ['AR'] = 'llvm-ar-12'
+            #os.environ['AS'] = 'llvm-as-12'
+        else:
+            #os.environ['RANLIB'] = 'llvm-ranlib'
+            #os.environ['AR'] = 'llvm-ar'
+            #os.environ['AS'] = 'llvm-as'
+    elif 'qemu' in build_modes:
+        #os.environ['CC'] = 'clang'
+        #os.environ['CXX'] = 'clang++'
+    elif 'gcc' in build_modes:
+        #os.environ['CC'] = 'afl-gcc-fast'
+        #os.environ['CXX'] = 'afl-g++-fast'
+        if build_flags.find('array-bounds') != -1:
+            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+        else:
+            #os.environ['CFLAGS'] = ''
+            #os.environ['CXXFLAGS'] = ''
+            #os.environ['CPPFLAGS'] = ''
+    else:
+        #os.environ['CC'] = '/afl/afl-clang-fast'
+        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+
+    print('AFL++ build: ')
+    print(build_modes)
+
+    if 'qemu' in build_modes or 'symcc' in build_modes:
+        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
+        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+
+    if 'tracepc' in build_modes or 'pcguard' in build_modes:
+        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+    elif 'classic' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+    elif 'native' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+
+    # Instrumentation coverage options:
+    # Do not use a fixed map location (LTO only)
+    if 'dynamic' in build_modes:
+        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+    # Use a fixed map location (LTO only)
+    if 'fixed' in build_modes:
+        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+    # Generate an extra dictionary.
+    if 'dict2file' in build_modes or 'native' in build_modes:
+        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
+    # Enable context sentitivity for LLVM mode (non LTO only)
+    if 'ctx' in build_modes:
+        #os.environ['AFL_LLVM_CTX'] = '1'
+    # Enable N-gram coverage for LLVM mode (non LTO only)
+    if 'ngram2' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+    elif 'ngram3' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+    elif 'ngram4' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+    elif 'ngram5' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+    elif 'ngram6' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+    elif 'ngram7' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+    elif 'ngram8' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+    elif 'ngram16' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+    if 'ctx1' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '1'
+    elif 'ctx2' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '2'
+    elif 'ctx3' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '3'
+    elif 'ctx4' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '4'
+
+    # Only one of the following OR cmplog
+    # enable laf-intel compare splitting
+    if 'laf' in build_modes:
+        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        if 'autodict' not in build_modes:
+            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+
+    if 'eclipser' in build_modes:
+        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+    else:
+        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+
+    # Some benchmarks like lcms. (see:
+    # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
+    # fail to compile if the compiler outputs things to stderr in unexpected
+    # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
+    # from writing AFL specific messages to stderr.
+    #os.environ['AFL_QUIET'] = '1'
+    #os.environ['AFL_MAP_SIZE'] = '2621440'
+
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+
+    with utils.restore_directory(src), utils.restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        utils.build_benchmark()
+
+    if 'cmplog' in build_modes and 'qemu' not in build_modes:
+
+        # CmpLog requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['AFL_LLVM_CMPLOG'] = '1'
+
+        # For CmpLog build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new CmpLog build directory.
+        cmplog_build_directory = get_cmplog_build_directory(build_directory)
+        os.mkdir(cmplog_build_directory)
+        new_env['OUT'] = cmplog_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(cmplog_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for CmpLog fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    if 'symcc' in build_modes:
+
+        symcc_build_directory = get_uninstrumented_build_directory(
+            build_directory)
+        os.mkdir(symcc_build_directory)
+
+        # symcc requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['CC'] = '/symcc/build/symcc'
+        new_env['CXX'] = '/symcc/build/sym++'
+        new_env['SYMCC_OUTPUT_DIR'] = '/tmp'
+        new_env['CXXFLAGS'] = new_env['CXXFLAGS'].replace('-stlib=libc++', '')
+        new_env['FUZZER_LIB'] = '/libfuzzer-harness.o'
+        new_env['OUT'] = symcc_build_directory
+        new_env['SYMCC_LIBCXX_PATH'] = '/libcxx_native_build'
+        new_env['SYMCC_NO_SYMBOLIC_INPUT'] = '1'
+        new_env['SYMCC_SILENT'] = '1'
+
+        # For symcc build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new symcc build directory.
+        new_env['OUT'] = symcc_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(symcc_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for symcc fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    shutil.copy('/afl/afl-fuzz', build_directory)
+    if os.path.exists('/afl/afl-qemu-trace'):
+        shutil.copy('/afl/afl-qemu-trace', build_directory)
+    if os.path.exists('/aflpp_qemu_driver_hook.so'):
+        shutil.copy('/aflpp_qemu_driver_hook.so', build_directory)
+    if os.path.exists('/get_frida_entry.sh'):
+        shutil.copy('/afl/afl-frida-trace.so', build_directory)
+        shutil.copy('/get_frida_entry.sh', build_directory)
+
+
+# pylint: disable=too-many-arguments
+def fuzz(input_corpus,
+         output_corpus,
+         target_binary,
+         flags=tuple(),
+         skip=False,
+         no_cmplog=False):  # pylint: disable=too-many-arguments
+    """Run fuzzer."""
+    # Calculate CmpLog binary path from the instrumented target binary.
+    target_binary_directory = os.path.dirname(target_binary)
+    cmplog_target_binary_directory = (
+        get_cmplog_build_directory(target_binary_directory))
+    target_binary_name = os.path.basename(target_binary)
+    cmplog_target_binary = os.path.join(cmplog_target_binary_directory,
+                                        target_binary_name)
+
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+    # decomment this to enable libdislocator.
+    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+
+    flags = list(flags)
+
+    if os.path.exists('./afl++.dict'):
+        flags += ['-x', './afl++.dict']
+
+    # Move the following to skip for upcoming _double tests:
+    if os.path.exists(cmplog_target_binary) and no_cmplog is False:
+        flags += ['-c', cmplog_target_binary]
+
+    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    #os.environ['AFL_FAST_CAL'] = '1'
+
+    if not skip:
+        #os.environ['AFL_DISABLE_TRIM'] = '1'
+        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        if 'ADDITIONAL_ARGS' in os.environ:
+            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+
+    afl_fuzzer.run_afl_fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            additional_flags=flags)

--- a/fuzzers/aflplusplus_314/runner.Dockerfile
+++ b/fuzzers/aflplusplus_314/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/fuzzers/aflplusplus_400/builder.Dockerfile
+++ b/fuzzers/aflplusplus_400/builder.Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        python3-dev \
+        python3-setuptools \
+        automake \
+        cmake \
+        git \
+        flex \
+        bison \
+        libglib2.0-dev \
+        libpixman-1-dev \
+        cargo \
+        libgtk-3-dev \
+        # for QEMU mode
+        ninja-build \
+        gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-plugin-dev \
+        libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
+
+# Download afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus /afl && \
+    cd /afl && \
+    git checkout 143c9d175e9357ba548413ee7dcee6a8de23f733 || \
+    true
+
+RUN apt install -y lsb-release wget software-properties-common gnupg
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13
+
+ENV LLVM_CONFIG llvm-config-13
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && \
+    unset CFLAGS CXXFLAGS && \
+    export CC=clang AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /

--- a/fuzzers/aflplusplus_400/description.md
+++ b/fuzzers/aflplusplus_400/description.md
@@ -1,0 +1,14 @@
+# aflplusplus
+
+AFL++ fuzzer instance that has the following config active for all benchmarks:
+  - PCGUARD instrumentation 
+  - cmplog feature
+  - dict2file feature
+  - "fast" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_400/fuzzer.py
+++ b/fuzzers/aflplusplus_400/fuzzer.py
@@ -38,17 +38,17 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     build_modes = list(args)
     if 'BUILD_MODES' in os.environ:
-        build_modes = #os.environ['BUILD_MODES'].split(',')
+        build_modes = os.environ['BUILD_MODES'].split(',')
 
     # Placeholder comment.
-    build_directory = #os.environ['OUT']
+    build_directory = os.environ['OUT']
 
     # If nothing was set this is the default:
     if not build_modes:
         build_modes = ['tracepc', 'cmplog', 'dict2file']
 
     # For bug type benchmarks we have to instrument via native clang pcguard :(
-    build_flags = #os.environ['CFLAGS']
+    build_flags = os.environ['CFLAGS']
 
     if build_flags.find(
             'array-bounds'
@@ -58,115 +58,115 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     # Instrumentation coverage modes:
     if 'lto' in build_modes:
-        #os.environ['CC'] = '/afl/afl-clang-lto'
-        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        os.environ['CC'] = '/afl/afl-clang-lto'
+        os.environ['CXX'] = '/afl/afl-clang-lto++'
         edge_file = build_directory + '/aflpp_edges.txt'
-        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
         if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-13'
-            #os.environ['AR'] = 'llvm-ar-13'
-            #os.environ['AS'] = 'llvm-as-13'
+            os.environ['RANLIB'] = 'llvm-ranlib-13'
+            os.environ['AR'] = 'llvm-ar-13'
+            os.environ['AS'] = 'llvm-as-13'
         elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-12'
-            #os.environ['AR'] = 'llvm-ar-12'
-            #os.environ['AS'] = 'llvm-as-12'
+            os.environ['RANLIB'] = 'llvm-ranlib-12'
+            os.environ['AR'] = 'llvm-ar-12'
+            os.environ['AS'] = 'llvm-as-12'
         else:
-            #os.environ['RANLIB'] = 'llvm-ranlib'
-            #os.environ['AR'] = 'llvm-ar'
-            #os.environ['AS'] = 'llvm-as'
+            os.environ['RANLIB'] = 'llvm-ranlib'
+            os.environ['AR'] = 'llvm-ar'
+            os.environ['AS'] = 'llvm-as'
     elif 'qemu' in build_modes:
-        #os.environ['CC'] = 'clang'
-        #os.environ['CXX'] = 'clang++'
+        os.environ['CC'] = 'clang'
+        os.environ['CXX'] = 'clang++'
     elif 'gcc' in build_modes:
-        #os.environ['CC'] = 'afl-gcc-fast'
-        #os.environ['CXX'] = 'afl-g++-fast'
+        os.environ['CC'] = 'afl-gcc-fast'
+        os.environ['CXX'] = 'afl-g++-fast'
         if build_flags.find('array-bounds') != -1:
-            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
-            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
         else:
-            #os.environ['CFLAGS'] = ''
-            #os.environ['CXXFLAGS'] = ''
-            #os.environ['CPPFLAGS'] = ''
+            os.environ['CFLAGS'] = ''
+            os.environ['CXXFLAGS'] = ''
+            os.environ['CPPFLAGS'] = ''
     else:
-        #os.environ['CC'] = '/afl/afl-clang-fast'
-        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+        os.environ['CC'] = '/afl/afl-clang-fast'
+        os.environ['CXX'] = '/afl/afl-clang-fast++'
 
     print('AFL++ build: ')
     print(build_modes)
 
     if 'qemu' in build_modes or 'symcc' in build_modes:
-        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
         cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
-        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+        os.environ['CXXFLAGS'] = ' '.join(cxxflags)
 
     if 'tracepc' in build_modes or 'pcguard' in build_modes:
-        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+        os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
     elif 'classic' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
     elif 'native' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
 
     # Instrumentation coverage options:
     # Do not use a fixed map location (LTO only)
     if 'dynamic' in build_modes:
-        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+        os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
     # Use a fixed map location (LTO only)
     if 'fixed' in build_modes:
-        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+        os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
     # Generate an extra dictionary.
     if 'dict2file' in build_modes or 'native' in build_modes:
-        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
         #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
     # Enable context sentitivity for LLVM mode (non LTO only)
     if 'ctx' in build_modes:
-        #os.environ['AFL_LLVM_CTX'] = '1'
+        os.environ['AFL_LLVM_CTX'] = '1'
     # Enable N-gram coverage for LLVM mode (non LTO only)
     if 'ngram2' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
     elif 'ngram3' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
     elif 'ngram4' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
     elif 'ngram5' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
     elif 'ngram6' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
     elif 'ngram7' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
     elif 'ngram8' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
     elif 'ngram16' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
     if 'ctx1' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '1'
+        os.environ['AFL_LLVM_CTX_K'] = '1'
     elif 'ctx2' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '2'
+        os.environ['AFL_LLVM_CTX_K'] = '2'
     elif 'ctx3' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '3'
+        os.environ['AFL_LLVM_CTX_K'] = '3'
     elif 'ctx4' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '4'
+        os.environ['AFL_LLVM_CTX_K'] = '4'
 
     # Only one of the following OR cmplog
     # enable laf-intel compare splitting
     if 'laf' in build_modes:
-        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
         if 'autodict' not in build_modes:
-            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+            os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
 
     if 'eclipser' in build_modes:
-        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+        os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
     else:
-        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+        os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
 
     # Some benchmarks like lcms. (see:
     # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
     # fail to compile if the compiler outputs things to stderr in unexpected
     # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
     # from writing AFL specific messages to stderr.
-    #os.environ['AFL_QUIET'] = '1'
-    #os.environ['AFL_MAP_SIZE'] = '2621440'
+    os.environ['AFL_QUIET'] = '1'
+    os.environ['AFL_MAP_SIZE'] = '2621440'
 
     src = os.getenv('SRC')
     work = os.getenv('WORK')
@@ -253,8 +253,8 @@ def fuzz(input_corpus,
 
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     # decomment this to enable libdislocator.
-    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
-    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+    # os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
     flags = list(flags)
 
@@ -265,15 +265,16 @@ def fuzz(input_corpus,
     if os.path.exists(cmplog_target_binary) and no_cmplog is False:
         flags += ['-c', cmplog_target_binary]
 
-    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
-    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
-    #os.environ['AFL_FAST_CAL'] = '1'
+    #os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    os.environ['AFL_FAST_CAL'] = '1'
+    os.environ['AFL_NO_WARN_INSTABILITY'] = '1'
 
     if not skip:
-        #os.environ['AFL_DISABLE_TRIM'] = '1'
-        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        os.environ['AFL_DISABLE_TRIM'] = '1'
+        os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
         if 'ADDITIONAL_ARGS' in os.environ:
-            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+            flags += os.environ['ADDITIONAL_ARGS'].split(' ')
 
     afl_fuzzer.run_afl_fuzz(input_corpus,
                             output_corpus,

--- a/fuzzers/aflplusplus_400/fuzzer.py
+++ b/fuzzers/aflplusplus_400/fuzzer.py
@@ -1,0 +1,281 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration code for AFLplusplus fuzzer."""
+
+import os
+import shutil
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+from fuzzers import utils
+
+
+def get_cmplog_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'cmplog')
+
+
+def get_uninstrumented_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
+
+
+def build(*args):  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    # BUILD_MODES is not already supported by fuzzbench, meanwhile we provide
+    # a default configuration.
+
+    build_modes = list(args)
+    if 'BUILD_MODES' in os.environ:
+        build_modes = #os.environ['BUILD_MODES'].split(',')
+
+    # Placeholder comment.
+    build_directory = #os.environ['OUT']
+
+    # If nothing was set this is the default:
+    if not build_modes:
+        build_modes = ['tracepc', 'cmplog', 'dict2file']
+
+    # For bug type benchmarks we have to instrument via native clang pcguard :(
+    build_flags = #os.environ['CFLAGS']
+
+    if build_flags.find(
+            'array-bounds'
+    ) != -1 and 'qemu' not in build_modes and 'classic' not in build_modes:
+        if 'gcc' not in build_modes:
+            build_modes[0] = 'native'
+
+    # Instrumentation coverage modes:
+    if 'lto' in build_modes:
+        #os.environ['CC'] = '/afl/afl-clang-lto'
+        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        edge_file = build_directory + '/aflpp_edges.txt'
+        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-13'
+            #os.environ['AR'] = 'llvm-ar-13'
+            #os.environ['AS'] = 'llvm-as-13'
+        elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-12'
+            #os.environ['AR'] = 'llvm-ar-12'
+            #os.environ['AS'] = 'llvm-as-12'
+        else:
+            #os.environ['RANLIB'] = 'llvm-ranlib'
+            #os.environ['AR'] = 'llvm-ar'
+            #os.environ['AS'] = 'llvm-as'
+    elif 'qemu' in build_modes:
+        #os.environ['CC'] = 'clang'
+        #os.environ['CXX'] = 'clang++'
+    elif 'gcc' in build_modes:
+        #os.environ['CC'] = 'afl-gcc-fast'
+        #os.environ['CXX'] = 'afl-g++-fast'
+        if build_flags.find('array-bounds') != -1:
+            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+        else:
+            #os.environ['CFLAGS'] = ''
+            #os.environ['CXXFLAGS'] = ''
+            #os.environ['CPPFLAGS'] = ''
+    else:
+        #os.environ['CC'] = '/afl/afl-clang-fast'
+        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+
+    print('AFL++ build: ')
+    print(build_modes)
+
+    if 'qemu' in build_modes or 'symcc' in build_modes:
+        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
+        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+
+    if 'tracepc' in build_modes or 'pcguard' in build_modes:
+        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+    elif 'classic' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+    elif 'native' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+
+    # Instrumentation coverage options:
+    # Do not use a fixed map location (LTO only)
+    if 'dynamic' in build_modes:
+        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+    # Use a fixed map location (LTO only)
+    if 'fixed' in build_modes:
+        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+    # Generate an extra dictionary.
+    if 'dict2file' in build_modes or 'native' in build_modes:
+        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
+    # Enable context sentitivity for LLVM mode (non LTO only)
+    if 'ctx' in build_modes:
+        #os.environ['AFL_LLVM_CTX'] = '1'
+    # Enable N-gram coverage for LLVM mode (non LTO only)
+    if 'ngram2' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+    elif 'ngram3' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+    elif 'ngram4' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+    elif 'ngram5' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+    elif 'ngram6' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+    elif 'ngram7' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+    elif 'ngram8' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+    elif 'ngram16' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+    if 'ctx1' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '1'
+    elif 'ctx2' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '2'
+    elif 'ctx3' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '3'
+    elif 'ctx4' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '4'
+
+    # Only one of the following OR cmplog
+    # enable laf-intel compare splitting
+    if 'laf' in build_modes:
+        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        if 'autodict' not in build_modes:
+            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+
+    if 'eclipser' in build_modes:
+        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+    else:
+        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+
+    # Some benchmarks like lcms. (see:
+    # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
+    # fail to compile if the compiler outputs things to stderr in unexpected
+    # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
+    # from writing AFL specific messages to stderr.
+    #os.environ['AFL_QUIET'] = '1'
+    #os.environ['AFL_MAP_SIZE'] = '2621440'
+
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+
+    with utils.restore_directory(src), utils.restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        utils.build_benchmark()
+
+    if 'cmplog' in build_modes and 'qemu' not in build_modes:
+
+        # CmpLog requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['AFL_LLVM_CMPLOG'] = '1'
+
+        # For CmpLog build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new CmpLog build directory.
+        cmplog_build_directory = get_cmplog_build_directory(build_directory)
+        os.mkdir(cmplog_build_directory)
+        new_env['OUT'] = cmplog_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(cmplog_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for CmpLog fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    if 'symcc' in build_modes:
+
+        symcc_build_directory = get_uninstrumented_build_directory(
+            build_directory)
+        os.mkdir(symcc_build_directory)
+
+        # symcc requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['CC'] = '/symcc/build/symcc'
+        new_env['CXX'] = '/symcc/build/sym++'
+        new_env['SYMCC_OUTPUT_DIR'] = '/tmp'
+        new_env['CXXFLAGS'] = new_env['CXXFLAGS'].replace('-stlib=libc++', '')
+        new_env['FUZZER_LIB'] = '/libfuzzer-harness.o'
+        new_env['OUT'] = symcc_build_directory
+        new_env['SYMCC_LIBCXX_PATH'] = '/libcxx_native_build'
+        new_env['SYMCC_NO_SYMBOLIC_INPUT'] = '1'
+        new_env['SYMCC_SILENT'] = '1'
+
+        # For symcc build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new symcc build directory.
+        new_env['OUT'] = symcc_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(symcc_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for symcc fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    shutil.copy('/afl/afl-fuzz', build_directory)
+    if os.path.exists('/afl/afl-qemu-trace'):
+        shutil.copy('/afl/afl-qemu-trace', build_directory)
+    if os.path.exists('/aflpp_qemu_driver_hook.so'):
+        shutil.copy('/aflpp_qemu_driver_hook.so', build_directory)
+    if os.path.exists('/get_frida_entry.sh'):
+        shutil.copy('/afl/afl-frida-trace.so', build_directory)
+        shutil.copy('/get_frida_entry.sh', build_directory)
+
+
+# pylint: disable=too-many-arguments
+def fuzz(input_corpus,
+         output_corpus,
+         target_binary,
+         flags=tuple(),
+         skip=False,
+         no_cmplog=False):  # pylint: disable=too-many-arguments
+    """Run fuzzer."""
+    # Calculate CmpLog binary path from the instrumented target binary.
+    target_binary_directory = os.path.dirname(target_binary)
+    cmplog_target_binary_directory = (
+        get_cmplog_build_directory(target_binary_directory))
+    target_binary_name = os.path.basename(target_binary)
+    cmplog_target_binary = os.path.join(cmplog_target_binary_directory,
+                                        target_binary_name)
+
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+    # decomment this to enable libdislocator.
+    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+
+    flags = list(flags)
+
+    if os.path.exists('./afl++.dict'):
+        flags += ['-x', './afl++.dict']
+
+    # Move the following to skip for upcoming _double tests:
+    if os.path.exists(cmplog_target_binary) and no_cmplog is False:
+        flags += ['-c', cmplog_target_binary]
+
+    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    #os.environ['AFL_FAST_CAL'] = '1'
+
+    if not skip:
+        #os.environ['AFL_DISABLE_TRIM'] = '1'
+        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        if 'ADDITIONAL_ARGS' in os.environ:
+            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+
+    afl_fuzzer.run_afl_fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            additional_flags=flags)

--- a/fuzzers/aflplusplus_400/runner.Dockerfile
+++ b/fuzzers/aflplusplus_400/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/fuzzers/aflplusplus_401/builder.Dockerfile
+++ b/fuzzers/aflplusplus_401/builder.Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        python3-dev \
+        python3-setuptools \
+        automake \
+        cmake \
+        git \
+        flex \
+        bison \
+        libglib2.0-dev \
+        libpixman-1-dev \
+        cargo \
+        libgtk-3-dev \
+        # for QEMU mode
+        ninja-build \
+        gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-plugin-dev \
+        libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
+
+# Download afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus /afl && \
+    cd /afl && \
+    git checkout 40947508037b874020c8dd1251359fecaab04b9d || \
+    true
+
+RUN apt install -y lsb-release wget software-properties-common gnupg
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13
+
+ENV LLVM_CONFIG llvm-config-13
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && \
+    unset CFLAGS CXXFLAGS && \
+    export CC=clang AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /

--- a/fuzzers/aflplusplus_401/description.md
+++ b/fuzzers/aflplusplus_401/description.md
@@ -1,0 +1,14 @@
+# aflplusplus
+
+AFL++ fuzzer instance that has the following config active for all benchmarks:
+  - PCGUARD instrumentation 
+  - cmplog feature
+  - dict2file feature
+  - "fast" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_401/fuzzer.py
+++ b/fuzzers/aflplusplus_401/fuzzer.py
@@ -38,17 +38,17 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     build_modes = list(args)
     if 'BUILD_MODES' in os.environ:
-        build_modes = #os.environ['BUILD_MODES'].split(',')
+        build_modes = os.environ['BUILD_MODES'].split(',')
 
     # Placeholder comment.
-    build_directory = #os.environ['OUT']
+    build_directory = os.environ['OUT']
 
     # If nothing was set this is the default:
     if not build_modes:
         build_modes = ['tracepc', 'cmplog', 'dict2file']
 
     # For bug type benchmarks we have to instrument via native clang pcguard :(
-    build_flags = #os.environ['CFLAGS']
+    build_flags = os.environ['CFLAGS']
 
     if build_flags.find(
             'array-bounds'
@@ -58,115 +58,115 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     # Instrumentation coverage modes:
     if 'lto' in build_modes:
-        #os.environ['CC'] = '/afl/afl-clang-lto'
-        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        os.environ['CC'] = '/afl/afl-clang-lto'
+        os.environ['CXX'] = '/afl/afl-clang-lto++'
         edge_file = build_directory + '/aflpp_edges.txt'
-        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
         if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-13'
-            #os.environ['AR'] = 'llvm-ar-13'
-            #os.environ['AS'] = 'llvm-as-13'
+            os.environ['RANLIB'] = 'llvm-ranlib-13'
+            os.environ['AR'] = 'llvm-ar-13'
+            os.environ['AS'] = 'llvm-as-13'
         elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-12'
-            #os.environ['AR'] = 'llvm-ar-12'
-            #os.environ['AS'] = 'llvm-as-12'
+            os.environ['RANLIB'] = 'llvm-ranlib-12'
+            os.environ['AR'] = 'llvm-ar-12'
+            os.environ['AS'] = 'llvm-as-12'
         else:
-            #os.environ['RANLIB'] = 'llvm-ranlib'
-            #os.environ['AR'] = 'llvm-ar'
-            #os.environ['AS'] = 'llvm-as'
+            os.environ['RANLIB'] = 'llvm-ranlib'
+            os.environ['AR'] = 'llvm-ar'
+            os.environ['AS'] = 'llvm-as'
     elif 'qemu' in build_modes:
-        #os.environ['CC'] = 'clang'
-        #os.environ['CXX'] = 'clang++'
+        os.environ['CC'] = 'clang'
+        os.environ['CXX'] = 'clang++'
     elif 'gcc' in build_modes:
-        #os.environ['CC'] = 'afl-gcc-fast'
-        #os.environ['CXX'] = 'afl-g++-fast'
+        os.environ['CC'] = 'afl-gcc-fast'
+        os.environ['CXX'] = 'afl-g++-fast'
         if build_flags.find('array-bounds') != -1:
-            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
-            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
         else:
-            #os.environ['CFLAGS'] = ''
-            #os.environ['CXXFLAGS'] = ''
-            #os.environ['CPPFLAGS'] = ''
+            os.environ['CFLAGS'] = ''
+            os.environ['CXXFLAGS'] = ''
+            os.environ['CPPFLAGS'] = ''
     else:
-        #os.environ['CC'] = '/afl/afl-clang-fast'
-        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+        os.environ['CC'] = '/afl/afl-clang-fast'
+        os.environ['CXX'] = '/afl/afl-clang-fast++'
 
     print('AFL++ build: ')
     print(build_modes)
 
     if 'qemu' in build_modes or 'symcc' in build_modes:
-        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
         cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
-        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+        os.environ['CXXFLAGS'] = ' '.join(cxxflags)
 
     if 'tracepc' in build_modes or 'pcguard' in build_modes:
-        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+        os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
     elif 'classic' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
     elif 'native' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
 
     # Instrumentation coverage options:
     # Do not use a fixed map location (LTO only)
     if 'dynamic' in build_modes:
-        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+        os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
     # Use a fixed map location (LTO only)
     if 'fixed' in build_modes:
-        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+        os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
     # Generate an extra dictionary.
     if 'dict2file' in build_modes or 'native' in build_modes:
-        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
         #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
     # Enable context sentitivity for LLVM mode (non LTO only)
     if 'ctx' in build_modes:
-        #os.environ['AFL_LLVM_CTX'] = '1'
+        os.environ['AFL_LLVM_CTX'] = '1'
     # Enable N-gram coverage for LLVM mode (non LTO only)
     if 'ngram2' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
     elif 'ngram3' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
     elif 'ngram4' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
     elif 'ngram5' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
     elif 'ngram6' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
     elif 'ngram7' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
     elif 'ngram8' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
     elif 'ngram16' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
     if 'ctx1' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '1'
+        os.environ['AFL_LLVM_CTX_K'] = '1'
     elif 'ctx2' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '2'
+        os.environ['AFL_LLVM_CTX_K'] = '2'
     elif 'ctx3' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '3'
+        os.environ['AFL_LLVM_CTX_K'] = '3'
     elif 'ctx4' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '4'
+        os.environ['AFL_LLVM_CTX_K'] = '4'
 
     # Only one of the following OR cmplog
     # enable laf-intel compare splitting
     if 'laf' in build_modes:
-        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
         if 'autodict' not in build_modes:
-            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+            os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
 
     if 'eclipser' in build_modes:
-        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+        os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
     else:
-        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+        os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
 
     # Some benchmarks like lcms. (see:
     # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
     # fail to compile if the compiler outputs things to stderr in unexpected
     # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
     # from writing AFL specific messages to stderr.
-    #os.environ['AFL_QUIET'] = '1'
-    #os.environ['AFL_MAP_SIZE'] = '2621440'
+    os.environ['AFL_QUIET'] = '1'
+    os.environ['AFL_MAP_SIZE'] = '2621440'
 
     src = os.getenv('SRC')
     work = os.getenv('WORK')
@@ -253,8 +253,8 @@ def fuzz(input_corpus,
 
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     # decomment this to enable libdislocator.
-    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
-    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+    # os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
     flags = list(flags)
 
@@ -265,15 +265,16 @@ def fuzz(input_corpus,
     if os.path.exists(cmplog_target_binary) and no_cmplog is False:
         flags += ['-c', cmplog_target_binary]
 
-    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
-    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
-    #os.environ['AFL_FAST_CAL'] = '1'
+    #os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    os.environ['AFL_FAST_CAL'] = '1'
+    os.environ['AFL_NO_WARN_INSTABILITY'] = '1'
 
     if not skip:
-        #os.environ['AFL_DISABLE_TRIM'] = '1'
-        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        os.environ['AFL_DISABLE_TRIM'] = '1'
+        os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
         if 'ADDITIONAL_ARGS' in os.environ:
-            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+            flags += os.environ['ADDITIONAL_ARGS'].split(' ')
 
     afl_fuzzer.run_afl_fuzz(input_corpus,
                             output_corpus,

--- a/fuzzers/aflplusplus_401/fuzzer.py
+++ b/fuzzers/aflplusplus_401/fuzzer.py
@@ -1,0 +1,281 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration code for AFLplusplus fuzzer."""
+
+import os
+import shutil
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+from fuzzers import utils
+
+
+def get_cmplog_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'cmplog')
+
+
+def get_uninstrumented_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
+
+
+def build(*args):  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    # BUILD_MODES is not already supported by fuzzbench, meanwhile we provide
+    # a default configuration.
+
+    build_modes = list(args)
+    if 'BUILD_MODES' in os.environ:
+        build_modes = #os.environ['BUILD_MODES'].split(',')
+
+    # Placeholder comment.
+    build_directory = #os.environ['OUT']
+
+    # If nothing was set this is the default:
+    if not build_modes:
+        build_modes = ['tracepc', 'cmplog', 'dict2file']
+
+    # For bug type benchmarks we have to instrument via native clang pcguard :(
+    build_flags = #os.environ['CFLAGS']
+
+    if build_flags.find(
+            'array-bounds'
+    ) != -1 and 'qemu' not in build_modes and 'classic' not in build_modes:
+        if 'gcc' not in build_modes:
+            build_modes[0] = 'native'
+
+    # Instrumentation coverage modes:
+    if 'lto' in build_modes:
+        #os.environ['CC'] = '/afl/afl-clang-lto'
+        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        edge_file = build_directory + '/aflpp_edges.txt'
+        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-13'
+            #os.environ['AR'] = 'llvm-ar-13'
+            #os.environ['AS'] = 'llvm-as-13'
+        elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-12'
+            #os.environ['AR'] = 'llvm-ar-12'
+            #os.environ['AS'] = 'llvm-as-12'
+        else:
+            #os.environ['RANLIB'] = 'llvm-ranlib'
+            #os.environ['AR'] = 'llvm-ar'
+            #os.environ['AS'] = 'llvm-as'
+    elif 'qemu' in build_modes:
+        #os.environ['CC'] = 'clang'
+        #os.environ['CXX'] = 'clang++'
+    elif 'gcc' in build_modes:
+        #os.environ['CC'] = 'afl-gcc-fast'
+        #os.environ['CXX'] = 'afl-g++-fast'
+        if build_flags.find('array-bounds') != -1:
+            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+        else:
+            #os.environ['CFLAGS'] = ''
+            #os.environ['CXXFLAGS'] = ''
+            #os.environ['CPPFLAGS'] = ''
+    else:
+        #os.environ['CC'] = '/afl/afl-clang-fast'
+        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+
+    print('AFL++ build: ')
+    print(build_modes)
+
+    if 'qemu' in build_modes or 'symcc' in build_modes:
+        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
+        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+
+    if 'tracepc' in build_modes or 'pcguard' in build_modes:
+        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+    elif 'classic' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+    elif 'native' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+
+    # Instrumentation coverage options:
+    # Do not use a fixed map location (LTO only)
+    if 'dynamic' in build_modes:
+        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+    # Use a fixed map location (LTO only)
+    if 'fixed' in build_modes:
+        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+    # Generate an extra dictionary.
+    if 'dict2file' in build_modes or 'native' in build_modes:
+        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
+    # Enable context sentitivity for LLVM mode (non LTO only)
+    if 'ctx' in build_modes:
+        #os.environ['AFL_LLVM_CTX'] = '1'
+    # Enable N-gram coverage for LLVM mode (non LTO only)
+    if 'ngram2' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+    elif 'ngram3' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+    elif 'ngram4' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+    elif 'ngram5' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+    elif 'ngram6' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+    elif 'ngram7' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+    elif 'ngram8' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+    elif 'ngram16' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+    if 'ctx1' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '1'
+    elif 'ctx2' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '2'
+    elif 'ctx3' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '3'
+    elif 'ctx4' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '4'
+
+    # Only one of the following OR cmplog
+    # enable laf-intel compare splitting
+    if 'laf' in build_modes:
+        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        if 'autodict' not in build_modes:
+            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+
+    if 'eclipser' in build_modes:
+        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+    else:
+        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+
+    # Some benchmarks like lcms. (see:
+    # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
+    # fail to compile if the compiler outputs things to stderr in unexpected
+    # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
+    # from writing AFL specific messages to stderr.
+    #os.environ['AFL_QUIET'] = '1'
+    #os.environ['AFL_MAP_SIZE'] = '2621440'
+
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+
+    with utils.restore_directory(src), utils.restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        utils.build_benchmark()
+
+    if 'cmplog' in build_modes and 'qemu' not in build_modes:
+
+        # CmpLog requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['AFL_LLVM_CMPLOG'] = '1'
+
+        # For CmpLog build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new CmpLog build directory.
+        cmplog_build_directory = get_cmplog_build_directory(build_directory)
+        os.mkdir(cmplog_build_directory)
+        new_env['OUT'] = cmplog_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(cmplog_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for CmpLog fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    if 'symcc' in build_modes:
+
+        symcc_build_directory = get_uninstrumented_build_directory(
+            build_directory)
+        os.mkdir(symcc_build_directory)
+
+        # symcc requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['CC'] = '/symcc/build/symcc'
+        new_env['CXX'] = '/symcc/build/sym++'
+        new_env['SYMCC_OUTPUT_DIR'] = '/tmp'
+        new_env['CXXFLAGS'] = new_env['CXXFLAGS'].replace('-stlib=libc++', '')
+        new_env['FUZZER_LIB'] = '/libfuzzer-harness.o'
+        new_env['OUT'] = symcc_build_directory
+        new_env['SYMCC_LIBCXX_PATH'] = '/libcxx_native_build'
+        new_env['SYMCC_NO_SYMBOLIC_INPUT'] = '1'
+        new_env['SYMCC_SILENT'] = '1'
+
+        # For symcc build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new symcc build directory.
+        new_env['OUT'] = symcc_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(symcc_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for symcc fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    shutil.copy('/afl/afl-fuzz', build_directory)
+    if os.path.exists('/afl/afl-qemu-trace'):
+        shutil.copy('/afl/afl-qemu-trace', build_directory)
+    if os.path.exists('/aflpp_qemu_driver_hook.so'):
+        shutil.copy('/aflpp_qemu_driver_hook.so', build_directory)
+    if os.path.exists('/get_frida_entry.sh'):
+        shutil.copy('/afl/afl-frida-trace.so', build_directory)
+        shutil.copy('/get_frida_entry.sh', build_directory)
+
+
+# pylint: disable=too-many-arguments
+def fuzz(input_corpus,
+         output_corpus,
+         target_binary,
+         flags=tuple(),
+         skip=False,
+         no_cmplog=False):  # pylint: disable=too-many-arguments
+    """Run fuzzer."""
+    # Calculate CmpLog binary path from the instrumented target binary.
+    target_binary_directory = os.path.dirname(target_binary)
+    cmplog_target_binary_directory = (
+        get_cmplog_build_directory(target_binary_directory))
+    target_binary_name = os.path.basename(target_binary)
+    cmplog_target_binary = os.path.join(cmplog_target_binary_directory,
+                                        target_binary_name)
+
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+    # decomment this to enable libdislocator.
+    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+
+    flags = list(flags)
+
+    if os.path.exists('./afl++.dict'):
+        flags += ['-x', './afl++.dict']
+
+    # Move the following to skip for upcoming _double tests:
+    if os.path.exists(cmplog_target_binary) and no_cmplog is False:
+        flags += ['-c', cmplog_target_binary]
+
+    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    #os.environ['AFL_FAST_CAL'] = '1'
+
+    if not skip:
+        #os.environ['AFL_DISABLE_TRIM'] = '1'
+        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        if 'ADDITIONAL_ARGS' in os.environ:
+            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+
+    afl_fuzzer.run_afl_fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            additional_flags=flags)

--- a/fuzzers/aflplusplus_401/runner.Dockerfile
+++ b/fuzzers/aflplusplus_401/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/fuzzers/aflplusplus_402/builder.Dockerfile
+++ b/fuzzers/aflplusplus_402/builder.Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        python3-dev \
+        python3-setuptools \
+        automake \
+        cmake \
+        git \
+        flex \
+        bison \
+        libglib2.0-dev \
+        libpixman-1-dev \
+        cargo \
+        libgtk-3-dev \
+        # for QEMU mode
+        ninja-build \
+        gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-plugin-dev \
+        libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
+
+# Download afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus /afl && \
+    cd /afl && \
+    git checkout 3e2986dd78dbc45035b47a34eedd7dd1b9a4d0b3 || \
+    true
+
+RUN apt install -y lsb-release wget software-properties-common gnupg
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13
+
+ENV LLVM_CONFIG llvm-config-13
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && \
+    unset CFLAGS CXXFLAGS && \
+    export CC=clang AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /

--- a/fuzzers/aflplusplus_402/description.md
+++ b/fuzzers/aflplusplus_402/description.md
@@ -1,0 +1,14 @@
+# aflplusplus
+
+AFL++ fuzzer instance that has the following config active for all benchmarks:
+  - PCGUARD instrumentation 
+  - cmplog feature
+  - dict2file feature
+  - "fast" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_402/fuzzer.py
+++ b/fuzzers/aflplusplus_402/fuzzer.py
@@ -38,17 +38,17 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     build_modes = list(args)
     if 'BUILD_MODES' in os.environ:
-        build_modes = #os.environ['BUILD_MODES'].split(',')
+        build_modes = os.environ['BUILD_MODES'].split(',')
 
     # Placeholder comment.
-    build_directory = #os.environ['OUT']
+    build_directory = os.environ['OUT']
 
     # If nothing was set this is the default:
     if not build_modes:
         build_modes = ['tracepc', 'cmplog', 'dict2file']
 
     # For bug type benchmarks we have to instrument via native clang pcguard :(
-    build_flags = #os.environ['CFLAGS']
+    build_flags = os.environ['CFLAGS']
 
     if build_flags.find(
             'array-bounds'
@@ -58,115 +58,115 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     # Instrumentation coverage modes:
     if 'lto' in build_modes:
-        #os.environ['CC'] = '/afl/afl-clang-lto'
-        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        os.environ['CC'] = '/afl/afl-clang-lto'
+        os.environ['CXX'] = '/afl/afl-clang-lto++'
         edge_file = build_directory + '/aflpp_edges.txt'
-        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
         if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-13'
-            #os.environ['AR'] = 'llvm-ar-13'
-            #os.environ['AS'] = 'llvm-as-13'
+            os.environ['RANLIB'] = 'llvm-ranlib-13'
+            os.environ['AR'] = 'llvm-ar-13'
+            os.environ['AS'] = 'llvm-as-13'
         elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-12'
-            #os.environ['AR'] = 'llvm-ar-12'
-            #os.environ['AS'] = 'llvm-as-12'
+            os.environ['RANLIB'] = 'llvm-ranlib-12'
+            os.environ['AR'] = 'llvm-ar-12'
+            os.environ['AS'] = 'llvm-as-12'
         else:
-            #os.environ['RANLIB'] = 'llvm-ranlib'
-            #os.environ['AR'] = 'llvm-ar'
-            #os.environ['AS'] = 'llvm-as'
+            os.environ['RANLIB'] = 'llvm-ranlib'
+            os.environ['AR'] = 'llvm-ar'
+            os.environ['AS'] = 'llvm-as'
     elif 'qemu' in build_modes:
-        #os.environ['CC'] = 'clang'
-        #os.environ['CXX'] = 'clang++'
+        os.environ['CC'] = 'clang'
+        os.environ['CXX'] = 'clang++'
     elif 'gcc' in build_modes:
-        #os.environ['CC'] = 'afl-gcc-fast'
-        #os.environ['CXX'] = 'afl-g++-fast'
+        os.environ['CC'] = 'afl-gcc-fast'
+        os.environ['CXX'] = 'afl-g++-fast'
         if build_flags.find('array-bounds') != -1:
-            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
-            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
         else:
-            #os.environ['CFLAGS'] = ''
-            #os.environ['CXXFLAGS'] = ''
-            #os.environ['CPPFLAGS'] = ''
+            os.environ['CFLAGS'] = ''
+            os.environ['CXXFLAGS'] = ''
+            os.environ['CPPFLAGS'] = ''
     else:
-        #os.environ['CC'] = '/afl/afl-clang-fast'
-        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+        os.environ['CC'] = '/afl/afl-clang-fast'
+        os.environ['CXX'] = '/afl/afl-clang-fast++'
 
     print('AFL++ build: ')
     print(build_modes)
 
     if 'qemu' in build_modes or 'symcc' in build_modes:
-        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
         cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
-        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+        os.environ['CXXFLAGS'] = ' '.join(cxxflags)
 
     if 'tracepc' in build_modes or 'pcguard' in build_modes:
-        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+        os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
     elif 'classic' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
     elif 'native' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
 
     # Instrumentation coverage options:
     # Do not use a fixed map location (LTO only)
     if 'dynamic' in build_modes:
-        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+        os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
     # Use a fixed map location (LTO only)
     if 'fixed' in build_modes:
-        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+        os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
     # Generate an extra dictionary.
     if 'dict2file' in build_modes or 'native' in build_modes:
-        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
         #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
     # Enable context sentitivity for LLVM mode (non LTO only)
     if 'ctx' in build_modes:
-        #os.environ['AFL_LLVM_CTX'] = '1'
+        os.environ['AFL_LLVM_CTX'] = '1'
     # Enable N-gram coverage for LLVM mode (non LTO only)
     if 'ngram2' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
     elif 'ngram3' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
     elif 'ngram4' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
     elif 'ngram5' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
     elif 'ngram6' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
     elif 'ngram7' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
     elif 'ngram8' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
     elif 'ngram16' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
     if 'ctx1' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '1'
+        os.environ['AFL_LLVM_CTX_K'] = '1'
     elif 'ctx2' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '2'
+        os.environ['AFL_LLVM_CTX_K'] = '2'
     elif 'ctx3' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '3'
+        os.environ['AFL_LLVM_CTX_K'] = '3'
     elif 'ctx4' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '4'
+        os.environ['AFL_LLVM_CTX_K'] = '4'
 
     # Only one of the following OR cmplog
     # enable laf-intel compare splitting
     if 'laf' in build_modes:
-        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
         if 'autodict' not in build_modes:
-            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+            os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
 
     if 'eclipser' in build_modes:
-        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+        os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
     else:
-        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+        os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
 
     # Some benchmarks like lcms. (see:
     # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
     # fail to compile if the compiler outputs things to stderr in unexpected
     # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
     # from writing AFL specific messages to stderr.
-    #os.environ['AFL_QUIET'] = '1'
-    #os.environ['AFL_MAP_SIZE'] = '2621440'
+    os.environ['AFL_QUIET'] = '1'
+    os.environ['AFL_MAP_SIZE'] = '2621440'
 
     src = os.getenv('SRC')
     work = os.getenv('WORK')
@@ -253,8 +253,8 @@ def fuzz(input_corpus,
 
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     # decomment this to enable libdislocator.
-    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
-    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+    # os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
     flags = list(flags)
 
@@ -265,15 +265,16 @@ def fuzz(input_corpus,
     if os.path.exists(cmplog_target_binary) and no_cmplog is False:
         flags += ['-c', cmplog_target_binary]
 
-    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
-    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
-    #os.environ['AFL_FAST_CAL'] = '1'
+    #os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    os.environ['AFL_FAST_CAL'] = '1'
+    os.environ['AFL_NO_WARN_INSTABILITY'] = '1'
 
     if not skip:
-        #os.environ['AFL_DISABLE_TRIM'] = '1'
-        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        os.environ['AFL_DISABLE_TRIM'] = '1'
+        os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
         if 'ADDITIONAL_ARGS' in os.environ:
-            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+            flags += os.environ['ADDITIONAL_ARGS'].split(' ')
 
     afl_fuzzer.run_afl_fuzz(input_corpus,
                             output_corpus,

--- a/fuzzers/aflplusplus_402/fuzzer.py
+++ b/fuzzers/aflplusplus_402/fuzzer.py
@@ -1,0 +1,281 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration code for AFLplusplus fuzzer."""
+
+import os
+import shutil
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+from fuzzers import utils
+
+
+def get_cmplog_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'cmplog')
+
+
+def get_uninstrumented_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
+
+
+def build(*args):  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    # BUILD_MODES is not already supported by fuzzbench, meanwhile we provide
+    # a default configuration.
+
+    build_modes = list(args)
+    if 'BUILD_MODES' in os.environ:
+        build_modes = #os.environ['BUILD_MODES'].split(',')
+
+    # Placeholder comment.
+    build_directory = #os.environ['OUT']
+
+    # If nothing was set this is the default:
+    if not build_modes:
+        build_modes = ['tracepc', 'cmplog', 'dict2file']
+
+    # For bug type benchmarks we have to instrument via native clang pcguard :(
+    build_flags = #os.environ['CFLAGS']
+
+    if build_flags.find(
+            'array-bounds'
+    ) != -1 and 'qemu' not in build_modes and 'classic' not in build_modes:
+        if 'gcc' not in build_modes:
+            build_modes[0] = 'native'
+
+    # Instrumentation coverage modes:
+    if 'lto' in build_modes:
+        #os.environ['CC'] = '/afl/afl-clang-lto'
+        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        edge_file = build_directory + '/aflpp_edges.txt'
+        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-13'
+            #os.environ['AR'] = 'llvm-ar-13'
+            #os.environ['AS'] = 'llvm-as-13'
+        elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-12'
+            #os.environ['AR'] = 'llvm-ar-12'
+            #os.environ['AS'] = 'llvm-as-12'
+        else:
+            #os.environ['RANLIB'] = 'llvm-ranlib'
+            #os.environ['AR'] = 'llvm-ar'
+            #os.environ['AS'] = 'llvm-as'
+    elif 'qemu' in build_modes:
+        #os.environ['CC'] = 'clang'
+        #os.environ['CXX'] = 'clang++'
+    elif 'gcc' in build_modes:
+        #os.environ['CC'] = 'afl-gcc-fast'
+        #os.environ['CXX'] = 'afl-g++-fast'
+        if build_flags.find('array-bounds') != -1:
+            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+        else:
+            #os.environ['CFLAGS'] = ''
+            #os.environ['CXXFLAGS'] = ''
+            #os.environ['CPPFLAGS'] = ''
+    else:
+        #os.environ['CC'] = '/afl/afl-clang-fast'
+        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+
+    print('AFL++ build: ')
+    print(build_modes)
+
+    if 'qemu' in build_modes or 'symcc' in build_modes:
+        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
+        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+
+    if 'tracepc' in build_modes or 'pcguard' in build_modes:
+        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+    elif 'classic' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+    elif 'native' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+
+    # Instrumentation coverage options:
+    # Do not use a fixed map location (LTO only)
+    if 'dynamic' in build_modes:
+        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+    # Use a fixed map location (LTO only)
+    if 'fixed' in build_modes:
+        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+    # Generate an extra dictionary.
+    if 'dict2file' in build_modes or 'native' in build_modes:
+        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
+    # Enable context sentitivity for LLVM mode (non LTO only)
+    if 'ctx' in build_modes:
+        #os.environ['AFL_LLVM_CTX'] = '1'
+    # Enable N-gram coverage for LLVM mode (non LTO only)
+    if 'ngram2' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+    elif 'ngram3' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+    elif 'ngram4' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+    elif 'ngram5' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+    elif 'ngram6' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+    elif 'ngram7' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+    elif 'ngram8' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+    elif 'ngram16' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+    if 'ctx1' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '1'
+    elif 'ctx2' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '2'
+    elif 'ctx3' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '3'
+    elif 'ctx4' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '4'
+
+    # Only one of the following OR cmplog
+    # enable laf-intel compare splitting
+    if 'laf' in build_modes:
+        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        if 'autodict' not in build_modes:
+            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+
+    if 'eclipser' in build_modes:
+        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+    else:
+        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+
+    # Some benchmarks like lcms. (see:
+    # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
+    # fail to compile if the compiler outputs things to stderr in unexpected
+    # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
+    # from writing AFL specific messages to stderr.
+    #os.environ['AFL_QUIET'] = '1'
+    #os.environ['AFL_MAP_SIZE'] = '2621440'
+
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+
+    with utils.restore_directory(src), utils.restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        utils.build_benchmark()
+
+    if 'cmplog' in build_modes and 'qemu' not in build_modes:
+
+        # CmpLog requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['AFL_LLVM_CMPLOG'] = '1'
+
+        # For CmpLog build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new CmpLog build directory.
+        cmplog_build_directory = get_cmplog_build_directory(build_directory)
+        os.mkdir(cmplog_build_directory)
+        new_env['OUT'] = cmplog_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(cmplog_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for CmpLog fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    if 'symcc' in build_modes:
+
+        symcc_build_directory = get_uninstrumented_build_directory(
+            build_directory)
+        os.mkdir(symcc_build_directory)
+
+        # symcc requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['CC'] = '/symcc/build/symcc'
+        new_env['CXX'] = '/symcc/build/sym++'
+        new_env['SYMCC_OUTPUT_DIR'] = '/tmp'
+        new_env['CXXFLAGS'] = new_env['CXXFLAGS'].replace('-stlib=libc++', '')
+        new_env['FUZZER_LIB'] = '/libfuzzer-harness.o'
+        new_env['OUT'] = symcc_build_directory
+        new_env['SYMCC_LIBCXX_PATH'] = '/libcxx_native_build'
+        new_env['SYMCC_NO_SYMBOLIC_INPUT'] = '1'
+        new_env['SYMCC_SILENT'] = '1'
+
+        # For symcc build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new symcc build directory.
+        new_env['OUT'] = symcc_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(symcc_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for symcc fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    shutil.copy('/afl/afl-fuzz', build_directory)
+    if os.path.exists('/afl/afl-qemu-trace'):
+        shutil.copy('/afl/afl-qemu-trace', build_directory)
+    if os.path.exists('/aflpp_qemu_driver_hook.so'):
+        shutil.copy('/aflpp_qemu_driver_hook.so', build_directory)
+    if os.path.exists('/get_frida_entry.sh'):
+        shutil.copy('/afl/afl-frida-trace.so', build_directory)
+        shutil.copy('/get_frida_entry.sh', build_directory)
+
+
+# pylint: disable=too-many-arguments
+def fuzz(input_corpus,
+         output_corpus,
+         target_binary,
+         flags=tuple(),
+         skip=False,
+         no_cmplog=False):  # pylint: disable=too-many-arguments
+    """Run fuzzer."""
+    # Calculate CmpLog binary path from the instrumented target binary.
+    target_binary_directory = os.path.dirname(target_binary)
+    cmplog_target_binary_directory = (
+        get_cmplog_build_directory(target_binary_directory))
+    target_binary_name = os.path.basename(target_binary)
+    cmplog_target_binary = os.path.join(cmplog_target_binary_directory,
+                                        target_binary_name)
+
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+    # decomment this to enable libdislocator.
+    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+
+    flags = list(flags)
+
+    if os.path.exists('./afl++.dict'):
+        flags += ['-x', './afl++.dict']
+
+    # Move the following to skip for upcoming _double tests:
+    if os.path.exists(cmplog_target_binary) and no_cmplog is False:
+        flags += ['-c', cmplog_target_binary]
+
+    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    #os.environ['AFL_FAST_CAL'] = '1'
+
+    if not skip:
+        #os.environ['AFL_DISABLE_TRIM'] = '1'
+        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        if 'ADDITIONAL_ARGS' in os.environ:
+            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+
+    afl_fuzzer.run_afl_fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            additional_flags=flags)

--- a/fuzzers/aflplusplus_402/runner.Dockerfile
+++ b/fuzzers/aflplusplus_402/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/fuzzers/aflplusplus_403/builder.Dockerfile
+++ b/fuzzers/aflplusplus_403/builder.Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        python3-dev \
+        python3-setuptools \
+        automake \
+        cmake \
+        git \
+        flex \
+        bison \
+        libglib2.0-dev \
+        libpixman-1-dev \
+        cargo \
+        libgtk-3-dev \
+        # for QEMU mode
+        ninja-build \
+        gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-plugin-dev \
+        libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
+
+# Download afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus /afl && \
+    cd /afl && \
+    git checkout ad4b7274766418d2006177edebf0d242b49c5fef || \
+    true
+
+RUN apt install -y lsb-release wget software-properties-common gnupg
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13
+
+ENV LLVM_CONFIG llvm-config-13
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && \
+    unset CFLAGS CXXFLAGS && \
+    export CC=clang AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /

--- a/fuzzers/aflplusplus_403/description.md
+++ b/fuzzers/aflplusplus_403/description.md
@@ -1,0 +1,14 @@
+# aflplusplus
+
+AFL++ fuzzer instance that has the following config active for all benchmarks:
+  - PCGUARD instrumentation 
+  - cmplog feature
+  - dict2file feature
+  - "fast" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_403/fuzzer.py
+++ b/fuzzers/aflplusplus_403/fuzzer.py
@@ -38,17 +38,17 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     build_modes = list(args)
     if 'BUILD_MODES' in os.environ:
-        build_modes = #os.environ['BUILD_MODES'].split(',')
+        build_modes = os.environ['BUILD_MODES'].split(',')
 
     # Placeholder comment.
-    build_directory = #os.environ['OUT']
+    build_directory = os.environ['OUT']
 
     # If nothing was set this is the default:
     if not build_modes:
         build_modes = ['tracepc', 'cmplog', 'dict2file']
 
     # For bug type benchmarks we have to instrument via native clang pcguard :(
-    build_flags = #os.environ['CFLAGS']
+    build_flags = os.environ['CFLAGS']
 
     if build_flags.find(
             'array-bounds'
@@ -58,115 +58,115 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     # Instrumentation coverage modes:
     if 'lto' in build_modes:
-        #os.environ['CC'] = '/afl/afl-clang-lto'
-        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        os.environ['CC'] = '/afl/afl-clang-lto'
+        os.environ['CXX'] = '/afl/afl-clang-lto++'
         edge_file = build_directory + '/aflpp_edges.txt'
-        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
         if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-13'
-            #os.environ['AR'] = 'llvm-ar-13'
-            #os.environ['AS'] = 'llvm-as-13'
+            os.environ['RANLIB'] = 'llvm-ranlib-13'
+            os.environ['AR'] = 'llvm-ar-13'
+            os.environ['AS'] = 'llvm-as-13'
         elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-12'
-            #os.environ['AR'] = 'llvm-ar-12'
-            #os.environ['AS'] = 'llvm-as-12'
+            os.environ['RANLIB'] = 'llvm-ranlib-12'
+            os.environ['AR'] = 'llvm-ar-12'
+            os.environ['AS'] = 'llvm-as-12'
         else:
-            #os.environ['RANLIB'] = 'llvm-ranlib'
-            #os.environ['AR'] = 'llvm-ar'
-            #os.environ['AS'] = 'llvm-as'
+            os.environ['RANLIB'] = 'llvm-ranlib'
+            os.environ['AR'] = 'llvm-ar'
+            os.environ['AS'] = 'llvm-as'
     elif 'qemu' in build_modes:
-        #os.environ['CC'] = 'clang'
-        #os.environ['CXX'] = 'clang++'
+        os.environ['CC'] = 'clang'
+        os.environ['CXX'] = 'clang++'
     elif 'gcc' in build_modes:
-        #os.environ['CC'] = 'afl-gcc-fast'
-        #os.environ['CXX'] = 'afl-g++-fast'
+        os.environ['CC'] = 'afl-gcc-fast'
+        os.environ['CXX'] = 'afl-g++-fast'
         if build_flags.find('array-bounds') != -1:
-            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
-            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
         else:
-            #os.environ['CFLAGS'] = ''
-            #os.environ['CXXFLAGS'] = ''
-            #os.environ['CPPFLAGS'] = ''
+            os.environ['CFLAGS'] = ''
+            os.environ['CXXFLAGS'] = ''
+            os.environ['CPPFLAGS'] = ''
     else:
-        #os.environ['CC'] = '/afl/afl-clang-fast'
-        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+        os.environ['CC'] = '/afl/afl-clang-fast'
+        os.environ['CXX'] = '/afl/afl-clang-fast++'
 
     print('AFL++ build: ')
     print(build_modes)
 
     if 'qemu' in build_modes or 'symcc' in build_modes:
-        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
         cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
-        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+        os.environ['CXXFLAGS'] = ' '.join(cxxflags)
 
     if 'tracepc' in build_modes or 'pcguard' in build_modes:
-        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+        os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
     elif 'classic' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
     elif 'native' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
 
     # Instrumentation coverage options:
     # Do not use a fixed map location (LTO only)
     if 'dynamic' in build_modes:
-        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+        os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
     # Use a fixed map location (LTO only)
     if 'fixed' in build_modes:
-        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+        os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
     # Generate an extra dictionary.
     if 'dict2file' in build_modes or 'native' in build_modes:
-        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
         #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
     # Enable context sentitivity for LLVM mode (non LTO only)
     if 'ctx' in build_modes:
-        #os.environ['AFL_LLVM_CTX'] = '1'
+        os.environ['AFL_LLVM_CTX'] = '1'
     # Enable N-gram coverage for LLVM mode (non LTO only)
     if 'ngram2' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
     elif 'ngram3' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
     elif 'ngram4' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
     elif 'ngram5' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
     elif 'ngram6' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
     elif 'ngram7' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
     elif 'ngram8' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
     elif 'ngram16' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
     if 'ctx1' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '1'
+        os.environ['AFL_LLVM_CTX_K'] = '1'
     elif 'ctx2' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '2'
+        os.environ['AFL_LLVM_CTX_K'] = '2'
     elif 'ctx3' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '3'
+        os.environ['AFL_LLVM_CTX_K'] = '3'
     elif 'ctx4' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '4'
+        os.environ['AFL_LLVM_CTX_K'] = '4'
 
     # Only one of the following OR cmplog
     # enable laf-intel compare splitting
     if 'laf' in build_modes:
-        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
         if 'autodict' not in build_modes:
-            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+            os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
 
     if 'eclipser' in build_modes:
-        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+        os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
     else:
-        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+        os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
 
     # Some benchmarks like lcms. (see:
     # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
     # fail to compile if the compiler outputs things to stderr in unexpected
     # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
     # from writing AFL specific messages to stderr.
-    #os.environ['AFL_QUIET'] = '1'
-    #os.environ['AFL_MAP_SIZE'] = '2621440'
+    os.environ['AFL_QUIET'] = '1'
+    os.environ['AFL_MAP_SIZE'] = '2621440'
 
     src = os.getenv('SRC')
     work = os.getenv('WORK')
@@ -253,8 +253,8 @@ def fuzz(input_corpus,
 
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     # decomment this to enable libdislocator.
-    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
-    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+    # os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
     flags = list(flags)
 
@@ -265,15 +265,16 @@ def fuzz(input_corpus,
     if os.path.exists(cmplog_target_binary) and no_cmplog is False:
         flags += ['-c', cmplog_target_binary]
 
-    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
-    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
-    #os.environ['AFL_FAST_CAL'] = '1'
+    #os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    os.environ['AFL_FAST_CAL'] = '1'
+    os.environ['AFL_NO_WARN_INSTABILITY'] = '1'
 
     if not skip:
-        #os.environ['AFL_DISABLE_TRIM'] = '1'
-        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        os.environ['AFL_DISABLE_TRIM'] = '1'
+        os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
         if 'ADDITIONAL_ARGS' in os.environ:
-            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+            flags += os.environ['ADDITIONAL_ARGS'].split(' ')
 
     afl_fuzzer.run_afl_fuzz(input_corpus,
                             output_corpus,

--- a/fuzzers/aflplusplus_403/fuzzer.py
+++ b/fuzzers/aflplusplus_403/fuzzer.py
@@ -1,0 +1,281 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration code for AFLplusplus fuzzer."""
+
+import os
+import shutil
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+from fuzzers import utils
+
+
+def get_cmplog_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'cmplog')
+
+
+def get_uninstrumented_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
+
+
+def build(*args):  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    # BUILD_MODES is not already supported by fuzzbench, meanwhile we provide
+    # a default configuration.
+
+    build_modes = list(args)
+    if 'BUILD_MODES' in os.environ:
+        build_modes = #os.environ['BUILD_MODES'].split(',')
+
+    # Placeholder comment.
+    build_directory = #os.environ['OUT']
+
+    # If nothing was set this is the default:
+    if not build_modes:
+        build_modes = ['tracepc', 'cmplog', 'dict2file']
+
+    # For bug type benchmarks we have to instrument via native clang pcguard :(
+    build_flags = #os.environ['CFLAGS']
+
+    if build_flags.find(
+            'array-bounds'
+    ) != -1 and 'qemu' not in build_modes and 'classic' not in build_modes:
+        if 'gcc' not in build_modes:
+            build_modes[0] = 'native'
+
+    # Instrumentation coverage modes:
+    if 'lto' in build_modes:
+        #os.environ['CC'] = '/afl/afl-clang-lto'
+        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        edge_file = build_directory + '/aflpp_edges.txt'
+        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-13'
+            #os.environ['AR'] = 'llvm-ar-13'
+            #os.environ['AS'] = 'llvm-as-13'
+        elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-12'
+            #os.environ['AR'] = 'llvm-ar-12'
+            #os.environ['AS'] = 'llvm-as-12'
+        else:
+            #os.environ['RANLIB'] = 'llvm-ranlib'
+            #os.environ['AR'] = 'llvm-ar'
+            #os.environ['AS'] = 'llvm-as'
+    elif 'qemu' in build_modes:
+        #os.environ['CC'] = 'clang'
+        #os.environ['CXX'] = 'clang++'
+    elif 'gcc' in build_modes:
+        #os.environ['CC'] = 'afl-gcc-fast'
+        #os.environ['CXX'] = 'afl-g++-fast'
+        if build_flags.find('array-bounds') != -1:
+            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+        else:
+            #os.environ['CFLAGS'] = ''
+            #os.environ['CXXFLAGS'] = ''
+            #os.environ['CPPFLAGS'] = ''
+    else:
+        #os.environ['CC'] = '/afl/afl-clang-fast'
+        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+
+    print('AFL++ build: ')
+    print(build_modes)
+
+    if 'qemu' in build_modes or 'symcc' in build_modes:
+        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
+        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+
+    if 'tracepc' in build_modes or 'pcguard' in build_modes:
+        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+    elif 'classic' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+    elif 'native' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+
+    # Instrumentation coverage options:
+    # Do not use a fixed map location (LTO only)
+    if 'dynamic' in build_modes:
+        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+    # Use a fixed map location (LTO only)
+    if 'fixed' in build_modes:
+        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+    # Generate an extra dictionary.
+    if 'dict2file' in build_modes or 'native' in build_modes:
+        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
+    # Enable context sentitivity for LLVM mode (non LTO only)
+    if 'ctx' in build_modes:
+        #os.environ['AFL_LLVM_CTX'] = '1'
+    # Enable N-gram coverage for LLVM mode (non LTO only)
+    if 'ngram2' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+    elif 'ngram3' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+    elif 'ngram4' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+    elif 'ngram5' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+    elif 'ngram6' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+    elif 'ngram7' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+    elif 'ngram8' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+    elif 'ngram16' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+    if 'ctx1' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '1'
+    elif 'ctx2' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '2'
+    elif 'ctx3' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '3'
+    elif 'ctx4' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '4'
+
+    # Only one of the following OR cmplog
+    # enable laf-intel compare splitting
+    if 'laf' in build_modes:
+        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        if 'autodict' not in build_modes:
+            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+
+    if 'eclipser' in build_modes:
+        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+    else:
+        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+
+    # Some benchmarks like lcms. (see:
+    # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
+    # fail to compile if the compiler outputs things to stderr in unexpected
+    # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
+    # from writing AFL specific messages to stderr.
+    #os.environ['AFL_QUIET'] = '1'
+    #os.environ['AFL_MAP_SIZE'] = '2621440'
+
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+
+    with utils.restore_directory(src), utils.restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        utils.build_benchmark()
+
+    if 'cmplog' in build_modes and 'qemu' not in build_modes:
+
+        # CmpLog requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['AFL_LLVM_CMPLOG'] = '1'
+
+        # For CmpLog build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new CmpLog build directory.
+        cmplog_build_directory = get_cmplog_build_directory(build_directory)
+        os.mkdir(cmplog_build_directory)
+        new_env['OUT'] = cmplog_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(cmplog_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for CmpLog fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    if 'symcc' in build_modes:
+
+        symcc_build_directory = get_uninstrumented_build_directory(
+            build_directory)
+        os.mkdir(symcc_build_directory)
+
+        # symcc requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['CC'] = '/symcc/build/symcc'
+        new_env['CXX'] = '/symcc/build/sym++'
+        new_env['SYMCC_OUTPUT_DIR'] = '/tmp'
+        new_env['CXXFLAGS'] = new_env['CXXFLAGS'].replace('-stlib=libc++', '')
+        new_env['FUZZER_LIB'] = '/libfuzzer-harness.o'
+        new_env['OUT'] = symcc_build_directory
+        new_env['SYMCC_LIBCXX_PATH'] = '/libcxx_native_build'
+        new_env['SYMCC_NO_SYMBOLIC_INPUT'] = '1'
+        new_env['SYMCC_SILENT'] = '1'
+
+        # For symcc build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new symcc build directory.
+        new_env['OUT'] = symcc_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(symcc_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for symcc fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    shutil.copy('/afl/afl-fuzz', build_directory)
+    if os.path.exists('/afl/afl-qemu-trace'):
+        shutil.copy('/afl/afl-qemu-trace', build_directory)
+    if os.path.exists('/aflpp_qemu_driver_hook.so'):
+        shutil.copy('/aflpp_qemu_driver_hook.so', build_directory)
+    if os.path.exists('/get_frida_entry.sh'):
+        shutil.copy('/afl/afl-frida-trace.so', build_directory)
+        shutil.copy('/get_frida_entry.sh', build_directory)
+
+
+# pylint: disable=too-many-arguments
+def fuzz(input_corpus,
+         output_corpus,
+         target_binary,
+         flags=tuple(),
+         skip=False,
+         no_cmplog=False):  # pylint: disable=too-many-arguments
+    """Run fuzzer."""
+    # Calculate CmpLog binary path from the instrumented target binary.
+    target_binary_directory = os.path.dirname(target_binary)
+    cmplog_target_binary_directory = (
+        get_cmplog_build_directory(target_binary_directory))
+    target_binary_name = os.path.basename(target_binary)
+    cmplog_target_binary = os.path.join(cmplog_target_binary_directory,
+                                        target_binary_name)
+
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+    # decomment this to enable libdislocator.
+    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+
+    flags = list(flags)
+
+    if os.path.exists('./afl++.dict'):
+        flags += ['-x', './afl++.dict']
+
+    # Move the following to skip for upcoming _double tests:
+    if os.path.exists(cmplog_target_binary) and no_cmplog is False:
+        flags += ['-c', cmplog_target_binary]
+
+    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    #os.environ['AFL_FAST_CAL'] = '1'
+
+    if not skip:
+        #os.environ['AFL_DISABLE_TRIM'] = '1'
+        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        if 'ADDITIONAL_ARGS' in os.environ:
+            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+
+    afl_fuzzer.run_afl_fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            additional_flags=flags)

--- a/fuzzers/aflplusplus_403/runner.Dockerfile
+++ b/fuzzers/aflplusplus_403/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/fuzzers/aflplusplus_404/builder.Dockerfile
+++ b/fuzzers/aflplusplus_404/builder.Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        python3-dev \
+        python3-setuptools \
+        automake \
+        cmake \
+        git \
+        flex \
+        bison \
+        libglib2.0-dev \
+        libpixman-1-dev \
+        cargo \
+        libgtk-3-dev \
+        # for QEMU mode
+        ninja-build \
+        gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-plugin-dev \
+        libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
+
+# Download afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus /afl && \
+    cd /afl && \
+    git checkout cbfa5207ba2853e249ffb256d99880368ee224e0 || \
+    true
+
+RUN apt install -y lsb-release wget software-properties-common gnupg
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13
+
+ENV LLVM_CONFIG llvm-config-13
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && \
+    unset CFLAGS CXXFLAGS && \
+    export CC=clang AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /

--- a/fuzzers/aflplusplus_404/description.md
+++ b/fuzzers/aflplusplus_404/description.md
@@ -1,0 +1,14 @@
+# aflplusplus
+
+AFL++ fuzzer instance that has the following config active for all benchmarks:
+  - PCGUARD instrumentation 
+  - cmplog feature
+  - dict2file feature
+  - "fast" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_404/fuzzer.py
+++ b/fuzzers/aflplusplus_404/fuzzer.py
@@ -38,17 +38,17 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     build_modes = list(args)
     if 'BUILD_MODES' in os.environ:
-        build_modes = #os.environ['BUILD_MODES'].split(',')
+        build_modes = os.environ['BUILD_MODES'].split(',')
 
     # Placeholder comment.
-    build_directory = #os.environ['OUT']
+    build_directory = os.environ['OUT']
 
     # If nothing was set this is the default:
     if not build_modes:
         build_modes = ['tracepc', 'cmplog', 'dict2file']
 
     # For bug type benchmarks we have to instrument via native clang pcguard :(
-    build_flags = #os.environ['CFLAGS']
+    build_flags = os.environ['CFLAGS']
 
     if build_flags.find(
             'array-bounds'
@@ -58,115 +58,115 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     # Instrumentation coverage modes:
     if 'lto' in build_modes:
-        #os.environ['CC'] = '/afl/afl-clang-lto'
-        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        os.environ['CC'] = '/afl/afl-clang-lto'
+        os.environ['CXX'] = '/afl/afl-clang-lto++'
         edge_file = build_directory + '/aflpp_edges.txt'
-        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
         if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-13'
-            #os.environ['AR'] = 'llvm-ar-13'
-            #os.environ['AS'] = 'llvm-as-13'
+            os.environ['RANLIB'] = 'llvm-ranlib-13'
+            os.environ['AR'] = 'llvm-ar-13'
+            os.environ['AS'] = 'llvm-as-13'
         elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-12'
-            #os.environ['AR'] = 'llvm-ar-12'
-            #os.environ['AS'] = 'llvm-as-12'
+            os.environ['RANLIB'] = 'llvm-ranlib-12'
+            os.environ['AR'] = 'llvm-ar-12'
+            os.environ['AS'] = 'llvm-as-12'
         else:
-            #os.environ['RANLIB'] = 'llvm-ranlib'
-            #os.environ['AR'] = 'llvm-ar'
-            #os.environ['AS'] = 'llvm-as'
+            os.environ['RANLIB'] = 'llvm-ranlib'
+            os.environ['AR'] = 'llvm-ar'
+            os.environ['AS'] = 'llvm-as'
     elif 'qemu' in build_modes:
-        #os.environ['CC'] = 'clang'
-        #os.environ['CXX'] = 'clang++'
+        os.environ['CC'] = 'clang'
+        os.environ['CXX'] = 'clang++'
     elif 'gcc' in build_modes:
-        #os.environ['CC'] = 'afl-gcc-fast'
-        #os.environ['CXX'] = 'afl-g++-fast'
+        os.environ['CC'] = 'afl-gcc-fast'
+        os.environ['CXX'] = 'afl-g++-fast'
         if build_flags.find('array-bounds') != -1:
-            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
-            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
         else:
-            #os.environ['CFLAGS'] = ''
-            #os.environ['CXXFLAGS'] = ''
-            #os.environ['CPPFLAGS'] = ''
+            os.environ['CFLAGS'] = ''
+            os.environ['CXXFLAGS'] = ''
+            os.environ['CPPFLAGS'] = ''
     else:
-        #os.environ['CC'] = '/afl/afl-clang-fast'
-        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+        os.environ['CC'] = '/afl/afl-clang-fast'
+        os.environ['CXX'] = '/afl/afl-clang-fast++'
 
     print('AFL++ build: ')
     print(build_modes)
 
     if 'qemu' in build_modes or 'symcc' in build_modes:
-        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
         cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
-        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+        os.environ['CXXFLAGS'] = ' '.join(cxxflags)
 
     if 'tracepc' in build_modes or 'pcguard' in build_modes:
-        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+        os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
     elif 'classic' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
     elif 'native' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
 
     # Instrumentation coverage options:
     # Do not use a fixed map location (LTO only)
     if 'dynamic' in build_modes:
-        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+        os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
     # Use a fixed map location (LTO only)
     if 'fixed' in build_modes:
-        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+        os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
     # Generate an extra dictionary.
     if 'dict2file' in build_modes or 'native' in build_modes:
-        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
         #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
     # Enable context sentitivity for LLVM mode (non LTO only)
     if 'ctx' in build_modes:
-        #os.environ['AFL_LLVM_CTX'] = '1'
+        os.environ['AFL_LLVM_CTX'] = '1'
     # Enable N-gram coverage for LLVM mode (non LTO only)
     if 'ngram2' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
     elif 'ngram3' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
     elif 'ngram4' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
     elif 'ngram5' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
     elif 'ngram6' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
     elif 'ngram7' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
     elif 'ngram8' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
     elif 'ngram16' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
     if 'ctx1' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '1'
+        os.environ['AFL_LLVM_CTX_K'] = '1'
     elif 'ctx2' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '2'
+        os.environ['AFL_LLVM_CTX_K'] = '2'
     elif 'ctx3' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '3'
+        os.environ['AFL_LLVM_CTX_K'] = '3'
     elif 'ctx4' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '4'
+        os.environ['AFL_LLVM_CTX_K'] = '4'
 
     # Only one of the following OR cmplog
     # enable laf-intel compare splitting
     if 'laf' in build_modes:
-        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
         if 'autodict' not in build_modes:
-            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+            os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
 
     if 'eclipser' in build_modes:
-        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+        os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
     else:
-        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+        os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
 
     # Some benchmarks like lcms. (see:
     # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
     # fail to compile if the compiler outputs things to stderr in unexpected
     # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
     # from writing AFL specific messages to stderr.
-    #os.environ['AFL_QUIET'] = '1'
-    #os.environ['AFL_MAP_SIZE'] = '2621440'
+    os.environ['AFL_QUIET'] = '1'
+    os.environ['AFL_MAP_SIZE'] = '2621440'
 
     src = os.getenv('SRC')
     work = os.getenv('WORK')
@@ -253,8 +253,8 @@ def fuzz(input_corpus,
 
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     # decomment this to enable libdislocator.
-    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
-    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+    # os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
     flags = list(flags)
 
@@ -265,15 +265,16 @@ def fuzz(input_corpus,
     if os.path.exists(cmplog_target_binary) and no_cmplog is False:
         flags += ['-c', cmplog_target_binary]
 
-    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
-    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
-    #os.environ['AFL_FAST_CAL'] = '1'
+    #os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    os.environ['AFL_FAST_CAL'] = '1'
+    os.environ['AFL_NO_WARN_INSTABILITY'] = '1'
 
     if not skip:
-        #os.environ['AFL_DISABLE_TRIM'] = '1'
-        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        os.environ['AFL_DISABLE_TRIM'] = '1'
+        os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
         if 'ADDITIONAL_ARGS' in os.environ:
-            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+            flags += os.environ['ADDITIONAL_ARGS'].split(' ')
 
     afl_fuzzer.run_afl_fuzz(input_corpus,
                             output_corpus,

--- a/fuzzers/aflplusplus_404/fuzzer.py
+++ b/fuzzers/aflplusplus_404/fuzzer.py
@@ -1,0 +1,281 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration code for AFLplusplus fuzzer."""
+
+import os
+import shutil
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+from fuzzers import utils
+
+
+def get_cmplog_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'cmplog')
+
+
+def get_uninstrumented_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
+
+
+def build(*args):  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    # BUILD_MODES is not already supported by fuzzbench, meanwhile we provide
+    # a default configuration.
+
+    build_modes = list(args)
+    if 'BUILD_MODES' in os.environ:
+        build_modes = #os.environ['BUILD_MODES'].split(',')
+
+    # Placeholder comment.
+    build_directory = #os.environ['OUT']
+
+    # If nothing was set this is the default:
+    if not build_modes:
+        build_modes = ['tracepc', 'cmplog', 'dict2file']
+
+    # For bug type benchmarks we have to instrument via native clang pcguard :(
+    build_flags = #os.environ['CFLAGS']
+
+    if build_flags.find(
+            'array-bounds'
+    ) != -1 and 'qemu' not in build_modes and 'classic' not in build_modes:
+        if 'gcc' not in build_modes:
+            build_modes[0] = 'native'
+
+    # Instrumentation coverage modes:
+    if 'lto' in build_modes:
+        #os.environ['CC'] = '/afl/afl-clang-lto'
+        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        edge_file = build_directory + '/aflpp_edges.txt'
+        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-13'
+            #os.environ['AR'] = 'llvm-ar-13'
+            #os.environ['AS'] = 'llvm-as-13'
+        elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-12'
+            #os.environ['AR'] = 'llvm-ar-12'
+            #os.environ['AS'] = 'llvm-as-12'
+        else:
+            #os.environ['RANLIB'] = 'llvm-ranlib'
+            #os.environ['AR'] = 'llvm-ar'
+            #os.environ['AS'] = 'llvm-as'
+    elif 'qemu' in build_modes:
+        #os.environ['CC'] = 'clang'
+        #os.environ['CXX'] = 'clang++'
+    elif 'gcc' in build_modes:
+        #os.environ['CC'] = 'afl-gcc-fast'
+        #os.environ['CXX'] = 'afl-g++-fast'
+        if build_flags.find('array-bounds') != -1:
+            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+        else:
+            #os.environ['CFLAGS'] = ''
+            #os.environ['CXXFLAGS'] = ''
+            #os.environ['CPPFLAGS'] = ''
+    else:
+        #os.environ['CC'] = '/afl/afl-clang-fast'
+        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+
+    print('AFL++ build: ')
+    print(build_modes)
+
+    if 'qemu' in build_modes or 'symcc' in build_modes:
+        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
+        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+
+    if 'tracepc' in build_modes or 'pcguard' in build_modes:
+        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+    elif 'classic' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+    elif 'native' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+
+    # Instrumentation coverage options:
+    # Do not use a fixed map location (LTO only)
+    if 'dynamic' in build_modes:
+        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+    # Use a fixed map location (LTO only)
+    if 'fixed' in build_modes:
+        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+    # Generate an extra dictionary.
+    if 'dict2file' in build_modes or 'native' in build_modes:
+        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
+    # Enable context sentitivity for LLVM mode (non LTO only)
+    if 'ctx' in build_modes:
+        #os.environ['AFL_LLVM_CTX'] = '1'
+    # Enable N-gram coverage for LLVM mode (non LTO only)
+    if 'ngram2' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+    elif 'ngram3' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+    elif 'ngram4' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+    elif 'ngram5' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+    elif 'ngram6' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+    elif 'ngram7' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+    elif 'ngram8' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+    elif 'ngram16' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+    if 'ctx1' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '1'
+    elif 'ctx2' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '2'
+    elif 'ctx3' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '3'
+    elif 'ctx4' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '4'
+
+    # Only one of the following OR cmplog
+    # enable laf-intel compare splitting
+    if 'laf' in build_modes:
+        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        if 'autodict' not in build_modes:
+            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+
+    if 'eclipser' in build_modes:
+        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+    else:
+        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+
+    # Some benchmarks like lcms. (see:
+    # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
+    # fail to compile if the compiler outputs things to stderr in unexpected
+    # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
+    # from writing AFL specific messages to stderr.
+    #os.environ['AFL_QUIET'] = '1'
+    #os.environ['AFL_MAP_SIZE'] = '2621440'
+
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+
+    with utils.restore_directory(src), utils.restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        utils.build_benchmark()
+
+    if 'cmplog' in build_modes and 'qemu' not in build_modes:
+
+        # CmpLog requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['AFL_LLVM_CMPLOG'] = '1'
+
+        # For CmpLog build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new CmpLog build directory.
+        cmplog_build_directory = get_cmplog_build_directory(build_directory)
+        os.mkdir(cmplog_build_directory)
+        new_env['OUT'] = cmplog_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(cmplog_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for CmpLog fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    if 'symcc' in build_modes:
+
+        symcc_build_directory = get_uninstrumented_build_directory(
+            build_directory)
+        os.mkdir(symcc_build_directory)
+
+        # symcc requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['CC'] = '/symcc/build/symcc'
+        new_env['CXX'] = '/symcc/build/sym++'
+        new_env['SYMCC_OUTPUT_DIR'] = '/tmp'
+        new_env['CXXFLAGS'] = new_env['CXXFLAGS'].replace('-stlib=libc++', '')
+        new_env['FUZZER_LIB'] = '/libfuzzer-harness.o'
+        new_env['OUT'] = symcc_build_directory
+        new_env['SYMCC_LIBCXX_PATH'] = '/libcxx_native_build'
+        new_env['SYMCC_NO_SYMBOLIC_INPUT'] = '1'
+        new_env['SYMCC_SILENT'] = '1'
+
+        # For symcc build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new symcc build directory.
+        new_env['OUT'] = symcc_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(symcc_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for symcc fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    shutil.copy('/afl/afl-fuzz', build_directory)
+    if os.path.exists('/afl/afl-qemu-trace'):
+        shutil.copy('/afl/afl-qemu-trace', build_directory)
+    if os.path.exists('/aflpp_qemu_driver_hook.so'):
+        shutil.copy('/aflpp_qemu_driver_hook.so', build_directory)
+    if os.path.exists('/get_frida_entry.sh'):
+        shutil.copy('/afl/afl-frida-trace.so', build_directory)
+        shutil.copy('/get_frida_entry.sh', build_directory)
+
+
+# pylint: disable=too-many-arguments
+def fuzz(input_corpus,
+         output_corpus,
+         target_binary,
+         flags=tuple(),
+         skip=False,
+         no_cmplog=False):  # pylint: disable=too-many-arguments
+    """Run fuzzer."""
+    # Calculate CmpLog binary path from the instrumented target binary.
+    target_binary_directory = os.path.dirname(target_binary)
+    cmplog_target_binary_directory = (
+        get_cmplog_build_directory(target_binary_directory))
+    target_binary_name = os.path.basename(target_binary)
+    cmplog_target_binary = os.path.join(cmplog_target_binary_directory,
+                                        target_binary_name)
+
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+    # decomment this to enable libdislocator.
+    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+
+    flags = list(flags)
+
+    if os.path.exists('./afl++.dict'):
+        flags += ['-x', './afl++.dict']
+
+    # Move the following to skip for upcoming _double tests:
+    if os.path.exists(cmplog_target_binary) and no_cmplog is False:
+        flags += ['-c', cmplog_target_binary]
+
+    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    #os.environ['AFL_FAST_CAL'] = '1'
+
+    if not skip:
+        #os.environ['AFL_DISABLE_TRIM'] = '1'
+        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        if 'ADDITIONAL_ARGS' in os.environ:
+            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+
+    afl_fuzzer.run_afl_fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            additional_flags=flags)

--- a/fuzzers/aflplusplus_404/runner.Dockerfile
+++ b/fuzzers/aflplusplus_404/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/fuzzers/aflplusplus_405/builder.Dockerfile
+++ b/fuzzers/aflplusplus_405/builder.Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        python3-dev \
+        python3-setuptools \
+        automake \
+        cmake \
+        git \
+        flex \
+        bison \
+        libglib2.0-dev \
+        libpixman-1-dev \
+        cargo \
+        libgtk-3-dev \
+        # for QEMU mode
+        ninja-build \
+        gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-plugin-dev \
+        libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
+
+# Download afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus /afl && \
+    cd /afl && \
+    git checkout 3b6fcd911a860a8c823c912c4b08b423734e4cfe || \
+    true
+
+RUN apt install -y lsb-release wget software-properties-common gnupg
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13
+
+ENV LLVM_CONFIG llvm-config-13
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && \
+    unset CFLAGS CXXFLAGS && \
+    export CC=clang AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /

--- a/fuzzers/aflplusplus_405/description.md
+++ b/fuzzers/aflplusplus_405/description.md
@@ -1,0 +1,14 @@
+# aflplusplus
+
+AFL++ fuzzer instance that has the following config active for all benchmarks:
+  - PCGUARD instrumentation 
+  - cmplog feature
+  - dict2file feature
+  - "fast" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_405/fuzzer.py
+++ b/fuzzers/aflplusplus_405/fuzzer.py
@@ -38,17 +38,17 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     build_modes = list(args)
     if 'BUILD_MODES' in os.environ:
-        build_modes = #os.environ['BUILD_MODES'].split(',')
+        build_modes = os.environ['BUILD_MODES'].split(',')
 
     # Placeholder comment.
-    build_directory = #os.environ['OUT']
+    build_directory = os.environ['OUT']
 
     # If nothing was set this is the default:
     if not build_modes:
         build_modes = ['tracepc', 'cmplog', 'dict2file']
 
     # For bug type benchmarks we have to instrument via native clang pcguard :(
-    build_flags = #os.environ['CFLAGS']
+    build_flags = os.environ['CFLAGS']
 
     if build_flags.find(
             'array-bounds'
@@ -58,115 +58,115 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     # Instrumentation coverage modes:
     if 'lto' in build_modes:
-        #os.environ['CC'] = '/afl/afl-clang-lto'
-        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        os.environ['CC'] = '/afl/afl-clang-lto'
+        os.environ['CXX'] = '/afl/afl-clang-lto++'
         edge_file = build_directory + '/aflpp_edges.txt'
-        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
         if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-13'
-            #os.environ['AR'] = 'llvm-ar-13'
-            #os.environ['AS'] = 'llvm-as-13'
+            os.environ['RANLIB'] = 'llvm-ranlib-13'
+            os.environ['AR'] = 'llvm-ar-13'
+            os.environ['AS'] = 'llvm-as-13'
         elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-12'
-            #os.environ['AR'] = 'llvm-ar-12'
-            #os.environ['AS'] = 'llvm-as-12'
+            os.environ['RANLIB'] = 'llvm-ranlib-12'
+            os.environ['AR'] = 'llvm-ar-12'
+            os.environ['AS'] = 'llvm-as-12'
         else:
-            #os.environ['RANLIB'] = 'llvm-ranlib'
-            #os.environ['AR'] = 'llvm-ar'
-            #os.environ['AS'] = 'llvm-as'
+            os.environ['RANLIB'] = 'llvm-ranlib'
+            os.environ['AR'] = 'llvm-ar'
+            os.environ['AS'] = 'llvm-as'
     elif 'qemu' in build_modes:
-        #os.environ['CC'] = 'clang'
-        #os.environ['CXX'] = 'clang++'
+        os.environ['CC'] = 'clang'
+        os.environ['CXX'] = 'clang++'
     elif 'gcc' in build_modes:
-        #os.environ['CC'] = 'afl-gcc-fast'
-        #os.environ['CXX'] = 'afl-g++-fast'
+        os.environ['CC'] = 'afl-gcc-fast'
+        os.environ['CXX'] = 'afl-g++-fast'
         if build_flags.find('array-bounds') != -1:
-            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
-            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
         else:
-            #os.environ['CFLAGS'] = ''
-            #os.environ['CXXFLAGS'] = ''
-            #os.environ['CPPFLAGS'] = ''
+            os.environ['CFLAGS'] = ''
+            os.environ['CXXFLAGS'] = ''
+            os.environ['CPPFLAGS'] = ''
     else:
-        #os.environ['CC'] = '/afl/afl-clang-fast'
-        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+        os.environ['CC'] = '/afl/afl-clang-fast'
+        os.environ['CXX'] = '/afl/afl-clang-fast++'
 
     print('AFL++ build: ')
     print(build_modes)
 
     if 'qemu' in build_modes or 'symcc' in build_modes:
-        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
         cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
-        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+        os.environ['CXXFLAGS'] = ' '.join(cxxflags)
 
     if 'tracepc' in build_modes or 'pcguard' in build_modes:
-        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+        os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
     elif 'classic' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
     elif 'native' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
 
     # Instrumentation coverage options:
     # Do not use a fixed map location (LTO only)
     if 'dynamic' in build_modes:
-        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+        os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
     # Use a fixed map location (LTO only)
     if 'fixed' in build_modes:
-        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+        os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
     # Generate an extra dictionary.
     if 'dict2file' in build_modes or 'native' in build_modes:
-        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
         #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
     # Enable context sentitivity for LLVM mode (non LTO only)
     if 'ctx' in build_modes:
-        #os.environ['AFL_LLVM_CTX'] = '1'
+        os.environ['AFL_LLVM_CTX'] = '1'
     # Enable N-gram coverage for LLVM mode (non LTO only)
     if 'ngram2' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
     elif 'ngram3' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
     elif 'ngram4' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
     elif 'ngram5' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
     elif 'ngram6' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
     elif 'ngram7' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
     elif 'ngram8' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
     elif 'ngram16' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
     if 'ctx1' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '1'
+        os.environ['AFL_LLVM_CTX_K'] = '1'
     elif 'ctx2' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '2'
+        os.environ['AFL_LLVM_CTX_K'] = '2'
     elif 'ctx3' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '3'
+        os.environ['AFL_LLVM_CTX_K'] = '3'
     elif 'ctx4' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '4'
+        os.environ['AFL_LLVM_CTX_K'] = '4'
 
     # Only one of the following OR cmplog
     # enable laf-intel compare splitting
     if 'laf' in build_modes:
-        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
         if 'autodict' not in build_modes:
-            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+            os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
 
     if 'eclipser' in build_modes:
-        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+        os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
     else:
-        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+        os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
 
     # Some benchmarks like lcms. (see:
     # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
     # fail to compile if the compiler outputs things to stderr in unexpected
     # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
     # from writing AFL specific messages to stderr.
-    #os.environ['AFL_QUIET'] = '1'
-    #os.environ['AFL_MAP_SIZE'] = '2621440'
+    os.environ['AFL_QUIET'] = '1'
+    os.environ['AFL_MAP_SIZE'] = '2621440'
 
     src = os.getenv('SRC')
     work = os.getenv('WORK')
@@ -253,8 +253,8 @@ def fuzz(input_corpus,
 
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     # decomment this to enable libdislocator.
-    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
-    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+    # os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
     flags = list(flags)
 
@@ -265,15 +265,16 @@ def fuzz(input_corpus,
     if os.path.exists(cmplog_target_binary) and no_cmplog is False:
         flags += ['-c', cmplog_target_binary]
 
-    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
-    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
-    #os.environ['AFL_FAST_CAL'] = '1'
+    #os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    os.environ['AFL_FAST_CAL'] = '1'
+    os.environ['AFL_NO_WARN_INSTABILITY'] = '1'
 
     if not skip:
-        #os.environ['AFL_DISABLE_TRIM'] = '1'
-        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        os.environ['AFL_DISABLE_TRIM'] = '1'
+        os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
         if 'ADDITIONAL_ARGS' in os.environ:
-            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+            flags += os.environ['ADDITIONAL_ARGS'].split(' ')
 
     afl_fuzzer.run_afl_fuzz(input_corpus,
                             output_corpus,

--- a/fuzzers/aflplusplus_405/fuzzer.py
+++ b/fuzzers/aflplusplus_405/fuzzer.py
@@ -1,0 +1,281 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration code for AFLplusplus fuzzer."""
+
+import os
+import shutil
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+from fuzzers import utils
+
+
+def get_cmplog_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'cmplog')
+
+
+def get_uninstrumented_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
+
+
+def build(*args):  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    # BUILD_MODES is not already supported by fuzzbench, meanwhile we provide
+    # a default configuration.
+
+    build_modes = list(args)
+    if 'BUILD_MODES' in os.environ:
+        build_modes = #os.environ['BUILD_MODES'].split(',')
+
+    # Placeholder comment.
+    build_directory = #os.environ['OUT']
+
+    # If nothing was set this is the default:
+    if not build_modes:
+        build_modes = ['tracepc', 'cmplog', 'dict2file']
+
+    # For bug type benchmarks we have to instrument via native clang pcguard :(
+    build_flags = #os.environ['CFLAGS']
+
+    if build_flags.find(
+            'array-bounds'
+    ) != -1 and 'qemu' not in build_modes and 'classic' not in build_modes:
+        if 'gcc' not in build_modes:
+            build_modes[0] = 'native'
+
+    # Instrumentation coverage modes:
+    if 'lto' in build_modes:
+        #os.environ['CC'] = '/afl/afl-clang-lto'
+        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        edge_file = build_directory + '/aflpp_edges.txt'
+        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-13'
+            #os.environ['AR'] = 'llvm-ar-13'
+            #os.environ['AS'] = 'llvm-as-13'
+        elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-12'
+            #os.environ['AR'] = 'llvm-ar-12'
+            #os.environ['AS'] = 'llvm-as-12'
+        else:
+            #os.environ['RANLIB'] = 'llvm-ranlib'
+            #os.environ['AR'] = 'llvm-ar'
+            #os.environ['AS'] = 'llvm-as'
+    elif 'qemu' in build_modes:
+        #os.environ['CC'] = 'clang'
+        #os.environ['CXX'] = 'clang++'
+    elif 'gcc' in build_modes:
+        #os.environ['CC'] = 'afl-gcc-fast'
+        #os.environ['CXX'] = 'afl-g++-fast'
+        if build_flags.find('array-bounds') != -1:
+            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+        else:
+            #os.environ['CFLAGS'] = ''
+            #os.environ['CXXFLAGS'] = ''
+            #os.environ['CPPFLAGS'] = ''
+    else:
+        #os.environ['CC'] = '/afl/afl-clang-fast'
+        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+
+    print('AFL++ build: ')
+    print(build_modes)
+
+    if 'qemu' in build_modes or 'symcc' in build_modes:
+        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
+        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+
+    if 'tracepc' in build_modes or 'pcguard' in build_modes:
+        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+    elif 'classic' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+    elif 'native' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+
+    # Instrumentation coverage options:
+    # Do not use a fixed map location (LTO only)
+    if 'dynamic' in build_modes:
+        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+    # Use a fixed map location (LTO only)
+    if 'fixed' in build_modes:
+        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+    # Generate an extra dictionary.
+    if 'dict2file' in build_modes or 'native' in build_modes:
+        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
+    # Enable context sentitivity for LLVM mode (non LTO only)
+    if 'ctx' in build_modes:
+        #os.environ['AFL_LLVM_CTX'] = '1'
+    # Enable N-gram coverage for LLVM mode (non LTO only)
+    if 'ngram2' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+    elif 'ngram3' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+    elif 'ngram4' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+    elif 'ngram5' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+    elif 'ngram6' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+    elif 'ngram7' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+    elif 'ngram8' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+    elif 'ngram16' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+    if 'ctx1' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '1'
+    elif 'ctx2' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '2'
+    elif 'ctx3' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '3'
+    elif 'ctx4' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '4'
+
+    # Only one of the following OR cmplog
+    # enable laf-intel compare splitting
+    if 'laf' in build_modes:
+        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        if 'autodict' not in build_modes:
+            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+
+    if 'eclipser' in build_modes:
+        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+    else:
+        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+
+    # Some benchmarks like lcms. (see:
+    # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
+    # fail to compile if the compiler outputs things to stderr in unexpected
+    # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
+    # from writing AFL specific messages to stderr.
+    #os.environ['AFL_QUIET'] = '1'
+    #os.environ['AFL_MAP_SIZE'] = '2621440'
+
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+
+    with utils.restore_directory(src), utils.restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        utils.build_benchmark()
+
+    if 'cmplog' in build_modes and 'qemu' not in build_modes:
+
+        # CmpLog requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['AFL_LLVM_CMPLOG'] = '1'
+
+        # For CmpLog build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new CmpLog build directory.
+        cmplog_build_directory = get_cmplog_build_directory(build_directory)
+        os.mkdir(cmplog_build_directory)
+        new_env['OUT'] = cmplog_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(cmplog_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for CmpLog fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    if 'symcc' in build_modes:
+
+        symcc_build_directory = get_uninstrumented_build_directory(
+            build_directory)
+        os.mkdir(symcc_build_directory)
+
+        # symcc requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['CC'] = '/symcc/build/symcc'
+        new_env['CXX'] = '/symcc/build/sym++'
+        new_env['SYMCC_OUTPUT_DIR'] = '/tmp'
+        new_env['CXXFLAGS'] = new_env['CXXFLAGS'].replace('-stlib=libc++', '')
+        new_env['FUZZER_LIB'] = '/libfuzzer-harness.o'
+        new_env['OUT'] = symcc_build_directory
+        new_env['SYMCC_LIBCXX_PATH'] = '/libcxx_native_build'
+        new_env['SYMCC_NO_SYMBOLIC_INPUT'] = '1'
+        new_env['SYMCC_SILENT'] = '1'
+
+        # For symcc build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new symcc build directory.
+        new_env['OUT'] = symcc_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(symcc_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for symcc fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    shutil.copy('/afl/afl-fuzz', build_directory)
+    if os.path.exists('/afl/afl-qemu-trace'):
+        shutil.copy('/afl/afl-qemu-trace', build_directory)
+    if os.path.exists('/aflpp_qemu_driver_hook.so'):
+        shutil.copy('/aflpp_qemu_driver_hook.so', build_directory)
+    if os.path.exists('/get_frida_entry.sh'):
+        shutil.copy('/afl/afl-frida-trace.so', build_directory)
+        shutil.copy('/get_frida_entry.sh', build_directory)
+
+
+# pylint: disable=too-many-arguments
+def fuzz(input_corpus,
+         output_corpus,
+         target_binary,
+         flags=tuple(),
+         skip=False,
+         no_cmplog=False):  # pylint: disable=too-many-arguments
+    """Run fuzzer."""
+    # Calculate CmpLog binary path from the instrumented target binary.
+    target_binary_directory = os.path.dirname(target_binary)
+    cmplog_target_binary_directory = (
+        get_cmplog_build_directory(target_binary_directory))
+    target_binary_name = os.path.basename(target_binary)
+    cmplog_target_binary = os.path.join(cmplog_target_binary_directory,
+                                        target_binary_name)
+
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+    # decomment this to enable libdislocator.
+    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+
+    flags = list(flags)
+
+    if os.path.exists('./afl++.dict'):
+        flags += ['-x', './afl++.dict']
+
+    # Move the following to skip for upcoming _double tests:
+    if os.path.exists(cmplog_target_binary) and no_cmplog is False:
+        flags += ['-c', cmplog_target_binary]
+
+    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    #os.environ['AFL_FAST_CAL'] = '1'
+
+    if not skip:
+        #os.environ['AFL_DISABLE_TRIM'] = '1'
+        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        if 'ADDITIONAL_ARGS' in os.environ:
+            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+
+    afl_fuzzer.run_afl_fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            additional_flags=flags)

--- a/fuzzers/aflplusplus_405/runner.Dockerfile
+++ b/fuzzers/aflplusplus_405/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/fuzzers/aflplusplus_406/builder.Dockerfile
+++ b/fuzzers/aflplusplus_406/builder.Dockerfile
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        python3-dev \
+        python3-setuptools \
+        automake \
+        cmake \
+        git \
+        flex \
+        bison \
+        libglib2.0-dev \
+        libpixman-1-dev \
+        cargo \
+        libgtk-3-dev \
+        # for QEMU mode
+        ninja-build \
+        gcc-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-plugin-dev \
+        libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
+
+# Download afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus /afl && \
+    cd /afl && \
+    git checkout b2f9802f9f0f54337c552d83a860f3e1a84d7191 || \
+    true
+
+RUN apt install -y lsb-release wget software-properties-common gnupg
+
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13
+
+ENV LLVM_CONFIG llvm-config-13
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && \
+    unset CFLAGS CXXFLAGS && \
+    export CC=clang AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /

--- a/fuzzers/aflplusplus_406/description.md
+++ b/fuzzers/aflplusplus_406/description.md
@@ -1,0 +1,14 @@
+# aflplusplus
+
+AFL++ fuzzer instance that has the following config active for all benchmarks:
+  - PCGUARD instrumentation 
+  - cmplog feature
+  - dict2file feature
+  - "fast" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_406/fuzzer.py
+++ b/fuzzers/aflplusplus_406/fuzzer.py
@@ -38,17 +38,17 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     build_modes = list(args)
     if 'BUILD_MODES' in os.environ:
-        build_modes = #os.environ['BUILD_MODES'].split(',')
+        build_modes = os.environ['BUILD_MODES'].split(',')
 
     # Placeholder comment.
-    build_directory = #os.environ['OUT']
+    build_directory = os.environ['OUT']
 
     # If nothing was set this is the default:
     if not build_modes:
         build_modes = ['tracepc', 'cmplog', 'dict2file']
 
     # For bug type benchmarks we have to instrument via native clang pcguard :(
-    build_flags = #os.environ['CFLAGS']
+    build_flags = os.environ['CFLAGS']
 
     if build_flags.find(
             'array-bounds'
@@ -58,115 +58,115 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
 
     # Instrumentation coverage modes:
     if 'lto' in build_modes:
-        #os.environ['CC'] = '/afl/afl-clang-lto'
-        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        os.environ['CC'] = '/afl/afl-clang-lto'
+        os.environ['CXX'] = '/afl/afl-clang-lto++'
         edge_file = build_directory + '/aflpp_edges.txt'
-        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
         if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-13'
-            #os.environ['AR'] = 'llvm-ar-13'
-            #os.environ['AS'] = 'llvm-as-13'
+            os.environ['RANLIB'] = 'llvm-ranlib-13'
+            os.environ['AR'] = 'llvm-ar-13'
+            os.environ['AS'] = 'llvm-as-13'
         elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
-            #os.environ['RANLIB'] = 'llvm-ranlib-12'
-            #os.environ['AR'] = 'llvm-ar-12'
-            #os.environ['AS'] = 'llvm-as-12'
+            os.environ['RANLIB'] = 'llvm-ranlib-12'
+            os.environ['AR'] = 'llvm-ar-12'
+            os.environ['AS'] = 'llvm-as-12'
         else:
-            #os.environ['RANLIB'] = 'llvm-ranlib'
-            #os.environ['AR'] = 'llvm-ar'
-            #os.environ['AS'] = 'llvm-as'
+            os.environ['RANLIB'] = 'llvm-ranlib'
+            os.environ['AR'] = 'llvm-ar'
+            os.environ['AS'] = 'llvm-as'
     elif 'qemu' in build_modes:
-        #os.environ['CC'] = 'clang'
-        #os.environ['CXX'] = 'clang++'
+        os.environ['CC'] = 'clang'
+        os.environ['CXX'] = 'clang++'
     elif 'gcc' in build_modes:
-        #os.environ['CC'] = 'afl-gcc-fast'
-        #os.environ['CXX'] = 'afl-g++-fast'
+        os.environ['CC'] = 'afl-gcc-fast'
+        os.environ['CXX'] = 'afl-g++-fast'
         if build_flags.find('array-bounds') != -1:
-            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
-            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
         else:
-            #os.environ['CFLAGS'] = ''
-            #os.environ['CXXFLAGS'] = ''
-            #os.environ['CPPFLAGS'] = ''
+            os.environ['CFLAGS'] = ''
+            os.environ['CXXFLAGS'] = ''
+            os.environ['CPPFLAGS'] = ''
     else:
-        #os.environ['CC'] = '/afl/afl-clang-fast'
-        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+        os.environ['CC'] = '/afl/afl-clang-fast'
+        os.environ['CXX'] = '/afl/afl-clang-fast++'
 
     print('AFL++ build: ')
     print(build_modes)
 
     if 'qemu' in build_modes or 'symcc' in build_modes:
-        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
         cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
-        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+        os.environ['CXXFLAGS'] = ' '.join(cxxflags)
 
     if 'tracepc' in build_modes or 'pcguard' in build_modes:
-        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+        os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
     elif 'classic' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
     elif 'native' in build_modes:
-        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+        os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
 
     # Instrumentation coverage options:
     # Do not use a fixed map location (LTO only)
     if 'dynamic' in build_modes:
-        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+        os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
     # Use a fixed map location (LTO only)
     if 'fixed' in build_modes:
-        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+        os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
     # Generate an extra dictionary.
     if 'dict2file' in build_modes or 'native' in build_modes:
-        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
         #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
     # Enable context sentitivity for LLVM mode (non LTO only)
     if 'ctx' in build_modes:
-        #os.environ['AFL_LLVM_CTX'] = '1'
+        os.environ['AFL_LLVM_CTX'] = '1'
     # Enable N-gram coverage for LLVM mode (non LTO only)
     if 'ngram2' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
     elif 'ngram3' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
     elif 'ngram4' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
     elif 'ngram5' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
     elif 'ngram6' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
     elif 'ngram7' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
     elif 'ngram8' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
     elif 'ngram16' in build_modes:
-        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+        os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
     if 'ctx1' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '1'
+        os.environ['AFL_LLVM_CTX_K'] = '1'
     elif 'ctx2' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '2'
+        os.environ['AFL_LLVM_CTX_K'] = '2'
     elif 'ctx3' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '3'
+        os.environ['AFL_LLVM_CTX_K'] = '3'
     elif 'ctx4' in build_modes:
-        #os.environ['AFL_LLVM_CTX_K'] = '4'
+        os.environ['AFL_LLVM_CTX_K'] = '4'
 
     # Only one of the following OR cmplog
     # enable laf-intel compare splitting
     if 'laf' in build_modes:
-        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
-        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
         if 'autodict' not in build_modes:
-            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+            os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
 
     if 'eclipser' in build_modes:
-        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+        os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
     else:
-        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+        os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
 
     # Some benchmarks like lcms. (see:
     # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
     # fail to compile if the compiler outputs things to stderr in unexpected
     # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
     # from writing AFL specific messages to stderr.
-    #os.environ['AFL_QUIET'] = '1'
-    #os.environ['AFL_MAP_SIZE'] = '2621440'
+    os.environ['AFL_QUIET'] = '1'
+    os.environ['AFL_MAP_SIZE'] = '2621440'
 
     src = os.getenv('SRC')
     work = os.getenv('WORK')
@@ -253,8 +253,8 @@ def fuzz(input_corpus,
 
     afl_fuzzer.prepare_fuzz_environment(input_corpus)
     # decomment this to enable libdislocator.
-    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
-    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+    # os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
     flags = list(flags)
 
@@ -265,15 +265,16 @@ def fuzz(input_corpus,
     if os.path.exists(cmplog_target_binary) and no_cmplog is False:
         flags += ['-c', cmplog_target_binary]
 
-    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
-    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
-    #os.environ['AFL_FAST_CAL'] = '1'
+    #os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    os.environ['AFL_FAST_CAL'] = '1'
+    os.environ['AFL_NO_WARN_INSTABILITY'] = '1'
 
     if not skip:
-        #os.environ['AFL_DISABLE_TRIM'] = '1'
-        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        os.environ['AFL_DISABLE_TRIM'] = '1'
+        os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
         if 'ADDITIONAL_ARGS' in os.environ:
-            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+            flags += os.environ['ADDITIONAL_ARGS'].split(' ')
 
     afl_fuzzer.run_afl_fuzz(input_corpus,
                             output_corpus,

--- a/fuzzers/aflplusplus_406/fuzzer.py
+++ b/fuzzers/aflplusplus_406/fuzzer.py
@@ -1,0 +1,281 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration code for AFLplusplus fuzzer."""
+
+import os
+import shutil
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+from fuzzers import utils
+
+
+def get_cmplog_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'cmplog')
+
+
+def get_uninstrumented_build_directory(target_directory):
+    """Return path to CmpLog target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
+
+
+def build(*args):  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    # BUILD_MODES is not already supported by fuzzbench, meanwhile we provide
+    # a default configuration.
+
+    build_modes = list(args)
+    if 'BUILD_MODES' in os.environ:
+        build_modes = #os.environ['BUILD_MODES'].split(',')
+
+    # Placeholder comment.
+    build_directory = #os.environ['OUT']
+
+    # If nothing was set this is the default:
+    if not build_modes:
+        build_modes = ['tracepc', 'cmplog', 'dict2file']
+
+    # For bug type benchmarks we have to instrument via native clang pcguard :(
+    build_flags = #os.environ['CFLAGS']
+
+    if build_flags.find(
+            'array-bounds'
+    ) != -1 and 'qemu' not in build_modes and 'classic' not in build_modes:
+        if 'gcc' not in build_modes:
+            build_modes[0] = 'native'
+
+    # Instrumentation coverage modes:
+    if 'lto' in build_modes:
+        #os.environ['CC'] = '/afl/afl-clang-lto'
+        #os.environ['CXX'] = '/afl/afl-clang-lto++'
+        edge_file = build_directory + '/aflpp_edges.txt'
+        #os.environ['AFL_LLVM_DOCUMENT_IDS'] = edge_file
+        if os.path.isfile('/usr/local/bin/llvm-ranlib-13'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-13'
+            #os.environ['AR'] = 'llvm-ar-13'
+            #os.environ['AS'] = 'llvm-as-13'
+        elif os.path.isfile('/usr/local/bin/llvm-ranlib-12'):
+            #os.environ['RANLIB'] = 'llvm-ranlib-12'
+            #os.environ['AR'] = 'llvm-ar-12'
+            #os.environ['AS'] = 'llvm-as-12'
+        else:
+            #os.environ['RANLIB'] = 'llvm-ranlib'
+            #os.environ['AR'] = 'llvm-ar'
+            #os.environ['AS'] = 'llvm-as'
+    elif 'qemu' in build_modes:
+        #os.environ['CC'] = 'clang'
+        #os.environ['CXX'] = 'clang++'
+    elif 'gcc' in build_modes:
+        #os.environ['CC'] = 'afl-gcc-fast'
+        #os.environ['CXX'] = 'afl-g++-fast'
+        if build_flags.find('array-bounds') != -1:
+            #os.environ['CFLAGS'] = '-fsanitize=address -O1'
+            #os.environ['CXXFLAGS'] = '-fsanitize=address -O1'
+        else:
+            #os.environ['CFLAGS'] = ''
+            #os.environ['CXXFLAGS'] = ''
+            #os.environ['CPPFLAGS'] = ''
+    else:
+        #os.environ['CC'] = '/afl/afl-clang-fast'
+        #os.environ['CXX'] = '/afl/afl-clang-fast++'
+
+    print('AFL++ build: ')
+    print(build_modes)
+
+    if 'qemu' in build_modes or 'symcc' in build_modes:
+        #os.environ['CFLAGS'] = ' '.join(utils.NO_SANITIZER_COMPAT_CFLAGS)
+        cxxflags = [utils.LIBCPLUSPLUS_FLAG] + utils.NO_SANITIZER_COMPAT_CFLAGS
+        #os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+
+    if 'tracepc' in build_modes or 'pcguard' in build_modes:
+        #os.environ['AFL_LLVM_USE_TRACE_PC'] = '1'
+    elif 'classic' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'CLASSIC'
+    elif 'native' in build_modes:
+        #os.environ['AFL_LLVM_INSTRUMENT'] = 'LLVMNATIVE'
+
+    # Instrumentation coverage options:
+    # Do not use a fixed map location (LTO only)
+    if 'dynamic' in build_modes:
+        #os.environ['AFL_LLVM_MAP_DYNAMIC'] = '1'
+    # Use a fixed map location (LTO only)
+    if 'fixed' in build_modes:
+        #os.environ['AFL_LLVM_MAP_ADDR'] = '0x10000'
+    # Generate an extra dictionary.
+    if 'dict2file' in build_modes or 'native' in build_modes:
+        #os.environ['AFL_LLVM_DICT2FILE'] = build_directory + '/afl++.dict'
+        #os.environ['AFL_LLVM_DICT2FILE_NO_MAIN'] = '1'
+    # Enable context sentitivity for LLVM mode (non LTO only)
+    if 'ctx' in build_modes:
+        #os.environ['AFL_LLVM_CTX'] = '1'
+    # Enable N-gram coverage for LLVM mode (non LTO only)
+    if 'ngram2' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '2'
+    elif 'ngram3' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '3'
+    elif 'ngram4' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '4'
+    elif 'ngram5' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '5'
+    elif 'ngram6' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '6'
+    elif 'ngram7' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '7'
+    elif 'ngram8' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '8'
+    elif 'ngram16' in build_modes:
+        #os.environ['AFL_LLVM_NGRAM_SIZE'] = '16'
+    if 'ctx1' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '1'
+    elif 'ctx2' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '2'
+    elif 'ctx3' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '3'
+    elif 'ctx4' in build_modes:
+        #os.environ['AFL_LLVM_CTX_K'] = '4'
+
+    # Only one of the following OR cmplog
+    # enable laf-intel compare splitting
+    if 'laf' in build_modes:
+        #os.environ['AFL_LLVM_LAF_SPLIT_SWITCHES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_COMPARES'] = '1'
+        #os.environ['AFL_LLVM_LAF_SPLIT_FLOATS'] = '1'
+        if 'autodict' not in build_modes:
+            #os.environ['AFL_LLVM_LAF_TRANSFORM_COMPARES'] = '1'
+
+    if 'eclipser' in build_modes:
+        #os.environ['FUZZER_LIB'] = '/libStandaloneFuzzTarget.a'
+    else:
+        #os.environ['FUZZER_LIB'] = '/libAFLDriver.a'
+
+    # Some benchmarks like lcms. (see:
+    # https://github.com/mm2/Little-CMS/commit/ab1093539b4287c233aca6a3cf53b234faceb792#diff-f0e6d05e72548974e852e8e55dffc4ccR212)
+    # fail to compile if the compiler outputs things to stderr in unexpected
+    # cases. Prevent these failures by using AFL_QUIET to stop afl-clang-fast
+    # from writing AFL specific messages to stderr.
+    #os.environ['AFL_QUIET'] = '1'
+    #os.environ['AFL_MAP_SIZE'] = '2621440'
+
+    src = os.getenv('SRC')
+    work = os.getenv('WORK')
+
+    with utils.restore_directory(src), utils.restore_directory(work):
+        # Restore SRC to its initial state so we can build again without any
+        # trouble. For some OSS-Fuzz projects, build_benchmark cannot be run
+        # twice in the same directory without this.
+        utils.build_benchmark()
+
+    if 'cmplog' in build_modes and 'qemu' not in build_modes:
+
+        # CmpLog requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['AFL_LLVM_CMPLOG'] = '1'
+
+        # For CmpLog build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new CmpLog build directory.
+        cmplog_build_directory = get_cmplog_build_directory(build_directory)
+        os.mkdir(cmplog_build_directory)
+        new_env['OUT'] = cmplog_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(cmplog_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for CmpLog fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    if 'symcc' in build_modes:
+
+        symcc_build_directory = get_uninstrumented_build_directory(
+            build_directory)
+        os.mkdir(symcc_build_directory)
+
+        # symcc requires an build with different instrumentation.
+        new_env = os.environ.copy()
+        new_env['CC'] = '/symcc/build/symcc'
+        new_env['CXX'] = '/symcc/build/sym++'
+        new_env['SYMCC_OUTPUT_DIR'] = '/tmp'
+        new_env['CXXFLAGS'] = new_env['CXXFLAGS'].replace('-stlib=libc++', '')
+        new_env['FUZZER_LIB'] = '/libfuzzer-harness.o'
+        new_env['OUT'] = symcc_build_directory
+        new_env['SYMCC_LIBCXX_PATH'] = '/libcxx_native_build'
+        new_env['SYMCC_NO_SYMBOLIC_INPUT'] = '1'
+        new_env['SYMCC_SILENT'] = '1'
+
+        # For symcc build, set the OUT and FUZZ_TARGET environment
+        # variable to point to the new symcc build directory.
+        new_env['OUT'] = symcc_build_directory
+        fuzz_target = os.getenv('FUZZ_TARGET')
+        if fuzz_target:
+            new_env['FUZZ_TARGET'] = os.path.join(symcc_build_directory,
+                                                  os.path.basename(fuzz_target))
+
+        print('Re-building benchmark for symcc fuzzing target')
+        utils.build_benchmark(env=new_env)
+
+    shutil.copy('/afl/afl-fuzz', build_directory)
+    if os.path.exists('/afl/afl-qemu-trace'):
+        shutil.copy('/afl/afl-qemu-trace', build_directory)
+    if os.path.exists('/aflpp_qemu_driver_hook.so'):
+        shutil.copy('/aflpp_qemu_driver_hook.so', build_directory)
+    if os.path.exists('/get_frida_entry.sh'):
+        shutil.copy('/afl/afl-frida-trace.so', build_directory)
+        shutil.copy('/get_frida_entry.sh', build_directory)
+
+
+# pylint: disable=too-many-arguments
+def fuzz(input_corpus,
+         output_corpus,
+         target_binary,
+         flags=tuple(),
+         skip=False,
+         no_cmplog=False):  # pylint: disable=too-many-arguments
+    """Run fuzzer."""
+    # Calculate CmpLog binary path from the instrumented target binary.
+    target_binary_directory = os.path.dirname(target_binary)
+    cmplog_target_binary_directory = (
+        get_cmplog_build_directory(target_binary_directory))
+    target_binary_name = os.path.basename(target_binary)
+    cmplog_target_binary = os.path.join(cmplog_target_binary_directory,
+                                        target_binary_name)
+
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+    # decomment this to enable libdislocator.
+    # #os.environ['AFL_ALIGNED_ALLOC'] = '1' # align malloc to max_align_t
+    # #os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
+
+    flags = list(flags)
+
+    if os.path.exists('./afl++.dict'):
+        flags += ['-x', './afl++.dict']
+
+    # Move the following to skip for upcoming _double tests:
+    if os.path.exists(cmplog_target_binary) and no_cmplog is False:
+        flags += ['-c', cmplog_target_binary]
+
+    ##os.environ['AFL_IGNORE_TIMEOUTS'] = '1'
+    #os.environ['AFL_IGNORE_UNKNOWN_ENVS'] = '1'
+    #os.environ['AFL_FAST_CAL'] = '1'
+
+    if not skip:
+        #os.environ['AFL_DISABLE_TRIM'] = '1'
+        #os.environ['AFL_CMPLOG_ONLY_NEW'] = '1'
+        if 'ADDITIONAL_ARGS' in os.environ:
+            flags += #os.environ['ADDITIONAL_ARGS'].split(' ')
+
+    afl_fuzzer.run_afl_fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            additional_flags=flags)

--- a/fuzzers/aflplusplus_406/runner.Dockerfile
+++ b/fuzzers/aflplusplus_406/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -20,7 +20,7 @@
 # Please add new experiment requests towards the top of this file.
 #
 
-- experiment: 2023-03-25-aflpp_comp
+- experiment: 2023-03-25-aflpp-comp
   description: "Tests main fuzzers"
   fuzzers:
     - aflplusplus

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -20,6 +20,33 @@
 # Please add new experiment requests towards the top of this file.
 #
 
+- experiment: 2023-03-25-aflpp_comp
+  description: "Tests main fuzzers"
+  fuzzers:
+    - aflplusplus
+    - aflplusplus_313
+    - aflplusplus_314
+    - aflplusplus_400
+    - aflplusplus_401
+    - aflplusplus_402
+    - aflplusplus_403
+    - aflplusplus_404
+    - aflplusplus_405
+    - aflplusplus_406
+  benchmarks:
+    - bloaty_fuzz_target
+    - curl_curl_fuzzer_http
+    - freetype2_ftfuzzer
+    - lcms_cms_transform_fuzzer
+    - libpcap_fuzz_both
+    - libxml2_xml
+    - mbedtls_fuzz_dtlsclient
+    - openthread_ot-ip6-send-fuzzer
+    - proj4_proj_crs_to_crs_fuzzer
+    - sqlite3_ossfuzz
+    - stb_stbi_read_fuzzer
+    - woff2_convert_woff2ttf_fuzzer
+
 - experiment: 2023-03-24-main
   description: "Tests main fuzzers"
   fuzzers:


### PR DESCRIPTION
This run https://www.fuzzbench.com/reports/experimental/2023-03-23-various/index.html
showed that v3.14c has a better performance than the current 4.06a which is baffling. The difference is huge!

so this experiment tests all afl++ versions starting with 3.13 up to current with the same llvm version (it needs version 13 because 3.14 is obviously not updated to current llvm changes).

It might be the llvm version it might be something else ... no clue, I need more data.
Curous that this did not come up earlier as I test this rigorously before a release.

