### PR TITLE
minimal changes for experiment

### DIFF
--- a/benchmarks/freetype2_ftfuzzer/Dockerfile
+++ b/benchmarks/freetype2_ftfuzzer/Dockerfile
@@ -25,7 +25,13 @@ RUN apt-get update &&  \
     wget
 
 RUN git clone git://git.sv.nongnu.org/freetype/freetype2.git
-RUN git clone https://github.com/unicode-org/text-rendering-tests.git TRT
+
 RUN wget https://github.com/libarchive/libarchive/releases/download/v3.4.3/libarchive-3.4.3.tar.xz
+
+RUN wget https://raw.githubusercontent.com/ardier/fuzzbench/minimized-subsumed-mutants-benchmark-with-seeds/benchmarks/freetype2_ftfuzzer_libafl/seeds.tar -O $SRC/seeds.tar && \
+    mkdir -p $SRC/seeds && \
+    tar -xvf $SRC/seeds.tar -C $SRC/seeds && \
+    rm $SRC/seeds.tar
+
 
 COPY * $SRC/

--- a/benchmarks/freetype2_ftfuzzer/build.sh
+++ b/benchmarks/freetype2_ftfuzzer/build.sh
@@ -15,8 +15,9 @@
 
 mkdir $OUT/seeds
 # TRT/fonts is the full seed folder, but they're too big
-cp TRT/fonts/TestKERNOne.otf $OUT/seeds/
-cp TRT/fonts/TestGLYFOne.ttf $OUT/seeds/
+# cp TRT/fonts/TestKERNOne.otf $OUT/seeds/
+# cp TRT/fonts/TestGLYFOne.ttf $OUT/seeds/
+cp seeds/*  $OUT/seeds/
 
 tar xf libarchive-3.4.3.tar.xz
 

--- a/service/experiment-config.yaml
+++ b/service/experiment-config.yaml
@@ -2,8 +2,8 @@
 # Unless you are a fuzzbench maintainer running this service, this
 # will not work with your setup.
 
-trials: 20
-max_total_time: 82800  # 23 hours, the default time for preemptible experiments.
+trials: 3
+max_total_time: 10800  # 3 hours, the default time for preemptible experiments.
 cloud_project: fuzzbench
 docker_registry: gcr.io/fuzzbench
 cloud_compute_zone: us-central1-c

--- a/service/gcbrun_experiment.py
+++ b/service/gcbrun_experiment.py
@@ -17,6 +17,7 @@
 from the last PR comment containing "/gcbrun" and pass it to run_experiment.py
 which will run an experiment."""
 
+# dummy comment for experiment
 import logging
 import os
 import sys


### PR DESCRIPTION
This experiment modifies the freetype2 benchmark to use a custom seed.
Given the failure of our previous experiments, we have kept this experiment extremely simple so that if it fails, we can pinpoint the problem more easily.

Please run the following command to run the experiment:
/gcbrun run_experiment.py -a --experiment-config /opt/fuzzbench/service/experiment-config.yaml --experiment-name 2024-12-28-afl-mutants --fuzzers afl --benchmarks freetype2_ftfuzzer

@DonggeLiu @jonathanmetzman Could you please have a look?

Thank you kindly in advance.