### PR TITLE
Update libafl_libfuzzer

### DIFF
--- a/fuzzers/libafl_libfuzzer/builder.Dockerfile
+++ b/fuzzers/libafl_libfuzzer/builder.Dockerfile
@@ -32,11 +32,9 @@ RUN if which rustup; then rustup self uninstall -y; fi && \
     rm /rustup.sh
 
 # Download libafl.
-RUN git clone \
-        --branch libfuzzer-publish && \
-        https://github.com/AFLplusplus/libafl /libafl && \
+RUN git clone https://github.com/AFLplusplus/libafl /libafl && \
     cd /libafl && \
-    git checkout c66f4bac88ba6323f4435b0b3d25ee69db7ae70e && \
+    git checkout defe9084aed5a80ac32fe9a1f3ff00baf97738c6 && \
     unset CFLAGS CXXFLAGS && \
     export LIBAFL_EDGES_MAP_SIZE=2621440 && \
     cd ./libafl_libfuzzer/libafl_libfuzzer_runtime && \

--- a/fuzzers/libafl_libfuzzer/builder.Dockerfile
+++ b/fuzzers/libafl_libfuzzer/builder.Dockerfile
@@ -28,15 +28,14 @@ RUN apt-get update && \
 # Uninstall old Rust & Install the latest one.
 RUN if which rustup; then rustup self uninstall -y; fi && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /rustup.sh && \
-    sh /rustup.sh --default-toolchain nightly -y && \
+    sh /rustup.sh --default-toolchain nightly-2023-08-23 -y && \
     rm /rustup.sh
 
 # Download libafl.
 RUN git clone \
-        --branch libfuzzer \
         https://github.com/AFLplusplus/libafl /libafl && \
     cd /libafl && \
-    git checkout d31f82387d1d233771ff1e13ef7e49cdb508410f && \
+    git checkout 920853195104845bd6b31e5a2dbdcde2c1472c08 && \
     unset CFLAGS CXXFLAGS && \
     export LIBAFL_EDGES_MAP_SIZE=2621440 && \
     cd ./libafl_libfuzzer/libafl_libfuzzer_runtime && \

--- a/fuzzers/libafl_libfuzzer/builder.Dockerfile
+++ b/fuzzers/libafl_libfuzzer/builder.Dockerfile
@@ -33,11 +33,12 @@ RUN if which rustup; then rustup self uninstall -y; fi && \
 
 # Download libafl.
 RUN git clone \
+        --branch libfuzzer-publish && \
         https://github.com/AFLplusplus/libafl /libafl && \
     cd /libafl && \
-    git checkout 920853195104845bd6b31e5a2dbdcde2c1472c08 && \
+    git checkout c66f4bac88ba6323f4435b0b3d25ee69db7ae70e && \
     unset CFLAGS CXXFLAGS && \
     export LIBAFL_EDGES_MAP_SIZE=2621440 && \
     cd ./libafl_libfuzzer/libafl_libfuzzer_runtime && \
-    env -i CXX=$CXX CC=$CC PATH="/root/.cargo/bin/:$PATH" cargo build --release && \
+    env -i CXX=$CXX CC=$CC PATH="/root/.cargo/bin/:$PATH" cargo build --profile release-fuzzbench && \
     cp ./target/release/libafl_libfuzzer_runtime.a /usr/lib/libFuzzer.a

--- a/fuzzers/libafl_libfuzzer/builder.Dockerfile
+++ b/fuzzers/libafl_libfuzzer/builder.Dockerfile
@@ -39,5 +39,5 @@ RUN git clone \
     unset CFLAGS CXXFLAGS && \
     export LIBAFL_EDGES_MAP_SIZE=2621440 && \
     cd ./libafl_libfuzzer/libafl_libfuzzer_runtime && \
-    env -i CXX=$CXX CC=$CC PATH="/root/.cargo/bin/:$PATH" cargo build --release --no-default-features && \
+    env -i CXX=$CXX CC=$CC PATH="/root/.cargo/bin/:$PATH" cargo build --release && \
     cp ./target/release/libafl_libfuzzer_runtime.a /usr/lib/libFuzzer.a

--- a/fuzzers/libafl_libfuzzer/builder.Dockerfile
+++ b/fuzzers/libafl_libfuzzer/builder.Dockerfile
@@ -39,4 +39,4 @@ RUN git clone https://github.com/AFLplusplus/libafl /libafl && \
     export LIBAFL_EDGES_MAP_SIZE=2621440 && \
     cd ./libafl_libfuzzer/libafl_libfuzzer_runtime && \
     env -i CXX=$CXX CC=$CC PATH="/root/.cargo/bin/:$PATH" cargo build --profile release-fuzzbench && \
-    cp ./target/release/libafl_libfuzzer_runtime.a /usr/lib/libFuzzer.a
+    cp ./target/release-fuzzbench/libafl_libfuzzer_runtime.a /usr/lib/libFuzzer.a


### PR DESCRIPTION
We recently updated libafl_libfuzzer in a lot of ways. This fetches the current "release" revision and pins the Rust version.