### PR TITLE
More informative logs to help debugging

### DIFF
--- a/common/fuzzer_utils.py
+++ b/common/fuzzer_utils.py
@@ -83,7 +83,11 @@ def get_fuzz_target_binary(search_directory: str,
     if os.path.exists(default_fuzz_target_binary):
         return default_fuzz_target_binary
 
+    logs.info('Searching for possible fuzz target in search directory: '
+              f'{search_directory}')
     for root, _, files in os.walk(search_directory):
+        logs.info(f'Searching for possible fuzz target under subdir {root}: '
+                  f'{files}')
         if root == 'uninstrumented':
             continue
         for filename in files:

--- a/experiment/measurer/coverage_utils.py
+++ b/experiment/measurer/coverage_utils.py
@@ -133,7 +133,9 @@ class CoverageReporter:  # pylint: disable=too-many-instance-attributes
 
         result = merge_profdata_files(files_to_merge, self.merged_profdata_file)
         if result.retcode != 0:
-            logger.error('Profdata files merging failed.')
+            logger.error(
+                f'Profdata files merging failed for (fuzzer, benchmark): '
+                f'({self.fuzzer}, {self.benchmark}).')
 
     def generate_coverage_summary_json(self):
         """Generates the coverage summary json from merged profdata file."""

--- a/experiment/runner.py
+++ b/experiment/runner.py
@@ -180,7 +180,8 @@ def run_fuzzer(max_total_time, log_filename):
     target_binary = fuzzer_utils.get_fuzz_target_binary(FUZZ_TARGET_DIR,
                                                         fuzz_target_name)
     if not target_binary:
-        logs.error('Fuzz target binary not found.')
+        logs.error(f'Fuzz target binary {fuzz_target_name} not found under '
+                   f'{FUZZ_TARGET_DIR}')
         return
 
     if max_total_time is None:


### PR DESCRIPTION
Recent experiments have [`Fuzz target binary not found.`](https://pantheon.corp.google.com/logs/query;query=jsonPayload.experiment%3D2024-08-22-2028-bases-2%0Aseverity%3E%3DERROR;cursorTimestamp=2024-08-22T01:44:37.540131675Z;startTime=2024-08-21T00:51:31.310Z;endTime=2024-08-23T00:51:31.310336Z?project=fuzzbench&e=-13802955&mods=logs_tg_prod) errors which appears to be flaky and cannot be reproduced locally.

This PR adds more logs to help understand the cause.