### PR TITLE
New scheduling algorithm for LibAFL

### DIFF
--- a/fuzzers/libafl_penalize/builder.Dockerfile
+++ b/fuzzers/libafl_penalize/builder.Dockerfile
@@ -38,7 +38,7 @@ RUN if which rustup; then rustup self uninstall -y; fi && \
 RUN git clone https://github.com/AFLplusplus/LibAFL /libafl
 
 # Checkout a current commit
-RUN cd /libafl && git pull && git checkout b4efb6151550a37f61a869acf2957a1b07894a93 || true
+RUN cd /libafl && git pull && git checkout b2275e1b11457a56934de64bf7da09311ab29bbc || true
 # Note that due a nightly bug it is currently fixed to a known version on top!
 
 # Compile libafl.

--- a/fuzzers/libafl_penalize/description.md
+++ b/fuzzers/libafl_penalize/description.md
@@ -1,0 +1,11 @@
+# libafl
+
+libafl fuzzer instance 
+  - cmplog feature
+  - persistent mode
+
+Repository: [https://github.com/AFLplusplus/libafl/](https://github.com/AFLplusplus/libafl/)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/libafl_penalize/fuzzer.py
+++ b/fuzzers/libafl_penalize/fuzzer.py
@@ -1,0 +1,72 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration code for a LibAFL-based fuzzer."""
+
+import os
+import subprocess
+
+from fuzzers import utils
+
+
+def prepare_fuzz_environment(input_corpus):
+    """Prepare to fuzz with a LibAFL-based fuzzer."""
+    os.environ['ASAN_OPTIONS'] = 'abort_on_error=1:detect_leaks=0:'\
+                                 'malloc_context_size=0:symbolize=0:'\
+                                 'allocator_may_return_null=1:'\
+                                 'detect_odr_violation=0:handle_segv=0:'\
+                                 'handle_sigbus=0:handle_abort=0:'\
+                                 'handle_sigfpe=0:handle_sigill=0'
+    os.environ['UBSAN_OPTIONS'] =  'abort_on_error=1:'\
+                                   'allocator_release_to_os_interval_ms=500:'\
+                                   'handle_abort=0:handle_segv=0:'\
+                                   'handle_sigbus=0:handle_sigfpe=0:'\
+                                   'handle_sigill=0:print_stacktrace=0:'\
+                                   'symbolize=0:symbolize_inline_frames=0'
+    # Create at least one non-empty seed to start.
+    utils.create_seed_file_for_empty_corpus(input_corpus)
+
+
+def build():  # pylint: disable=too-many-branches,too-many-statements
+    """Build benchmark."""
+    os.environ[
+        'CC'] = '/libafl/fuzzers/fuzzbench/target/release-fuzzbench/libafl_cc'
+    os.environ[
+        'CXX'] = '/libafl/fuzzers/fuzzbench/target/release-fuzzbench/libafl_cxx'
+
+    os.environ['ASAN_OPTIONS'] = 'abort_on_error=0:allocator_may_return_null=1'
+    os.environ['UBSAN_OPTIONS'] = 'abort_on_error=0'
+
+    cflags = ['--libafl']
+    cxxflags = ['--libafl', '--std=c++14']
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cxxflags)
+    utils.append_flags('LDFLAGS', cflags)
+
+    os.environ['FUZZER_LIB'] = '/stub_rt.a'
+    utils.build_benchmark()
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    prepare_fuzz_environment(input_corpus)
+    dictionary_path = utils.get_dictionary_path(target_binary)
+    command = [target_binary]
+    if dictionary_path:
+        command += (['-x', dictionary_path])
+    command += (['-o', output_corpus, '-i', input_corpus])
+    fuzzer_env = os.environ.copy()
+    fuzzer_env['LD_PRELOAD'] = '/usr/lib/x86_64-linux-gnu/libjemalloc.so.2'
+    print(command)
+    subprocess.check_call(command, cwd=os.environ['OUT'], env=fuzzer_env)

--- a/fuzzers/libafl_penalize/runner.Dockerfile
+++ b/fuzzers/libafl_penalize/runner.Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+RUN apt install libjemalloc2
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+#ENV AFL_MAP_SIZE=2621440
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/service/gcbrun_experiment.py
+++ b/service/gcbrun_experiment.py
@@ -28,7 +28,7 @@ from experiment import run_experiment
 TRIGGER_COMMAND = '/gcbrun'
 RUN_EXPERIMENT_COMMAND_STR = f'{TRIGGER_COMMAND} run_experiment.py '
 SKIP_COMMAND_STR = f'{TRIGGER_COMMAND} skip'
-# A DUMMY COMMENT
+# a dummy comment
 
 
 def get_comments(pull_request_number):


### PR DESCRIPTION
We want to test a new scheduling algorithm that gives less priority to the testcases that discovered crashes.

The command is
```
/gcbrun run_experiment.py -a --experiment-config /opt/fuzzbench/service/experiment-config.yaml --experiment-name 2024-04-24-libafl --fuzzers libafl libafl_penalize
```