### PR TITLE
Allow disabling `merge-with-nonprivate` in command line args

### DIFF
--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -300,7 +300,8 @@ def start_experiment(  # pylint: disable=too-many-arguments
         measurers_cpus: Optional[int] = None,
         runners_cpus: Optional[int] = None,
         region_coverage: bool = False,
-        custom_seed_corpus_dir: Optional[str] = None):
+        custom_seed_corpus_dir: Optional[str] = None,
+        merge_with_nonprivate: bool = True):
     """Start a fuzzer benchmarking experiment."""
     if not allow_uncommitted_changes:
         check_no_uncommitted_changes()
@@ -335,6 +336,7 @@ def start_experiment(  # pylint: disable=too-many-arguments
     if config['custom_seed_corpus_dir']:
         validate_custom_seed_corpus(config['custom_seed_corpus_dir'],
                                     benchmarks)
+    config['merge_with_nonprivate'] = merge_with_nonprivate
 
     return start_experiment_from_full_config(config)
 
@@ -694,6 +696,12 @@ def run_experiment_main(args=None):
         required=False,
         default=False,
         action='store_true')
+    parser.add_argument('-nm',
+                        '--no-merge-with-nonprivate',
+                        help='Do not merge past public experiment results',
+                        required=False,
+                        default=False,
+                        action='store_true')
     args = parser.parse_args(args)
     fuzzers = args.fuzzers or all_fuzzers
 
@@ -745,7 +753,8 @@ def run_experiment_main(args=None):
                      measurers_cpus=measurers_cpus,
                      runners_cpus=runners_cpus,
                      region_coverage=args.region_coverage,
-                     custom_seed_corpus_dir=args.custom_seed_corpus_dir)
+                     custom_seed_corpus_dir=args.custom_seed_corpus_dir,
+                     merge_with_nonprivate=not args.no_merge_with_nonprivate)
     return 0
 
 

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -27,18 +27,9 @@ from typing import Dict, List, Optional, Union
 
 import jinja2
 import yaml
-
-from common import benchmark_utils
-from common import experiment_utils
-from common import filestore_utils
-from common import filesystem
-from common import fuzzer_utils
-from common import gcloud
-from common import gsutil
-from common import logs
-from common import new_process
-from common import utils
-from common import yaml_utils
+from common import (benchmark_utils, experiment_utils, filestore_utils,
+                    filesystem, fuzzer_utils, gcloud, gsutil, logs,
+                    new_process, utils, yaml_utils)
 
 BENCHMARKS_DIR = os.path.join(utils.ROOT_DIR, 'benchmarks')
 FUZZERS_DIR = os.path.join(utils.ROOT_DIR, 'fuzzers')
@@ -726,8 +717,9 @@ def run_experiment_main(args=None):
                      f'{measurers_cpus}) you need to specify the runners cpus '
                      'argument too.')
 
-    if (runners_cpus if runners_cpus else 0) + (measurers_cpus if measurers_cpus
-                                                else 0) > os.cpu_count():
+    cpu_count = os.cpu_count()
+    if cpu_count and (runners_cpus if runners_cpus else 0) + (
+            measurers_cpus if measurers_cpus else 0) > cpu_count:
         parser.error(f'The sum of runners ({runners_cpus}) and measurers cpus '
                      f'({measurers_cpus}) is greater than the available cpu '
                      f'cores (os.cpu_count()).')


### PR DESCRIPTION
This makes it convenient to disable the config when running experiments under GitHub PRs:
People don't have to commit the config change before experiments and revert it before merging.

For example: 
1. https://github.com/google/fuzzbench/pull/1937/commits/35c164957a3139255705ab98e488e21bd572452f
2. https://github.com/google/fuzzbench/pull/1928/commits/d6a9a3396d4a4ae8f07b32d6fea282b75d238199