### PR TITLE
Fix bad link in documentation.

### DIFF
--- a/docs/running-a-cloud-experiment/setting_up_a_google_cloud_project.md
+++ b/docs/running-a-cloud-experiment/setting_up_a_google_cloud_project.md
@@ -193,4 +193,4 @@ reasonable amount of time.
 
 ## Run an experiment
 
-* Follow the [guide on running an experiment]({{ site.baseurl }}/running-your-own-experiment/running-an-experiment/)
+* Follow the [guide on running an experiment]({{ site.baseurl }}/running-a-cloud-experiment/running-an-experiment/)


### PR DESCRIPTION
The last link in the ["Setting up a cloud project"](https://google.github.io/fuzzbench/running-a-cloud-experiment/setting-up-a-google-cloud-project/) docs was wrong.