### PR TITLE
Fix #1896: Fix report generation when there is only one fuzzer.

### DIFF
--- a/analysis/data_utils.py
+++ b/analysis/data_utils.py
@@ -159,9 +159,14 @@ def add_bugs_covered_column(experiment_df):
     grouping2 = ['fuzzer', 'benchmark', 'trial_id']
     grouping3 = ['fuzzer', 'benchmark', 'trial_id', 'time']
     df = experiment_df.sort_values(grouping3)
-    df['firsts'] = (
-        df.groupby(grouping2, group_keys=False).apply(is_unique_crash) &
-        ~df.crash_key.isna())
+    firsts_data = df.groupby(grouping2, group_keys=False).apply(is_unique_crash) & ~df.crash_key.isna()
+    try:
+        df['firsts'] = (firsts_data)
+    except:
+        import traceback; traceback.print_exc()
+        firsts_data = firsts_data.stack().reset_index(drop=True)
+        df['firsts'] = (firsts_data)
+
     df['bugs_cumsum'] = df.groupby(grouping2)['firsts'].transform('cumsum')
     df['bugs_covered'] = (
         df.groupby(grouping3)['bugs_cumsum'].transform('max').astype(int))


### PR DESCRIPTION
Fix https://github.com/google/fuzzbench/issues/1896

When there is only one fuzzer, the `df.groupby(grouping2, group_keys=False).apply(is_unique_crash)`  is something like:

```
Name: firsts, dtype: bool
c1 firsts                                   0
fuzzer          benchmark   trial_id
aflplusplus libxml2_xml 58        True
```

which has only one row, even after reset_index

<img width="1002" height="428" alt="67f7ae6b97f3443e83b7690c78b09cca%2Fo%2F1768892165269" src="https://github.com/user-attachments/assets/f808b511-a605-481a-89bc-e37a00a7d4fd" />

This change uses `.stack().reset_index(drop=True)` to fix the issue only when the orignal code does not work