### PR TITLE
Add PCRE2 as a fuzzing benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,6 +36,7 @@ jobs:
           - openh264_decoder_fuzzer
           - openssl_x509
           - openthread_ot-ip6-send-fuzzer
+          - pcre2_pcre2_fuzzer
           - php_php-fuzz-parser_0dbedb
           - proj4_proj_crs_to_crs_fuzzer
           - re2_fuzzer

--- a/benchmarks/pcre2_pcre2_fuzzer/Dockerfile
+++ b/benchmarks/pcre2_pcre2_fuzzer/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:fb1a9a49752c9e504687448d1f1a048ec1e062e2e40f7e8a23e86b63ff3dad7c
+RUN apt-get update && apt-get install -y make autoconf automake libtool subversion
+
+RUN git clone https://github.com/PCRE2Project/pcre2 pcre2
+WORKDIR pcre2
+COPY build.sh $SRC/

--- a/benchmarks/pcre2_pcre2_fuzzer/benchmark.yaml
+++ b/benchmarks/pcre2_pcre2_fuzzer/benchmark.yaml
@@ -1,0 +1,4 @@
+commit: 6ae58beca071f13ccfed31d03b3f479ab520639b
+commit_date: 2024-06-06 22:00:00+00:00
+fuzz_target: pcre2_fuzzer
+project: pcre2

--- a/benchmarks/pcre2_pcre2_fuzzer/build.sh
+++ b/benchmarks/pcre2_pcre2_fuzzer/build.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -eu
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+./autogen.sh
+./configure --enable-fuzz-support \
+    --enable-never-backslash-C --with-match-limit=1000 --with-match-limit-depth=1000 \
+    --enable-jit \
+    --enable-pcre2-16 --enable-pcre2-32
+make -j$(nproc) clean
+make -j$(nproc) all
+
+# build fuzzers
+$CXX $CXXFLAGS -o $OUT/pcre2_fuzzer \
+    $LIB_FUZZING_ENGINE .libs/libpcre2-fuzzsupport.a .libs/libpcre2-8.a
+$CXX $CXXFLAGS -o $OUT/pcre2_fuzzer_16 \
+    $LIB_FUZZING_ENGINE .libs/libpcre2-fuzzsupport-16.a .libs/libpcre2-16.a
+$CXX $CXXFLAGS -o $OUT/pcre2_fuzzer_32 \
+    $LIB_FUZZING_ENGINE .libs/libpcre2-fuzzsupport-32.a .libs/libpcre2-32.a
+
+# test different link sizes
+for i in $(seq 3 4); do
+    ./configure --enable-fuzz-support \
+        --enable-never-backslash-C --with-match-limit=1000 --with-match-limit-depth=1000 \
+        --enable-jit \
+        --enable-pcre2-16 --enable-pcre2-32 --with-link-size=${i}
+    make -j$(nproc) clean
+    make -j$(nproc) all
+
+    # build fuzzers
+    $CXX $CXXFLAGS -o $OUT/pcre2_fuzzer_${i}l \
+        $LIB_FUZZING_ENGINE .libs/libpcre2-fuzzsupport.a .libs/libpcre2-8.a
+    $CXX $CXXFLAGS -o $OUT/pcre2_fuzzer_16_${i}l \
+        $LIB_FUZZING_ENGINE .libs/libpcre2-fuzzsupport-16.a .libs/libpcre2-16.a
+    $CXX $CXXFLAGS -o $OUT/pcre2_fuzzer_32_${i}l \
+        $LIB_FUZZING_ENGINE .libs/libpcre2-fuzzsupport-32.a .libs/libpcre2-32.a
+done
+
+# set up dictionary and options to use it
+for bits in "" "_16" "_32"; do
+  cp "pcre2_fuzzer${bits}.dict" "${OUT}/pcre2_fuzzer${bits}.dict"
+  for linksize in "" "_3l" "_4l"; do
+    cp "pcre2_fuzzer${bits}.options" "${OUT}/pcre2_fuzzer${bits}${linksize}.options"
+  done
+done

--- a/benchmarks/pcre2_pcre2_fuzzer/build.sh
+++ b/benchmarks/pcre2_pcre2_fuzzer/build.sh
@@ -19,41 +19,13 @@
 ./autogen.sh
 ./configure --enable-fuzz-support \
     --enable-never-backslash-C --with-match-limit=1000 --with-match-limit-depth=1000 \
-    --enable-jit \
-    --enable-pcre2-16 --enable-pcre2-32
+    --enable-jit
 make -j$(nproc) clean
 make -j$(nproc) all
 
-# build fuzzers
+# build fuzzer
 $CXX $CXXFLAGS -o $OUT/pcre2_fuzzer \
     $LIB_FUZZING_ENGINE .libs/libpcre2-fuzzsupport.a .libs/libpcre2-8.a
-$CXX $CXXFLAGS -o $OUT/pcre2_fuzzer_16 \
-    $LIB_FUZZING_ENGINE .libs/libpcre2-fuzzsupport-16.a .libs/libpcre2-16.a
-$CXX $CXXFLAGS -o $OUT/pcre2_fuzzer_32 \
-    $LIB_FUZZING_ENGINE .libs/libpcre2-fuzzsupport-32.a .libs/libpcre2-32.a
-
-# test different link sizes
-for i in $(seq 3 4); do
-    ./configure --enable-fuzz-support \
-        --enable-never-backslash-C --with-match-limit=1000 --with-match-limit-depth=1000 \
-        --enable-jit \
-        --enable-pcre2-16 --enable-pcre2-32 --with-link-size=${i}
-    make -j$(nproc) clean
-    make -j$(nproc) all
-
-    # build fuzzers
-    $CXX $CXXFLAGS -o $OUT/pcre2_fuzzer_${i}l \
-        $LIB_FUZZING_ENGINE .libs/libpcre2-fuzzsupport.a .libs/libpcre2-8.a
-    $CXX $CXXFLAGS -o $OUT/pcre2_fuzzer_16_${i}l \
-        $LIB_FUZZING_ENGINE .libs/libpcre2-fuzzsupport-16.a .libs/libpcre2-16.a
-    $CXX $CXXFLAGS -o $OUT/pcre2_fuzzer_32_${i}l \
-        $LIB_FUZZING_ENGINE .libs/libpcre2-fuzzsupport-32.a .libs/libpcre2-32.a
-done
 
 # set up dictionary and options to use it
-for bits in "" "_16" "_32"; do
-  cp "pcre2_fuzzer${bits}.dict" "${OUT}/pcre2_fuzzer${bits}.dict"
-  for linksize in "" "_3l" "_4l"; do
-    cp "pcre2_fuzzer${bits}.options" "${OUT}/pcre2_fuzzer${bits}${linksize}.options"
-  done
-done
+cp "pcre2_fuzzer.dict" "${OUT}/pcre2_fuzzer.dict"


### PR DESCRIPTION
PCRE2 is a complicated target which is prone to timeouts. This timeout-proneness is caused, in part, by the input representing *instructions* rather than flat data. Additionally, the state space of the program is significantly larger than the code coverage suggests. These two issues together make this a very hard target to fuzz, which has led to interesting problems in OSS-Fuzz and in local testing.

I think this target is interesting from a benchmarking perspective as it introduces complications which are not present in other targets in Fuzzbench and would like to add it to the standard benchmark suite. I have used the standard OSS-Fuzz integration script.

CC @PhilipHazel @alexdowad for input.