### PR TITLE
[DO NOT MERGE] Adding code for experiments using pubsub queues

### DIFF
--- a/experiment/measurer/measure_worker.py
+++ b/experiment/measurer/measure_worker.py
@@ -13,13 +13,16 @@
 # limitations under the License.
 """Module for measurer workers logic."""
 import time
+import json
 from typing import Dict, Optional
+from google.cloud import pubsub_v1
 from common import logs
 from database.models import Snapshot
 import experiment.measurer.datatypes as measurer_datatypes
 from experiment.measurer import measure_manager
 
 MEASUREMENT_TIMEOUT = 1
+GET_FROM_PUB_SUB_QUEUE_TIMEOUT = 3
 logger = logs.Logger()  # pylint: disable=invalid-name
 
 
@@ -28,8 +31,6 @@ class BaseMeasureWorker:
     implemented for Local and Google Cloud measure workers."""
 
     def __init__(self, config: Dict):
-        self.request_queue = config['request_queue']
-        self.response_queue = config['response_queue']
         self.region_coverage = config['region_coverage']
 
     def get_task_from_request_queue(self):
@@ -68,6 +69,11 @@ class LocalMeasureWorker(BaseMeasureWorker):
     """Class that holds implementations of core methods for running a measure
     worker locally."""
 
+    def __init__(self, config: Dict):
+        self.request_queue = config['request_queue']
+        self.response_queue = config['response_queue']
+        super().__init__(config)
+
     def get_task_from_request_queue(
             self) -> measurer_datatypes.SnapshotMeasureRequest:
         """Get item from request multiprocessing queue, block if necessary until
@@ -86,3 +92,71 @@ class LocalMeasureWorker(BaseMeasureWorker):
                 request.fuzzer, request.benchmark, request.trial_id,
                 request.cycle)
             self.response_queue.put(retry_request)
+
+
+class GoogleCloudMeasureWorker(BaseMeasureWorker):  # pylint: disable=too-many-instance-attributes
+    """Worker that consumes from a Google Cloud Pub/Sub Queue, instead of a
+    multiprocessing queue"""
+
+    def __init__(self, config: Dict):
+        super().__init__(config)
+        self.request_queue_topic_id = config['request_queue_topic_id']
+        self.response_queue_topic_id = config['response_queue_topic_id']
+        self.project_id = config['project_id']
+        self.experiment = config['experiment']
+        self.request_queue_subscription = f"""request-queue-subscription-
+            {self.experiment}"""
+        self.publisher_client = pubsub_v1.PublisherClient()
+        self.subscriber_client = pubsub_v1.SubscriberClient()
+        self.subscription_path = self.subscriber_client.subscription_path(
+            self.project_id, self.request_queue_subscription)
+        self._create_request_queue_subscription()
+
+    def _create_request_queue_subscription(self):
+        """Creates a new Pub/Sub subscription for the request queue."""
+        topic_path = self.response_queue_topic_id
+        subscription = self.subscriber_client.create_subscription(request={
+            'name': self.subscription_path,
+            'topic': topic_path
+        })
+        logger.info(f'Subscription {subscription.name} created successfully.')
+
+        return self.subscription_path
+
+    def get_task_from_request_queue(
+            self) -> measurer_datatypes.SnapshotMeasureRequest:
+        while True:
+            response = self.subscriber_client.pull(
+                request={
+                    'subscription': self.subscription_path,
+                    'max_messages': 1
+                },
+                timeout=GET_FROM_PUB_SUB_QUEUE_TIMEOUT)
+
+            if response.received_messages:
+                message = response.received_messages[0]
+                ack_ids = [message.ack_id]
+
+                # Acknowledge the received message to remove it from the queue.
+                self.subscriber_client.acknowledge(request={
+                    'subscription': self.subscription_path,
+                    'ack_ids': ack_ids
+                })
+
+                return message.message.data
+
+    def put_result_in_response_queue(self, measured_snapshot, request):
+        topic_path = self.publisher_client.topic_path(
+            self.project_id, self.response_queue_topic_id)
+        if measured_snapshot:
+            logger.info('Put measured snapshot in response_queue')
+            measured_snapshot_encoded = json.dumps(
+                measured_snapshot.__dict__).encode('utf-8')
+            self.publisher_client.publish(topic_path, measured_snapshot_encoded)
+        else:
+            retry_request = measurer_datatypes.SnapshotMeasureRequest(
+                request.fuzzer, request.benchmark, request.trial_id,
+                request.cycle)
+            retry_request_encoded = json.dumps(
+                retry_request.__dict__).encode('utf-8')
+            self.publisher_client.publish(topic_path, retry_request_encoded)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ google-auth==2.12.0
 google-cloud-error-reporting==1.6.3
 google-cloud-logging==3.1.2
 google-cloud-secret-manager==2.12.6
+google-cloud-pubsub==2.19.2
 clusterfuzz==2.6.0
 Jinja2==3.1.2
 numpy==1.23.4

--- a/service/experiment-config.yaml
+++ b/service/experiment-config.yaml
@@ -2,8 +2,8 @@
 # Unless you are a fuzzbench maintainer running this service, this
 # will not work with your setup.
 
-trials: 20
-max_total_time: 82800  # 23 hours, the default time for preemptible experiments.
+trials: 3
+max_total_time: 3660
 cloud_project: fuzzbench
 docker_registry: gcr.io/fuzzbench
 cloud_compute_zone: us-central1-c

--- a/service/gcbrun_experiment.py
+++ b/service/gcbrun_experiment.py
@@ -16,6 +16,7 @@
 """Entrypoint for gcbrun into run_experiment. This script will get the command
 from the last PR comment containing "/gcbrun" and pass it to run_experiment.py
 which will run an experiment."""
+# Dummy comment to trigger run experiment action
 
 import logging
 import os


### PR DESCRIPTION
This PR adds code to use pub sub queues when running cloud experiments, instead of python in-memory queues.

This PR is still a draft, I still want to do some improvements on top of it, but I appreciate any feedback. Will try to trigger a cloud experiment before adding reviewers to it.