### PR TITLE
Fix potential exception from coverage measurer logger.

### DIFF
--- a/experiment/measurer/run_coverage.py
+++ b/experiment/measurer/run_coverage.py
@@ -66,5 +66,5 @@ def do_coverage_run(  # pylint: disable=too-many-locals
         logger.error('Coverage run failed.',
                      extras={
                          'coverage_binary': coverage_binary,
-                         'output': result.output[-new_process.LOG_LIMIT_FIELD:],
+                         'output': result.output[-new_process.LOG_LIMIT_FIELD:] if result.output else 'None',
                      })


### PR DESCRIPTION
The error logger part assumes that the preceding `new_process.execute` must have captured stdout. If the call does not capture stdout, `result.output` will be None, and an exception will be raised when indexing it.

https://github.com/google/fuzzbench/blob/3234e151d70f6093272a9b4155e68ee57faf986c/experiment/measurer/run_coverage.py#L58-L70
