### PR TITLE
Experiment request for custom benchmarks

### DIFF
--- a/benchmarks/lcms_cms_transform_fuzzer_all_seeds/Dockerfile
+++ b/benchmarks/lcms_cms_transform_fuzzer_all_seeds/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
+
+RUN apt-get update && \
+    apt-get install -y \
+    make \
+    automake \
+    libtool \
+    wget
+
+RUN git clone https://github.com/mm2/Little-CMS.git
+
+RUN wget -qO $OUT/cms_transform_fuzzer.dict \
+    https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/icc.dict
+COPY cms_transform_fuzzer.cc build.sh $SRC/
+# Download the seeds tarball from your GitHub repository
+RUN wget https://raw.githubusercontent.com/ardier/fuzzbench/minimized-subsumed-mutants-benchmark-with-seeds/benchmarks/lcms_cms_transform_fuzzer_all_seeds/seeds.tar.gz -O /tmp/seeds.tar.gz
+
+# Extract the seeds tarball to the /opt/seeds directory
+RUN mkdir -p /opt/seeds && \
+    tar -xzvf /tmp/seeds.tar.gz -C /opt/seeds
+# ADD seeds /opt/seeds

--- a/benchmarks/lcms_cms_transform_fuzzer_all_seeds/benchmark.yaml
+++ b/benchmarks/lcms_cms_transform_fuzzer_all_seeds/benchmark.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+commit: f0d963261b28253999e239a844ac74d5a8960f40
+commit_date: 2023-01-25T18:20:28+0000
+fuzz_target: cms_transform_fuzzer
+project: lcms
+unsupported_fuzzers:
+  - symcc_afl
+  - symcc_afl_single
+  - symcc_aflplusplus
+  - afldd
+  - aflpp_vs_dd

--- a/benchmarks/lcms_cms_transform_fuzzer_all_seeds/build.sh
+++ b/benchmarks/lcms_cms_transform_fuzzer_all_seeds/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd Little-CMS
+./autogen.sh
+./configure
+make -j $(nproc)
+
+$CXX $CXXFLAGS $SRC/cms_transform_fuzzer.cc -I include/ src/.libs/liblcms2.a \
+    $FUZZER_LIB -o $OUT/cms_transform_fuzzer
+cp -r /opt/seeds $OUT/

--- a/benchmarks/lcms_cms_transform_fuzzer_all_seeds/cms_transform_fuzzer.cc
+++ b/benchmarks/lcms_cms_transform_fuzzer_all_seeds/cms_transform_fuzzer.cc
@@ -1,0 +1,61 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+
+#include "lcms2.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  cmsHPROFILE srcProfile = cmsOpenProfileFromMem(data, size);
+  if (!srcProfile) return 0;
+
+  cmsHPROFILE dstProfile = cmsCreate_sRGBProfile();
+  if (!dstProfile) {
+    cmsCloseProfile(srcProfile);
+    return 0;
+  }
+
+  cmsColorSpaceSignature srcCS = cmsGetColorSpace(srcProfile);
+  cmsUInt32Number nSrcComponents = cmsChannelsOf(srcCS);
+  cmsUInt32Number srcFormat;
+  if (srcCS == cmsSigLabData) {
+    srcFormat =
+        COLORSPACE_SH(PT_Lab) | CHANNELS_SH(nSrcComponents) | BYTES_SH(0);
+  } else {
+    srcFormat =
+        COLORSPACE_SH(PT_ANY) | CHANNELS_SH(nSrcComponents) | BYTES_SH(1);
+  }
+
+  cmsUInt32Number intent = 0;
+  cmsUInt32Number flags = 0;
+  cmsHTRANSFORM hTransform = cmsCreateTransform(
+      srcProfile, srcFormat, dstProfile, TYPE_BGR_8, intent, flags);
+  cmsCloseProfile(srcProfile);
+  cmsCloseProfile(dstProfile);
+  if (!hTransform) return 0;
+
+  uint8_t output[4];
+  if (T_BYTES(srcFormat) == 0) {  // 0 means double
+    double input[nSrcComponents];
+    for (uint32_t i = 0; i < nSrcComponents; i++) input[i] = 0.5f;
+    cmsDoTransform(hTransform, input, output, 1);
+  } else {
+    uint8_t input[nSrcComponents];
+    for (uint32_t i = 0; i < nSrcComponents; i++) input[i] = 128;
+    cmsDoTransform(hTransform, input, output, 1);
+  }
+  cmsDeleteTransform(hTransform);
+
+  return 0;
+}

