### PR TITLE
Add method to check if benchmarks are mixed

### DIFF
--- a/common/benchmark_utils.py
+++ b/common/benchmark_utils.py
@@ -165,18 +165,13 @@ def get_language(benchmark):
     return config.get('language', 'c++')
 
 
-def are_benchmarks_mixed(benchmarks):
-    """"Returns True if benchmarks list
-    is a mix of bugs and coverage benchmarks"""
-    if not benchmarks:
-        return False
+def are_benchmarks_mixed(benchmarks=None):
+    """Returns True if benchmarks list
+    is a mix of bugs and coverage benchmarks."""
+    if benchmarks is None:
+        benchmarks = get_all_benchmarks()
 
-    selected_coverage_benchmarks = get_coverage_benchmarks(benchmarks)
-    only_coverage_benchmarks = len(selected_coverage_benchmarks) == len(
-        benchmarks)
-    only_bug_benchmarks = len(selected_coverage_benchmarks) == 0
+    unique_benchmarks_types = set(
+        get_type(benchmark) for benchmark in benchmarks)
 
-    if only_bug_benchmarks or only_coverage_benchmarks:
-        return False
-
-    return True
+    return len(unique_benchmarks_types) > 1

--- a/common/benchmark_utils.py
+++ b/common/benchmark_utils.py
@@ -166,8 +166,8 @@ def get_language(benchmark):
 
 
 def are_benchmarks_mixed(benchmarks=None):
-    """Returns True if benchmarks list
-    is a mix of bugs and coverage benchmarks."""
+    """Returns True if benchmarks list is a mix of bugs and coverage
+    benchmarks."""
     if benchmarks is None:
         benchmarks = get_all_benchmarks()
 

--- a/common/benchmark_utils.py
+++ b/common/benchmark_utils.py
@@ -133,18 +133,18 @@ def get_all_benchmarks():
     return sorted(all_benchmarks)
 
 
-def get_coverage_benchmarks():
+def get_coverage_benchmarks(benchmarks=get_all_benchmarks()):
     """Returns the list of all coverage benchmarks."""
     return [
-        benchmark for benchmark in get_all_benchmarks()
+        benchmark for benchmark in benchmarks
         if get_type(benchmark) == BenchmarkType.CODE.value
     ]
 
 
-def get_bug_benchmarks():
+def get_bug_benchmarks(benchmarks=get_all_benchmarks()):
     """Returns the list of standard bug benchmarks."""
     return [
-        benchmark for benchmark in get_all_benchmarks()
+        benchmark for benchmark in benchmarks
         if get_type(benchmark) == BenchmarkType.BUG.value
     ]
 
@@ -163,3 +163,20 @@ def get_language(benchmark):
     """Returns the prorgamming language the benchmark was written in."""
     config = benchmark_config.get_config(benchmark)
     return config.get('language', 'c++')
+
+
+def are_benchmarks_mixed(benchmarks):
+    """"Returns True if benchmarks list
+    is a mix of bugs and coverage benchmarks"""
+    if not benchmarks:
+        return False
+
+    selected_coverage_benchmarks = get_coverage_benchmarks(benchmarks)
+    only_coverage_benchmarks = len(selected_coverage_benchmarks) == len(
+        benchmarks)
+    only_bug_benchmarks = len(selected_coverage_benchmarks) == 0
+
+    if only_bug_benchmarks or only_coverage_benchmarks:
+        return False
+
+    return True

--- a/common/test_benchmark_utils.py
+++ b/common/test_benchmark_utils.py
@@ -90,7 +90,7 @@ def test_get_default_type(_):
 def test_are_benchmarks_mixed_valid(benchmarks):
     """Tests that are_benchmarks_mixed returns True
     for a list that have both bug and coverage benchmarks"""
-    assert benchmark_utils.are_benchmarks_mixed(benchmarks) is True
+    assert benchmark_utils.are_benchmarks_mixed(benchmarks)
 
 
 @pytest.mark.parametrize(
@@ -99,4 +99,4 @@ def test_are_benchmarks_mixed_valid(benchmarks):
 def test_are_benchmarks_mixed_invalid(benchmarks):
     """Tests that are_benchmarks_mixed returns False
     for a list that have only bug or only coverage benchmarks"""
-    assert benchmark_utils.are_benchmarks_mixed(benchmarks) is False
+    assert not benchmark_utils.are_benchmarks_mixed(benchmarks)

--- a/common/test_benchmark_utils.py
+++ b/common/test_benchmark_utils.py
@@ -81,3 +81,22 @@ def test_validate_type_valid(benchmark_type):
 def test_get_default_type(_):
     """Tests that get_type returns the correct default value."""
     assert benchmark_utils.get_type('benchmark') == 'code'
+
+
+@pytest.mark.parametrize(
+    ('benchmarks'),
+    [['mbedtls_fuzz_dtlsclient_7c6b0e', 'mbedtls_fuzz_dtlsclient'],
+     ['bloaty_fuzz_target', 'bloaty_fuzz_target_52948c']])
+def test_are_benchmarks_mixed_valid(benchmarks):
+    """Tests that are_benchmarks_mixed returns True
+    for a list that have both bug and coverage benchmarks"""
+    assert benchmark_utils.are_benchmarks_mixed(benchmarks) is True
+
+
+@pytest.mark.parametrize(
+    ('benchmarks'),
+    [['mbedtls_fuzz_dtlsclient_7c6b0e'], ['mbedtls_fuzz_dtlsclient'], []])
+def test_are_benchmarks_mixed_invalid(benchmarks):
+    """Tests that are_benchmarks_mixed returns False
+    for a list that have only bug or only coverage benchmarks"""
+    assert benchmark_utils.are_benchmarks_mixed(benchmarks) is False

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -745,9 +745,12 @@ def run_experiment_main(args=None):
                          '"oss_fuzz_corpus" at the same time')
 
     if benchmark_utils.are_benchmarks_mixed(args.benchmarks):
+        benchmark_types = ';'.join(
+            [f'{b}: {benchmark_utils.get_type(b)}' for b in args.benchmarks])
         raise ValidationError(
-            'Selected benchmarks are a mix between coverage '
-            'and bug benchmarks. This is currently not supported.')
+            'Selected benchmarks are a mix between coverage'
+            'and bug benchmarks. This is currently not supported.'
+            f'Selected benchmarks: {benchmark_types}')
 
     start_experiment(args.experiment_name,
                      args.experiment_config,

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -625,6 +625,7 @@ def run_experiment_main(args=None):
 
     all_benchmarks = benchmark_utils.get_all_benchmarks()
     coverage_benchmarks = benchmark_utils.get_coverage_benchmarks()
+
     parser.add_argument('-b',
                         '--benchmarks',
                         help=('Benchmark names. '
@@ -742,6 +743,11 @@ def run_experiment_main(args=None):
         if args.oss_fuzz_corpus:
             parser.error('Cannot enable options "custom_seed_corpus_dir" and '
                          '"oss_fuzz_corpus" at the same time')
+
+    if benchmark_utils.are_benchmarks_mixed(args.benchmarks):
+        raise ValidationError(
+            'Selected benchmarks are a mix between coverage '
+            'and bug benchmarks. This is currently not supported.')
 
     start_experiment(args.experiment_name,
                      args.experiment_config,


### PR DESCRIPTION
Currently, Fuzzbench fails to generate a report if benchmarks are a mix between bug and coverage benchmarks.

This PR adds a method to check if benchmarks are a mix between bug and coverage benchmarks before starting the experiment, to spot the problem early and avoid wasting time.