### PR TITLE
Remove items that only contain space in gcb commands

### DIFF
--- a/service/gcbrun_experiment.py
+++ b/service/gcbrun_experiment.py
@@ -57,7 +57,10 @@ def get_latest_gcbrun_command(comments):
             continue
         if len(body) == len(RUN_EXPERIMENT_COMMAND_STR):
             return None
-        return body[len(RUN_EXPERIMENT_COMMAND_STR):].strip().split(' ')
+        command = body[len(RUN_EXPERIMENT_COMMAND_STR):].strip().split(' ')
+        # Items that only contain space are redundant and will confuse
+        # `run_experiment_main()` in `experiment/run_experiment.py`
+        return [word for word in command if word.strip()]
     return None
 
 


### PR DESCRIPTION
Fixes a known issues that affects many experiment requests, e.g., [this one](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/b1915f08-70ac-4321-ae45-38b45da07e70;step=1?project=fuzzbench) in #1859.  