--- a/benchmarks/lcms_cms_transform_fuzzer_dominator_mutants/Dockerfile
+++ b/benchmarks/lcms_cms_transform_fuzzer_dominator_mutants/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
+
+RUN apt-get update && \
+    apt-get install -y \
+    make \
+    automake \
+    libtool \
+    wget
+
+RUN git clone https://github.com/mm2/Little-CMS.git
+
+RUN wget -qO $OUT/cms_transform_fuzzer.dict \
+    https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/icc.dict
+COPY cms_transform_fuzzer.cc build.sh $SRC/
+# Download the seeds tarball from your GitHub repository
+RUN wget https://raw.githubusercontent.com/ardier/fuzzbench/minimized-subsumed-mutants-benchmark-with-seeds/benchmarks/lcms_cms_transform_fuzzer_dominator_mutants/seeds.tar.gz -O /tmp/seeds.tar.gz
+
+# Extract the seeds tarball to the /opt/seeds directory
+RUN mkdir -p /opt/seeds && \
+    tar -xzvf /tmp/seeds.tar.gz
+# ADD seeds /opt/seeds

--- a/benchmarks/lcms_cms_transform_fuzzer_dominator_mutants/benchmark.yaml
+++ b/benchmarks/lcms_cms_transform_fuzzer_dominator_mutants/benchmark.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+commit: f0d963261b28253999e239a844ac74d5a8960f40
+commit_date: 2023-01-25T18:20:28+0000
+fuzz_target: cms_transform_fuzzer
+project: lcms
+unsupported_fuzzers:
+  - symcc_afl
+  - symcc_afl_single
+  - symcc_aflplusplus
+  - afldd
+  - aflpp_vs_dd

--- a/benchmarks/lcms_cms_transform_fuzzer_dominator_mutants/build.sh
+++ b/benchmarks/lcms_cms_transform_fuzzer_dominator_mutants/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd Little-CMS
+./autogen.sh
+./configure
+make -j $(nproc)
+
+$CXX $CXXFLAGS $SRC/cms_transform_fuzzer.cc -I include/ src/.libs/liblcms2.a \
+    $FUZZER_LIB -o $OUT/cms_transform_fuzzer
+cp -r /opt/seeds $OUT/

--- a/benchmarks/lcms_cms_transform_fuzzer_dominator_mutants/cms_transform_fuzzer.cc
+++ b/benchmarks/lcms_cms_transform_fuzzer_dominator_mutants/cms_transform_fuzzer.cc
@@ -1,0 +1,61 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+
+#include "lcms2.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  cmsHPROFILE srcProfile = cmsOpenProfileFromMem(data, size);
+  if (!srcProfile) return 0;
+
+  cmsHPROFILE dstProfile = cmsCreate_sRGBProfile();
+  if (!dstProfile) {
+    cmsCloseProfile(srcProfile);
+    return 0;
+  }
+
+  cmsColorSpaceSignature srcCS = cmsGetColorSpace(srcProfile);
+  cmsUInt32Number nSrcComponents = cmsChannelsOf(srcCS);
+  cmsUInt32Number srcFormat;
+  if (srcCS == cmsSigLabData) {
+    srcFormat =
+        COLORSPACE_SH(PT_Lab) | CHANNELS_SH(nSrcComponents) | BYTES_SH(0);
+  } else {
+    srcFormat =
+        COLORSPACE_SH(PT_ANY) | CHANNELS_SH(nSrcComponents) | BYTES_SH(1);
+  }
+
+  cmsUInt32Number intent = 0;
+  cmsUInt32Number flags = 0;
+  cmsHTRANSFORM hTransform = cmsCreateTransform(
+      srcProfile, srcFormat, dstProfile, TYPE_BGR_8, intent, flags);
+  cmsCloseProfile(srcProfile);
+  cmsCloseProfile(dstProfile);
+  if (!hTransform) return 0;
+
+  uint8_t output[4];
+  if (T_BYTES(srcFormat) == 0) {  // 0 means double
+    double input[nSrcComponents];
+    for (uint32_t i = 0; i < nSrcComponents; i++) input[i] = 0.5f;
+    cmsDoTransform(hTransform, input, output, 1);
+  } else {
+    uint8_t input[nSrcComponents];
+    for (uint32_t i = 0; i < nSrcComponents; i++) input[i] = 128;
+    cmsDoTransform(hTransform, input, output, 1);
+  }
+  cmsDeleteTransform(hTransform);
+
+  return 0;
+}

