### PR TITLE
Remove retry circular dependency

### DIFF
--- a/common/logs.py
+++ b/common/logs.py
@@ -36,7 +36,7 @@ _default_extras = {}
 
 LOG_LENGTH_LIMIT = 250 * 1000
 
-NUM_ATTEMPTS = 5
+NUM_ATTEMPTS = 4
 RETRY_DELAY = 1
 BACKOFF = 2
 

--- a/common/logs.py
+++ b/common/logs.py
@@ -17,8 +17,8 @@ from enum import Enum
 import logging
 import os
 import sys
-import traceback
 import time
+import traceback
 
 import google.cloud.logging
 from google.cloud.logging_v2.handlers.handlers import CloudLoggingHandler
@@ -28,7 +28,7 @@ from google.cloud import error_reporting
 # pylint: disable=invalid-name
 
 from common import utils
-from common.retry import get_delay
+from common import retry
 
 _default_logger = None
 _log_client = None
@@ -190,7 +190,7 @@ def log(logger, severity, message, *args, extras=None):
         except Exception:  # pylint: disable=broad-except
             # We really dont want do to do anything here except sleep here,
             # since we cant log it out as log itself is already failing
-            time.sleep(get_delay(num_try, RETRY_DELAY, BACKOFF))
+            time.sleep(retry.get_delay(num_try, RETRY_DELAY, BACKOFF))
 
 
 def error(message, *args, extras=None, logger=None):
@@ -210,7 +210,7 @@ def error(message, *args, extras=None, logger=None):
             except Exception:  # pylint: disable=broad-except
                 # We really dont want do to do anything here except sleep here,
                 # since we cant log it out as log itself is already failing
-                time.sleep(get_delay(num_try, RETRY_DELAY, BACKOFF))
+                time.sleep(retry.get_delay(num_try, RETRY_DELAY, BACKOFF))
 
     if not any(sys.exc_info()):
         _report_error_with_retries(message % args)

