### PR TITLE
Fix log in retry wrap

### DIFF
--- a/common/retry.py
+++ b/common/retry.py
@@ -67,9 +67,10 @@ def wrap(  # pylint: disable=too-many-arguments
                 sleep(get_delay(num_try, delay, backoff))
                 return True
 
-            logs.error('Retrying on %s failed with %s. Raise.',
-                       function_with_type,
-                       sys.exc_info()[1])
+            if log_retries:
+                logs.error('Retrying on %s failed with %s. Raise.',
+                           function_with_type,
+                           sys.exc_info()[1])
             return False
 
         @functools.wraps(func)


### PR DESCRIPTION
Logs made in retries always should check for the `log_retries` parameter, to avoid the following cyclic scenario:

1. A log fails (e.g. permission issue)
2. The logging method uses a retry wrapper, so it tries again
3. The code inside the retry wrapper also calls a log method, so we go back to step 1

