### PR TITLE
Fix: correct logical condition for covered branches

### DIFF
--- a/experiment/measurer/coverage_utils.py
+++ b/experiment/measurer/coverage_utils.py
@@ -305,8 +305,8 @@ def extract_covered_branches_from_summary_json(summary_json_file):
         file_index = 6
         for function_data in functions_data:
             for branch in function_data['branches']:
-                if branch[hit_true_index] != 0 or branch[
-                        hit_false_index] != 0 and branch[
+                if (branch[hit_true_index] != 0 or branch[
+                        hit_false_index] != 0) and branch[
                             type_index] == branch_region_type:
                     covered_branches.append(branch[:hit_true_index] +
                                             branch[file_index:])


### PR DESCRIPTION
### Summary

This PR fixes the logic in the `extract_covered_branches_from_summary_json` function in `coverage_utils.py`.

The goal is to ensure that only branches which are:
- of type 4 (branch region), **and**
- actually covered (`hit_true > 0` or `hit_false > 0`)
are included in the result.

### Notes

- Fixes a logical error caused by incorrect operator precedence.
- Previously, branches with `type != 4` could be incorrectly included if `hit_true > 0`.

### Test Cases
```py
import pytest
from unittest.mock import patch
from experiment.measurer.coverage_utils import extract_covered_branches_from_summary_json

@pytest.fixture
def fake_coverage_data():
    return {
        "data": [
            {
                "functions": [
                    {
                        "branches": [
                            # type == 4, hit_true > 0 → should be included
                            [10, 5, 10, 15, 1, 0, 0, 0, 4],
                            # type == 4, hit_false > 0 → should be included
                            [11, 5, 11, 15, 0, 2, 0, 0, 4],
                            # type == 4, not covered → should be excluded
                            [12, 5, 12, 15, 0, 0, 0, 0, 4],
                            # type != 4 → should be excluded
                            [13, 5, 13, 15, 1, 0, 0, 0, 2],
                            # type == 4, both hit_true and hit_false > 0 → should be included
                            [14, 5, 14, 15, 3, 3, 0, 0, 4]
                        ]
                    }
                ]
            }
        ]
    }

@patch('experiment.measurer.coverage_utils.get_coverage_infomation')
def test_extract_covered_branches_from_summary_json(mock_get_info, fake_coverage_data):
    mock_get_info.return_value = fake_coverage_data

    result = extract_covered_branches_from_summary_json("dummy.json")

    # Expecting 3 valid covered branches (type == 4 and covered)
    assert len(result) == 3
    assert result[0][:2] == [10, 5]
    assert result[1][:2] == [11, 5]
    assert result[2][:2] == [14, 5]

```