### PR TITLE
Fix pkg_resources error in local experiment setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ rq==1.11.1
 scikit-posthocs==0.7.0
 scipy==1.9.2
 seaborn==0.13.2
+setuptools<82
 sqlalchemy==1.4.41
 protobuf==3.20.3
 


### PR DESCRIPTION
google-cloud-logging==3.1.2 still imports `pkg_resources`, which was removed in setuptools 82. Constrain setuptools to a compatible version so local dependency installation works again.

We reproduced this issue separately when installing fuzzbench in a brand new virtual machine. Other users may not encounter this problem for now due to some local package caching.