--- a/benchmarks/lcms_cms_transform_fuzzer_minimized_mutants/Dockerfile
+++ b/benchmarks/lcms_cms_transform_fuzzer_minimized_mutants/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
+
+RUN apt-get update && \
+    apt-get install -y \
+    make \
+    automake \
+    libtool \
+    wget
+
+RUN git clone https://github.com/mm2/Little-CMS.git
+
+RUN wget -qO $OUT/cms_transform_fuzzer.dict \
+    https://raw.githubusercontent.com/google/fuzzing/master/dictionaries/icc.dict
+COPY cms_transform_fuzzer.cc build.sh $SRC/
+# Download the seeds tarball from your GitHub repository
+RUN wget https://raw.githubusercontent.com/ardier/fuzzbench/minimized-subsumed-mutants-benchmark-with-seeds/benchmarks/lcms_cms_transform_fuzzer_minimized_mutants/seeds.tar.gz -O /tmp/seeds.tar.gz
+
+# Extract the seeds tarball to the /opt/seeds directory
+RUN mkdir -p /opt/seeds && \
+    tar -xzvf /tmp/seeds.tar.gz
+# ADD seeds /opt/seeds

--- a/benchmarks/lcms_cms_transform_fuzzer_minimized_mutants/benchmark.yaml
+++ b/benchmarks/lcms_cms_transform_fuzzer_minimized_mutants/benchmark.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+commit: f0d963261b28253999e239a844ac74d5a8960f40
+commit_date: 2023-01-25T18:20:28+0000
+fuzz_target: cms_transform_fuzzer
+project: lcms
+unsupported_fuzzers:
+  - symcc_afl
+  - symcc_afl_single
+  - symcc_aflplusplus
+  - afldd
+  - aflpp_vs_dd

--- a/benchmarks/lcms_cms_transform_fuzzer_minimized_mutants/build.sh
+++ b/benchmarks/lcms_cms_transform_fuzzer_minimized_mutants/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd Little-CMS
+./autogen.sh
+./configure
+make -j $(nproc)
+
+$CXX $CXXFLAGS $SRC/cms_transform_fuzzer.cc -I include/ src/.libs/liblcms2.a \
+    $FUZZER_LIB -o $OUT/cms_transform_fuzzer
+cp -r /opt/seeds $OUT/

