### PR TITLE
Improving log message

### DIFF
--- a/experiment/build/builder.py
+++ b/experiment/build/builder.py
@@ -23,7 +23,7 @@ import subprocess
 import sys
 import time
 import types
-from typing import Callable, List, Tuple
+from typing import List, Tuple
 
 from common import benchmark_config
 from common import benchmark_utils
@@ -136,7 +136,8 @@ def split_successes_and_failures(inputs: List,
     return successes, failures
 
 
-def retry_build_loop(build_func: types.FunctionType, inputs: List[Tuple]) -> List:
+def retry_build_loop(build_func: types.FunctionType,
+                     inputs: List[Tuple]) -> List:
     """Calls |build_func| in parallel on |inputs|. Repeat on failures up to
     |NUM_BUILD_ATTEMPTS| times. Returns the list of inputs that |build_func| was
     called successfully on."""

--- a/experiment/build/builder.py
+++ b/experiment/build/builder.py
@@ -22,6 +22,7 @@ import random
 import subprocess
 import sys
 import time
+import types
 from typing import Callable, List, Tuple
 
 from common import benchmark_config
@@ -135,7 +136,7 @@ def split_successes_and_failures(inputs: List,
     return successes, failures
 
 
-def retry_build_loop(build_func: Callable, inputs: List[Tuple]) -> List:
+def retry_build_loop(build_func: types.FunctionType, inputs: List[Tuple]) -> List:
     """Calls |build_func| in parallel on |inputs|. Repeat on failures up to
     |NUM_BUILD_ATTEMPTS| times. Returns the list of inputs that |build_func| was
     called successfully on."""
@@ -144,7 +145,7 @@ def retry_build_loop(build_func: Callable, inputs: List[Tuple]) -> List:
     logs.info('Concurrent builds: %d.', num_concurrent_builds)
     with mp_pool.ThreadPool(num_concurrent_builds) as pool:
         for _ in range(NUM_BUILD_ATTEMPTS):
-            logs.info('Building using (%s): %s', build_func, inputs)
+            logs.info('Building using (%s): %s', build_func.__name__, inputs)
             results = pool.starmap(build_func, inputs)
             curr_successes, curr_failures = split_successes_and_failures(
                 inputs, results)


### PR DESCRIPTION
Improving log message by displaying only function name, instead of trying to print function itself.

Also took the opportunity to replace `Callable` with `FunctionType` when declaring argument type, as Callable is more generic.

Before:
<img width="852" alt="Screenshot 2024-04-18 at 11 43 37" src="https://github.com/google/fuzzbench/assets/166517299/127314e2-1dbd-4b04-890a-fd8b0a0241ee">

After:
<img width="641" alt="Screenshot 2024-04-18 at 12 06 15" src="https://github.com/google/fuzzbench/assets/166517299/df17d486-5c8e-48f9-9c6d-0f23cc82380d">
