### PR TITLE
Fix error message in stop-experiment.py

### DIFF
--- a/experiment/stop_experiment.py
+++ b/experiment/stop_experiment.py
@@ -67,7 +67,7 @@ def stop_experiment(experiment_name, experiment_config_filename):
 def main():
     """Stop the experiment."""
     if len(sys.argv) != 3:
-        print('Usage {0} <experiment-name> <experiment-config.yaml>')
+        print(f'Usage {sys.argv[0]} <experiment-name> <experiment-config.yaml>')
         return 1
     logs.initialize()
     return 0 if stop_experiment(sys.argv[1], sys.argv[2]) else 1


### PR DESCRIPTION
It now prints the name of the script instead of `{0}`