### PR TITLE
Fix docker cache issue by ensuring git clone and checkout are in the same entry.

### DIFF
--- a/fuzzers/libafl/builder.Dockerfile
+++ b/fuzzers/libafl/builder.Dockerfile
@@ -35,11 +35,8 @@ RUN apt-get update && \
 RUN wget https://gist.githubusercontent.com/tokatoka/26f4ba95991c6e33139999976332aa8e/raw/698ac2087d58ce5c7a6ad59adce58dbfdc32bd46/createAliases.sh && chmod u+x ./createAliases.sh && ./createAliases.sh 
 
 # Download libafl.
-RUN git clone https://github.com/AFLplusplus/LibAFL /libafl
-
-# Checkout a current commit
-RUN cd /libafl && git pull && git checkout f856092f3d393056b010fcae3b086769377cba18 || true
 # Note that due a nightly bug it is currently fixed to a known version on top!
+RUN git clone https://github.com/AFLplusplus/LibAFL /libafl && cd /libafl && git pull && git checkout f856092f3d393056b010fcae3b086769377cba18 || true
 
 # Compile libafl.
 RUN cd /libafl && \

--- a/fuzzers/pastis/builder.Dockerfile
+++ b/fuzzers/pastis/builder.Dockerfile
@@ -25,10 +25,8 @@ RUN apt-get update && \
         libstdc++-$(gcc --version|head -n1|sed 's/\..*//'|sed 's/.* //')-dev
 
 # Download afl++.
-RUN git clone https://github.com/AFLplusplus/AFLplusplus /afl
-
 # Checkout a current commit
-RUN cd /afl && git checkout 35f09e11a4373b0fb42c690d23127c144f72f73c
+RUN git clone https://github.com/AFLplusplus/AFLplusplus /afl && cd /afl && git checkout 35f09e11a4373b0fb42c690d23127c144f72f73c
 
 # Build without Python support as we don't need it.
 # Set AFL_NO_X86 to skip flaky tests.

--- a/fuzzers/wingfuzz/builder.Dockerfile
+++ b/fuzzers/wingfuzz/builder.Dockerfile
@@ -15,7 +15,6 @@
 ARG parent_image
 FROM $parent_image
 
-RUN git clone https://github.com/WingTecherTHU/wingfuzz
-RUN cd wingfuzz && git checkout 6ef3281f145fa1839df0f46c38b348ec9d93b0e2 && \
+RUN git clone https://github.com/WingTecherTHU/wingfuzz && cd wingfuzz && git checkout 6ef3281f145fa1839df0f46c38b348ec9d93b0e2 && \
     ./build.sh && cd instrument && ./build.sh && clang -c WeakSym.c && \
     cp ../libFuzzer.a /libWingfuzz.a && cp WeakSym.o / && cp LoadCmpTracer.so /


### PR DESCRIPTION
If git clone and checkout are in different RUN instructions, modifying the commit ID in the subsequent checkout does not change the preceding git clone command. As a result, Docker uses the local cache, and even if the remote repository has been updated, Docker will not re-pull. This happens because Dockerfile caching is based on the command literal.