### PR TITLE
Fix saturated corpus experiment requests

### DIFF
--- a/service/automatic_run_experiment.py
+++ b/service/automatic_run_experiment.py
@@ -64,7 +64,7 @@ def _get_description(experiment_config: dict) -> Optional[str]:
 def _use_oss_fuzz_corpus(experiment_config: dict) -> bool:
     """Returns the oss_fuzz_corpus flag of the experiment described by
     |experiment_config| as a bool."""
-    return bool(experiment_config.get('oss_fuzz_corpus'))
+    return bool(experiment_config.get('oss-fuzz-corpus'))
 
 
 def _get_requested_experiments():


### PR DESCRIPTION
The parser for experiment-requests.yml checks `oss_fuzz_corpus`:

https://github.com/google/fuzzbench/blob/421187b515cfaf4d7ad8bfe9bfa9512372dceaae/service/automatic_run_experiment.py#L64-L67

Experiment request docs say to use `oss-fuzz-corpus`, not `oss_fuzz_corpus`

https://github.com/google/fuzzbench/blob/421187b515cfaf4d7ad8bfe9bfa9512372dceaae/service/experiment-requests.yaml#L9

and all the past experiment requests are using `oss-fuzz-corpus`
https://github.com/google/fuzzbench/blob/421187b515cfaf4d7ad8bfe9bfa9512372dceaae/service/experiment-requests.yaml#L2273-L2276