### PR TITLE
Support non-alphanumeric passwords in alembic.

### DIFF
--- a/database/alembic/env.py
+++ b/database/alembic/env.py
@@ -15,6 +15,7 @@
 
 from logging.config import fileConfig
 import os
+import urllib.parse
 
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
@@ -27,9 +28,9 @@ config = context.config
 
 DATABASE_URL = (
     'postgresql+psycopg2://postgres:{password}@127.0.0.1:5432'.format(
-        password=os.environ['POSTGRES_PASSWORD']))
+        password=urllib.parse.quote_plus(os.environ['POSTGRES_PASSWORD'])))
 
-config.set_main_option('sqlalchemy.url', DATABASE_URL)
+config.set_main_option('sqlalchemy.url', DATABASE_URL.replace('%', '%%'))
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.


### PR DESCRIPTION
This commit modifies alembic's `env.py`, so that it supports non-alphanumeric passwords.

The script creates an url to connect to the database, but the passworld was not url-escaped. Passwords with characters like `@`, `:` and `.` were causing failures.

The password is set as a config in sqlalchemy, which uses python's string interpolation. Now we replace instances of `%` with `%%` so that passwords that contain `%` can be used.

Fixes issue #1801