### PR TITLE
Reduce unecessary output from dispatcher when starting experiment.

### DIFF
--- a/docker/dispatcher-image/startup-dispatcher.sh
+++ b/docker/dispatcher-image/startup-dispatcher.sh
@@ -24,7 +24,7 @@ cloud_sql_proxy -instances="$CLOUD_SQL_INSTANCE_CONNECTION_NAME" &
 # Setup source code, virtualenv and dependencies.
 gsutil -m rsync -r "${EXPERIMENT_FILESTORE}/${EXPERIMENT}/input" "${WORK}"
 mkdir ${WORK}/src
-tar -xvzf ${WORK}/src.tar.gz -C ${WORK}/src
+tar -xzf ${WORK}/src.tar.gz -C ${WORK}/src
 
 # Set up credentials locally as cloud metadata service does not scale.
 credentials_file=${WORK}/creds.json

--- a/experiment/run_experiment.py
+++ b/experiment/run_experiment.py
@@ -553,7 +553,7 @@ class LocalDispatcher(BaseDispatcher):
             'rsync -r '
             '"${EXPERIMENT_FILESTORE}/${EXPERIMENT}/input/" ${WORK} && '
             'mkdir ${WORK}/src && '
-            'tar -xvzf ${WORK}/src.tar.gz -C ${WORK}/src && '
+            'tar -xzf ${WORK}/src.tar.gz -C ${WORK}/src && '
             'PYTHONPATH=${WORK}/src python3 '
             '${WORK}/src/experiment/dispatcher.py || '
             '/bin/bash'  # Open shell if experiment fails.


### PR DESCRIPTION
I found that every time I start a local experiment, the full file list of the fuzzbench code repository is always printed. I think these prints are not very meaningful, so this PR removes them.