### PR TITLE
Fix proj4 cannot find proj4.db

### DIFF
--- a/benchmarks/proj4_proj_crs_to_crs_fuzzer/third_party/build.sh
+++ b/benchmarks/proj4_proj_crs_to_crs_fuzzer/third_party/build.sh
@@ -85,3 +85,4 @@ echo "[libfuzzer]" > $OUT/proj_crs_to_crs_fuzzer.options
 echo "max_len = 10000" >> $OUT/proj_crs_to_crs_fuzzer.options
 
 cp -r data/* $OUT
+cp -r build/data/* $OUT


### PR DESCRIPTION
When fuzzing, the proj4 target frequently reports that proj.db is not found:
```
proj_create: Cannot find proj.db
```
The proj.db is generated under build/data, not data/.

See also: https://github.com/OSGeo/PROJ/pull/4665