--- a/benchmarks/lcms_cms_transform_fuzzer_minimized_mutants/cms_transform_fuzzer.cc
+++ b/benchmarks/lcms_cms_transform_fuzzer_minimized_mutants/cms_transform_fuzzer.cc
@@ -1,0 +1,61 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+
+#include "lcms2.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  cmsHPROFILE srcProfile = cmsOpenProfileFromMem(data, size);
+  if (!srcProfile) return 0;
+
+  cmsHPROFILE dstProfile = cmsCreate_sRGBProfile();
+  if (!dstProfile) {
+    cmsCloseProfile(srcProfile);
+    return 0;
+  }
+
+  cmsColorSpaceSignature srcCS = cmsGetColorSpace(srcProfile);
+  cmsUInt32Number nSrcComponents = cmsChannelsOf(srcCS);
+  cmsUInt32Number srcFormat;
+  if (srcCS == cmsSigLabData) {
+    srcFormat =
+        COLORSPACE_SH(PT_Lab) | CHANNELS_SH(nSrcComponents) | BYTES_SH(0);
+  } else {
+    srcFormat =
+        COLORSPACE_SH(PT_ANY) | CHANNELS_SH(nSrcComponents) | BYTES_SH(1);
+  }
+
+  cmsUInt32Number intent = 0;
+  cmsUInt32Number flags = 0;
+  cmsHTRANSFORM hTransform = cmsCreateTransform(
+      srcProfile, srcFormat, dstProfile, TYPE_BGR_8, intent, flags);
+  cmsCloseProfile(srcProfile);
+  cmsCloseProfile(dstProfile);
+  if (!hTransform) return 0;
+
+  uint8_t output[4];
+  if (T_BYTES(srcFormat) == 0) {  // 0 means double
+    double input[nSrcComponents];
+    for (uint32_t i = 0; i < nSrcComponents; i++) input[i] = 0.5f;
+    cmsDoTransform(hTransform, input, output, 1);
+  } else {
+    uint8_t input[nSrcComponents];
+    for (uint32_t i = 0; i < nSrcComponents; i++) input[i] = 128;
+    cmsDoTransform(hTransform, input, output, 1);
+  }
+  cmsDeleteTransform(hTransform);
+
+  return 0;
+}

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -20,6 +20,17 @@
 # Please add new experiment requests towards the top of this file.
 #
 
+- experiment: 2024-09-03-afl-mutants 
+  description: "Benchmark afl and afl++ with minizmied mutants"
+  fuzzers:
+    - afl
+    - aflplusplus
+  benchmarks:
+    - lcms_cms_transform_fuzzer
+    - lcms_cms_transform_fuzzer_all_seeds
+    - lcms_cms_transform_fuzzer_minimized_mutants
+    - lcms_cms_transform_fuzzer_dominator_mutants
+
 - experiment: 2023-06-12-aflpp
   description: "Benchmark afl++ releases and newmutation"
   fuzzers:
@@ -1027,13 +1038,13 @@
     - harfbuzz-1.3.2
     - lcms-2017-03-21
     - libjpeg-turbo-07-2017
-    - mbedtls_fuzz_dtlsclient 
+    - mbedtls_fuzz_dtlsclient
     - openthread-2019-12-23
     - proj4-2017-08-14
     - re2-2014-12-09
     - sqlite3_ossfuzz
     - vorbis-2017-12-11
-    - zlib_zlib_uncompress_fuzzer 
+    - zlib_zlib_uncompress_fuzzer
 
 - experiment: 2022-10-07-um-3b
   description: "UM fuzzer experiment"
@@ -1135,7 +1146,7 @@
   fuzzers:
     - aflplusplus
     - aflplusplus_um_random
-  
+
 - experiment: 2022-09-29-wingfuzz
   description: "Wingfuzz coverage experiment (compare against core fuzzers)"
   fuzzers:
@@ -1151,7 +1162,7 @@
     - libfuzzer
     - mopt
     - wingfuzz
-    
+
 - experiment: 2022-09-29
   description: "Main coverage experiment"
   type: code
@@ -1597,7 +1608,6 @@
     - mopt
     - aflfast
     - fairfuzz
-
 
 - experiment: 2022-04-10-aflpp
   description: "afl++ bug ranking"
@@ -2494,20 +2504,20 @@
 
 - experiment: 2021-06-02-symccafl-pp
   description: >
