### PR TITLE
update AFL++ commit id on fuzzbench

### DIFF
--- a/fuzzers/aflplusplus/builder.Dockerfile
+++ b/fuzzers/aflplusplus/builder.Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
 # Download afl++.
 RUN git clone -b dev https://github.com/AFLplusplus/AFLplusplus /afl && \
     cd /afl && \
-    git checkout 27d05f3c216e18163236efa42b630a5b3784d2e9 || \
+    git checkout 56d5aa3101945e81519a3fac8783d0d8fad82779 || \
     true
 
 # Build without Python support as we don't need it.

--- a/fuzzers/aflplusplus/runner.Dockerfile
+++ b/fuzzers/aflplusplus/runner.Dockerfile
@@ -21,4 +21,4 @@ ENV PATH="$PATH:/out"
 ENV AFL_SKIP_CPUFREQ=1
 ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
 ENV AFL_TESTCACHE_SIZE=2
-RUN apt install -y unzip git gdb joe
+# RUN apt-get update && apt-get upgrade && apt install -y unzip git gdb joe

--- a/fuzzers/aflplusplus_frida/builder.Dockerfile
+++ b/fuzzers/aflplusplus_frida/builder.Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
 
 # Download afl++
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
-    cd /afl && git checkout 27d05f3c216e18163236efa42b630a5b3784d2e9
+    cd /afl && git checkout 56d5aa3101945e81519a3fac8783d0d8fad82779
     
 # Build afl++ without Python support as we don't need it.
 # Set AFL_NO_X86 to skip flaky tests.

--- a/fuzzers/aflplusplus_qemu/builder.Dockerfile
+++ b/fuzzers/aflplusplus_qemu/builder.Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
 
 # Download afl++
 RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
-    cd /afl && git checkout 27d05f3c216e18163236efa42b630a5b3784d2e9 || true
+    cd /afl && git checkout 56d5aa3101945e81519a3fac8783d0d8fad82779 || true
     
 # Build afl++ without Python support as we don't need it.
 # Set AFL_NO_X86 to skip flaky tests.


### PR DESCRIPTION
the AFL++ commit id is from December, so a 4.10a state, where we are currently at 4.21a - this needs an update :)