--- a/common/logs.py
+++ b/common/logs.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Set up for logging."""
 from enum import Enum
-from common import retry
+from common.retry import get_delay
 import logging
 import os
 import sys
@@ -188,7 +188,7 @@ def log(logger, severity, message, *args, extras=None):
         except Exception:
             # We really dont want do to do anything here except sleep here,
             # since we cant log it out as log itself is already failing
-            time.sleep(retry.get_delay(num_try, RETRY_DELAY, BACKOFF))
+            time.sleep(get_delay(num_try, RETRY_DELAY, BACKOFF))
 
 
 def error(message, *args, extras=None, logger=None):
@@ -207,7 +207,7 @@ def error(message, *args, extras=None, logger=None):
             except:
                 # We really dont want do to do anything here except sleep here,
                 # since we cant log it out as log itself is already failing
-                time.sleep(retry.get_delay(num_try, RETRY_DELAY, BACKOFF))
+                time.sleep(get_delay(num_try, RETRY_DELAY, BACKOFF))
 
     if not any(sys.exc_info()):
         _report_error_with_retries(message % args)

--- a/common/logs.py
+++ b/common/logs.py
@@ -158,8 +158,8 @@ class LogSeverity(Enum):
 def log(logger, severity, message, *args, extras=None):
     """Log a message with severity |severity|. If using stack driver logging
     then |extras| is also logged (in addition to default extras)."""
-    # Custom retry logic to avoid circular dependency
-    # as retry from retry.py uses log
+    # Custom retry logic to avoid circular dependency as retry from
+    # retry.py uses log.
     for num_try in range(1, NUM_ATTEMPTS + 1):
         try:
             message = str(message)

--- a/common/logs.py
+++ b/common/logs.py
@@ -154,6 +154,7 @@ class LogSeverity(Enum):
     INFO = logging.INFO
     DEBUG = logging.DEBUG
 
+
 def log(logger, severity, message, *args, extras=None):
     """Log a message with severity |severity|. If using stack driver logging
     then |extras| is also logged (in addition to default extras)."""
@@ -188,7 +189,6 @@ def log(logger, severity, message, *args, extras=None):
             # We really dont want do to do anything here except sleep here,
             # since we cant log it out as log itself is already failing
             time.sleep(retry.get_delay(num_try, RETRY_DELAY, BACKOFF))
-            
 
 
 def error(message, *args, extras=None, logger=None):
@@ -198,7 +198,7 @@ def error(message, *args, extras=None, logger=None):
     def _report_error_with_retries(message):
         if utils.is_local():
             return
-        
+
         # Custom retry logic to avoid circular dependency as retry from retry.py uses log
         for num_try in range(1, NUM_RETRIES + 1):
             try:
@@ -207,8 +207,7 @@ def error(message, *args, extras=None, logger=None):
             except:
                 # We really dont want do to do anything here except sleep here,
                 # since we cant log it out as log itself is already failing
-                time.sleep(retry.get_delay(num_try, RETRY_DELAY, BACKOFF)) 
-
+                time.sleep(retry.get_delay(num_try, RETRY_DELAY, BACKOFF))
 
     if not any(sys.exc_info()):
         _report_error_with_retries(message % args)

--- a/common/retry.py
+++ b/common/retry.py
@@ -21,16 +21,12 @@ import sys
 import time
 
 from common import logs
+from common import utils
 
 
 def sleep(seconds):
     """Invoke time.sleep."""
     time.sleep(seconds)
-
-
-def get_delay(num_try, delay, backoff):
-    """Compute backoff delay."""
-    return delay * (backoff**(num_try - 1))
 
 
 def wrap(  # pylint: disable=too-many-arguments
@@ -62,7 +58,7 @@ def wrap(  # pylint: disable=too-many-arguments
                 logs.info('Retrying on %s failed with %s. Retrying again.',
                           function_with_type,
                           sys.exc_info()[1])
-                sleep(get_delay(num_try, delay, backoff))
+                sleep(utils.get_retry_delay(num_try, delay, backoff))
                 return True
 
             logs.error('Retrying on %s failed with %s. Raise.',

--- a/common/retry.py
+++ b/common/retry.py
@@ -20,6 +20,8 @@ import inspect
 import sys
 import time
 
+from common import logs 
+
 
 def sleep(seconds):
     """Invoke time.sleep."""
@@ -37,11 +39,8 @@ def wrap(  # pylint: disable=too-many-arguments
         function,
         backoff=2,
         exception_type=Exception,
-        log_retries=True,
         retry_on_false=False):
     """Retry decorator for a function."""
-    # To avoid circular dependency.
-    from common import logs  # pylint:disable=import-outside-toplevel
 
     assert delay > 0
     assert backoff >= 1
@@ -58,12 +57,10 @@ def wrap(  # pylint: disable=too-many-arguments
         def handle_retry(num_try, exception=None):
             """Handle retry."""
 
-            if (exception is None or
-                    isinstance(exception, exception_type)) and num_try < tries:
-                if log_retries:
-                    logs.info('Retrying on %s failed with %s. Retrying again.',
-                              function_with_type,
-                              sys.exc_info()[1])
+            if (exception is None or isinstance(exception, exception_type)) and num_try < tries:
+                logs.info('Retrying on %s failed with %s. Retrying again.',
+                        function_with_type,
+                        sys.exc_info()[1])
                 sleep(get_delay(num_try, delay, backoff))
                 return True
 

--- a/common/retry.py
+++ b/common/retry.py
@@ -20,7 +20,7 @@ import inspect
 import sys
 import time
 
-from common import logs 
+from common import logs
 
 
 def sleep(seconds):
@@ -57,10 +57,11 @@ def wrap(  # pylint: disable=too-many-arguments
         def handle_retry(num_try, exception=None):
             """Handle retry."""
 
-            if (exception is None or isinstance(exception, exception_type)) and num_try < tries:
+            if (exception is None or
+                    isinstance(exception, exception_type)) and num_try < tries:
                 logs.info('Retrying on %s failed with %s. Retrying again.',
-                        function_with_type,
-                        sys.exc_info()[1])
+                          function_with_type,
+                          sys.exc_info()[1])
                 sleep(get_delay(num_try, delay, backoff))
                 return True
 

--- a/common/test_common_utils.py
+++ b/common/test_common_utils.py
@@ -15,6 +15,7 @@
 
 from common import utils
 
+
 def test_get_retry_delay():
     """"Tests if get delay is working as expected"""
     delay = 3

--- a/common/test_common_utils.py
+++ b/common/test_common_utils.py
@@ -1,0 +1,30 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for utils.py"""
+
+from common import utils
+
+def test_get_retry_delay():
+    """"Tests if get delay is working as expected"""
+    delay = 3
+    backoff = 2
+
+    first_try = 1
+    first_try_delay = utils.get_retry_delay(first_try, delay, backoff)
+    # Backoff should have no effect on first try
+    assert first_try_delay == delay
+
+    second_try = 2
+    second_try_delay = utils.get_retry_delay(second_try, delay, backoff)
+    assert second_try_delay == delay * backoff

--- a/common/utils.py
+++ b/common/utils.py
@@ -73,3 +73,10 @@ def file_hash(file_path):
             chunk = file_handle.read(chunk_size)
 
     return digest.hexdigest()
+
+
+# Calculate a retry delay based on the current try,
+# a default delay, and an exponential backoff
+def get_retry_delay(num_try, delay, backoff):
+    """Compute backoff delay."""
+    return delay * (backoff**(num_try - 1))


### PR DESCRIPTION
Removing usage of `@retry.wrap` in logs methods.

This removal is necessary because retries also use logs inside of their implementation so we want to avoid the following cyclic scenario:

1. Log method is called
2. A log fails (e.g. permission issue)
3. The logging method uses a retry wrapper, so it tries again
4. The code inside the retry wrapper also calls a log method, so we go back to step 1

Before this PR, this scenario was avoided by using a `log_retries` parameter, that would disable loggings on retries functions when the retry was called from a log function. 

This PR remove this parameter and get rid of the circular dependency by making a custom retry logic inside of the logs methods.