-               Symcc experiment. The difference between this and
-               2021-06-01-symccafl is that we now have a version of
-               symcc in combination with aflplusplus. Some bug fixing in
-               symcc has happened, which makes it less prone to crashing.
-               The bug fixing is primarily for the aflplusplus hybrid,
-               since the bugs that were fixed has not been notable
-               (maybe seen once) in the symcc-afl combination.
-               Finally, we have added an increase in the timeout
-               of how often symcc runs, switching it from every
-               5 sec to ever 20 sec. Finally, in the aflplusplus
-               hybrid there is no use of afl-showmap, which means
-               all seeds created by symcc are pushed into the afl
-               queue. This changes the symcc set up as there is no
-               filtering done on the seeds pushed to afl.
+    Symcc experiment. The difference between this and
+    2021-06-01-symccafl is that we now have a version of
+    symcc in combination with aflplusplus. Some bug fixing in
+    symcc has happened, which makes it less prone to crashing.
+    The bug fixing is primarily for the aflplusplus hybrid,
+    since the bugs that were fixed has not been notable
+    (maybe seen once) in the symcc-afl combination.
+    Finally, we have added an increase in the timeout
+    of how often symcc runs, switching it from every
+    5 sec to ever 20 sec. Finally, in the aflplusplus
+    hybrid there is no use of afl-showmap, which means
+    all seeds created by symcc are pushed into the afl
+    queue. This changes the symcc set up as there is no
+    filtering done on the seeds pushed to afl.
   fuzzers:
     - symcc_afl
     - symcc_afl_single
@@ -2527,12 +2537,12 @@
 
 - experiment: 2021-06-01-symccafl
   description: >
-               Symcc-AFL test. The difference between this and
-               2021-05-29-symccafl is that we now have afl benchmarks
-               that run multiple instances of afl. This is for
-               comparison purposes since symcc also utilises mutliple
-               processes. The goal is to try and avoid any bias due
-               to more total CPU time.
+    Symcc-AFL test. The difference between this and
+    2021-05-29-symccafl is that we now have afl benchmarks
+    that run multiple instances of afl. This is for
+    comparison purposes since symcc also utilises mutliple
+    processes. The goal is to try and avoid any bias due
+    to more total CPU time.
   fuzzers:
     - symcc_afl
     - symcc_afl_single
@@ -3322,7 +3332,6 @@
     - libfuzzer
     - mopt
 
-
 - experiment: 2020-10-26
   description: "test new memcache algorithm, hopefully for the last time"
   fuzzers:
@@ -3330,7 +3339,6 @@
     - aflplusplus_memcache_2mb
     - aflplusplus_memcache_20mb
     - aflplusplus_memcache_200mb
-
 
 - experiment: 2020-10-25
   description: >
@@ -3355,7 +3363,6 @@
     - aflplusplus_fast_v2_late
     - aflplusplus_fast_branches_v2
     - aflplusplus
-
 
 - experiment: 2020-10-24
   description: >
@@ -3382,7 +3389,6 @@
     - afl_fast_v2
     - afl_fast
     - afl
-
 
 - experiment: 2020-10-23-2
   description: >

--- a/service/gcbrun_experiment.py
+++ b/service/gcbrun_experiment.py
@@ -16,7 +16,7 @@
 """Entrypoint for gcbrun into run_experiment. This script will get the command
 from the last PR comment containing "/gcbrun" and pass it to run_experiment.py
 which will run an experiment."""
-
+# a dummy comment for experiment!
 import logging
 import os
 import sys


### PR DESCRIPTION
### Description
Add mutant-based benchmarks and update experiment data in the YAML file.
This experiment only introduces new benchmarks as we want to address the saturated seed corpus problem through corpus reduction techniques. 

We have decided to use AFL and AFL++ for this experiment to observe any difference in the outcomes due to the difference in these fuzzers.

We use four benchmarks:

1. The original seed corpus from the lcms_cms_transform_fuzzer benchmark
2. An unfiltered seed corpus from our saturated corpus
3. Filtering strategy one applied to the seed corpus
4. Filtering strategy two applied to the seed corpus