### PR TITLE
Catch fuzzbench measurer worker exception.

### DIFF
--- a/experiment/measurer/measure_worker.py
+++ b/experiment/measurer/measure_worker.py
@@ -57,9 +57,13 @@ class BaseMeasureWorker:
                 'Measurer worker: Got request %s %s %d %d from request queue',
                 request.fuzzer, request.benchmark, request.trial_id,
                 request.cycle)
-            measured_snapshot = measure_manager.measure_snapshot_coverage(
-                request.fuzzer, request.benchmark, request.trial_id,
-                request.cycle, self.region_coverage)
+            measured_snapshot = None
+            try:
+                measured_snapshot = measure_manager.measure_snapshot_coverage(
+                    request.fuzzer, request.benchmark, request.trial_id,
+                    request.cycle, self.region_coverage)
+            except:
+                import traceback; traceback.print_exc()
             self.put_result_in_response_queue(measured_snapshot, request)
             time.sleep(MEASUREMENT_TIMEOUT)
 


### PR DESCRIPTION
The measurer worker is launched using multiprocessing.Pool's apply_async. If there is any uncaught exception, the worker thread will die and stop to do any more work. Probably related to #1108

https://github.com/google/fuzzbench/blob/fe8c15e1edbf796121cd3558305a1e7473a8c749/experiment/measurer/measure_manager.py#L813