### PR TITLE
Fix a case where `fuzz_target_path` is mysteriously None

### DIFF
--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -95,6 +95,8 @@ def _clean_seed_corpus(seed_corpus_dir):
 def get_clusterfuzz_seed_corpus_path(fuzz_target_path):
     """Returns the path of the clusterfuzz seed corpus archive if one exists.
     Otherwise returns None."""
+    if fuzz_target_path is None:
+        return None
     fuzz_target_without_extension = os.path.splitext(fuzz_target_path)[0]
     seed_corpus_path = (fuzz_target_without_extension +
                         SEED_CORPUS_ARCHIVE_SUFFIX)


### PR DESCRIPTION
This was observed in [this experiment](https://github.com/google/fuzzbench/pull/1880#issuecomment-1681602328). Here is [the error log](https://pantheon.corp.google.com/logs/query;cursorTimestamp=2023-08-17T12:43:22.568776528Z;endTime=2023-08-21T01:38:11.678Z;query=jsonPayload.experiment%3D%222023-08-04-sfuzz%22%0AjsonPayload.benchmark%3D%22woff2_convert_woff2ttf_fuzzer%22%0Aseverity%3E%3DWARNING%0AjsonPayload.message!%3D%22Corpus%20not%20found%20for%20cycle:%200.%22%0Atimestamp%3D%222023-08-17T12:43:18.463572869Z%22%0AinsertId%3D%2218yfmbdffhas18%22;startTime=2023-08-16T01:38:11.678Z?project=fuzzbench):
```
Traceback (most recent call last):
  File "/src/experiment/runner.py", line 454, in experiment_main
    runner.conduct_trial()
  File "/src/experiment/runner.py", line 276, in conduct_trial
    self.set_up_corpus_directories()
  File "/src/experiment/runner.py", line 261, in set_up_corpus_directories
    _unpack_clusterfuzz_seed_corpus(target_binary, input_corpus)
  File "/src/experiment/runner.py", line 132, in _unpack_clusterfuzz_seed_corpus
    seed_corpus_archive_path = get_clusterfuzz_seed_corpus_path(
  File "/src/experiment/runner.py", line 98, in get_clusterfuzz_seed_corpus_path
    fuzz_target_without_extension = os.path.splitext(fuzz_target_path)[0]
  File "/usr/local/lib/python3.10/posixpath.py", line 118, in splitext
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

I could not reproduce this error locally, but this PR should fix the error.
